### PR TITLE
feat: multi-replica session coherence + sandbox meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 !.env.example
 *.tsbuildinfo
 scripts/ralph/archive/
+docs/
+docker-compose.local.yml

--- a/scripts/initdb/00-create-tenant-dbs.sql
+++ b/scripts/initdb/00-create-tenant-dbs.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE vfs_tenant_a;
+CREATE DATABASE vfs_tenant_b;

--- a/src/api/__tests__/exec.test.ts
+++ b/src/api/__tests__/exec.test.ts
@@ -10,6 +10,7 @@ import { SignJWT } from "jose";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { type AuthVariables, authMiddleware } from "../auth.js";
 import { execRoutes } from "../routes/exec.js";
 import { SessionManager } from "../session-manager.js";
@@ -227,5 +228,43 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 		expect((exitEvent?.data as { t: string; exitCode: number; error: string }).error).toBe("timeout");
 
 		vi.restoreAllMocks();
+	});
+
+	it("rejects unauthorized cold-replica SSE requests before opening the stream", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		await ownerManager.withSession(SANDBOX_ID, async (session) => {
+			session.owner = "agent-1";
+			await ownerManager.persistSandboxMeta(SANDBOX_ID, { owner: "agent-1", python: false, javascript: false });
+		});
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const token = await makeToken("agent-2");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ script: "echo hello" }),
+		});
+
+		expect(res.status).toBe(403);
+		expect(res.headers.get("content-type")).not.toContain("text/event-stream");
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
 	});
 });

--- a/src/api/__tests__/files.test.ts
+++ b/src/api/__tests__/files.test.ts
@@ -13,6 +13,7 @@ import { SignJWT } from "jose";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { type AuthVariables, authMiddleware } from "../auth.js";
 import { fileRoutes } from "../routes/files.js";
 import { SessionManager } from "../session-manager.js";
@@ -173,6 +174,40 @@ describe("PUT /v1/sandboxes/:id/files/*path", () => {
 		});
 		expect(getRes.status).toBe(200);
 		expect(await getRes.text()).toBe("deep content");
+	});
+
+	it("returns 403 when a cold replica rehydrates a sandbox owned by another caller", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		await ownerManager.withSession(SANDBOX_ID, async (session) => {
+			session.owner = "agent-1";
+			await ownerManager.persistSandboxMeta(SANDBOX_ID, { owner: "agent-1", python: false, javascript: false });
+		});
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const token = await makeToken("agent-2");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/files/blocked.txt`, {
+			method: "PUT",
+			headers: { Authorization: `Bearer ${token}` },
+			body: "should not write",
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
 	});
 });
 

--- a/src/api/__tests__/ingest.test.ts
+++ b/src/api/__tests__/ingest.test.ts
@@ -14,6 +14,7 @@ import { SignJWT } from "jose";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { type AuthVariables, authMiddleware } from "../auth.js";
 import { ingestRoutes } from "../routes/ingest.js";
 import { SessionManager } from "../session-manager.js";
@@ -177,6 +178,43 @@ describe("POST /v1/sandboxes/:id/ingest", () => {
 		});
 
 		expect(res.status).toBe(404);
+	});
+
+	it("returns 403 when ingest-files hits a cold replica owned by another caller", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		await ownerManager.withSession(SANDBOX_ID, async (session) => {
+			session.owner = "agent-1";
+			await ownerManager.persistSandboxMeta(SANDBOX_ID, { owner: "agent-1", python: false, javascript: false });
+		});
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const token = await makeToken("agent-2");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				basePath: "/home/user/project",
+				files: { "blocked.txt": Buffer.from("denied").toString("base64") },
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
 	});
 });
 

--- a/src/api/__tests__/integration/concurrency.pg.test.ts
+++ b/src/api/__tests__/integration/concurrency.pg.test.ts
@@ -44,6 +44,7 @@ function errCode(e: unknown): string {
 // ── Per-describe sandbox tracking ─────────────────────────────────────────────
 
 let cleanup: string[] = [];
+let envCleanups: Array<() => Promise<void>> = [];
 
 function newId(): string {
 	const id = crypto.randomUUID();
@@ -54,6 +55,11 @@ function newId(): string {
 async function flushCleanup(): Promise<void> {
 	const ids = cleanup.splice(0);
 	await Promise.allSettled(ids.map((id) => destroySandbox("postgres", id)));
+}
+
+async function flushEnvCleanups(): Promise<void> {
+	const cleanups = envCleanups.splice(0);
+	await Promise.allSettled(cleanups.map((close) => close()));
 }
 
 /** Create a sandbox row in Postgres without warming the SessionManager pool. */
@@ -97,6 +103,13 @@ function makePgEnv() {
 	const app = new Hono<{ Variables: AuthVariables }>();
 	app.use("/v1/*", authMiddleware);
 	app.route("/v1/sandboxes", fileRoutes(sm));
+	const close = async () => {
+		if (connected) {
+			connected = false;
+			await metaDialect.disconnect();
+		}
+	};
+	envCleanups.push(close);
 	return { app, sm };
 }
 
@@ -122,9 +135,11 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to the same path", () => {
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 
@@ -181,9 +196,11 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to distinct paths", () => 
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 
@@ -218,9 +235,11 @@ describe.skipIf(!DB_URL)("Postgres: write-delete-read — pathCache cleared afte
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 
@@ -295,9 +314,11 @@ describe.skipIf(!DB_URL)("Postgres: overwrite consistency — contentCache stays
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 
@@ -360,9 +381,11 @@ describe.skipIf(!DB_URL)("Postgres: cross-sandbox isolation — writes in A not 
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 
@@ -445,9 +468,11 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 	beforeEach(() => {
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		cleanup = [];
+		envCleanups = [];
 	});
 	afterEach(async () => {
 		process.env.AUTH_SECRET = "";
+		await flushEnvCleanups();
 		await flushCleanup();
 	});
 

--- a/src/api/__tests__/integration/concurrency.pg.test.ts
+++ b/src/api/__tests__/integration/concurrency.pg.test.ts
@@ -73,22 +73,26 @@ async function createSandboxInPg(sandboxId: string): Promise<void> {
 }
 
 function makePgEnv() {
-	const existsDialect = new PostgresDialect(DB_URL!);
+	const metaDialect = new PostgresDialect(DB_URL!);
 	let connected = false;
-	const sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+	const ensureConnected = async () => {
 		if (!connected) {
-			await existsDialect.connect();
+			await metaDialect.connect();
 			connected = true;
 		}
-		return existsDialect.transaction(async (tx) => {
-			return existsDialect.sandboxExists(tx, sandboxId);
-		});
 	};
 
 	const sm = new SessionManager({
 		backend: "postgres",
 		createFs: (backend, sandboxId) => createSandboxFs(backend, sandboxId),
-		sandboxExistsFn,
+		getSandboxMetaFn: async (sandboxId) => {
+			await ensureConnected();
+			return metaDialect.transaction((tx) => metaDialect.getSandboxMeta(tx, sandboxId));
+		},
+		persistSandboxMetaFn: async (sandboxId, meta) => {
+			await ensureConnected();
+			await metaDialect.transaction((tx) => metaDialect.updateSandboxMeta(tx, sandboxId, meta));
+		},
 	});
 	const app = new Hono<{ Variables: AuthVariables }>();
 	app.use("/v1/*", authMiddleware);

--- a/src/api/__tests__/integration/concurrency.pg.test.ts
+++ b/src/api/__tests__/integration/concurrency.pg.test.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { SignJWT } from "jose";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PostgresDialect } from "../../../fs/sql-fs/dialects/postgres.js";
 import { createSandboxFs, destroySandbox } from "../../../fs/sql-fs/index.js";
 import { type AuthVariables, authMiddleware } from "../../auth.js";
 import { fileRoutes } from "../../routes/files.js";
@@ -55,10 +56,39 @@ async function flushCleanup(): Promise<void> {
 	await Promise.allSettled(ids.map((id) => destroySandbox("postgres", id)));
 }
 
+/** Create a sandbox row in Postgres without warming the SessionManager pool. */
+async function createSandboxInPg(sandboxId: string): Promise<void> {
+	const dialect = new PostgresDialect(DB_URL!);
+	await dialect.connect();
+	try {
+		await dialect.transaction(async (tx) => {
+			await dialect.createSandbox(tx, sandboxId);
+		});
+	} catch (e) {
+		const sqlErr = e as { code?: string };
+		if (sqlErr.code !== "23505") throw e;
+	} finally {
+		await dialect.disconnect();
+	}
+}
+
 function makePgEnv() {
+	const existsDialect = new PostgresDialect(DB_URL!);
+	let connected = false;
+	const sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+		if (!connected) {
+			await existsDialect.connect();
+			connected = true;
+		}
+		return existsDialect.transaction(async (tx) => {
+			return existsDialect.sandboxExists(tx, sandboxId);
+		});
+	};
+
 	const sm = new SessionManager({
 		backend: "postgres",
 		createFs: (backend, sandboxId) => createSandboxFs(backend, sandboxId),
+		sandboxExistsFn,
 	});
 	const app = new Hono<{ Variables: AuthVariables }>();
 	app.use("/v1/*", authMiddleware);
@@ -98,6 +128,7 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to the same path", () => {
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		const results = await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -118,6 +149,7 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to the same path", () => {
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -155,6 +187,7 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to distinct paths", () => 
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -191,6 +224,7 @@ describe.skipIf(!DB_URL)("Postgres: write-delete-read — pathCache cleared afte
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		await app.request(`/v1/sandboxes/${sbId}/files/home/user/gone.txt`, {
 			method: "PUT",
@@ -219,6 +253,7 @@ describe.skipIf(!DB_URL)("Postgres: write-delete-read — pathCache cleared afte
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 		const total = 10;
 		const keep = 5;
 
@@ -266,6 +301,7 @@ describe.skipIf(!DB_URL)("Postgres: overwrite consistency — contentCache stays
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		for (let i = 0; i < 10; i++) {
 			await app.request(`/v1/sandboxes/${sbId}/files/home/user/v.txt`, {
@@ -285,6 +321,7 @@ describe.skipIf(!DB_URL)("Postgres: overwrite consistency — contentCache stays
 		const { app } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await createSandboxInPg(sbId);
 
 		// Initial write
 		await app.request(`/v1/sandboxes/${sbId}/files/home/user/counter.txt`, {
@@ -330,6 +367,7 @@ describe.skipIf(!DB_URL)("Postgres: cross-sandbox isolation — writes in A not 
 		const token = await makeToken();
 		const sbA = newId();
 		const sbB = newId();
+		await Promise.all([createSandboxInPg(sbA), createSandboxInPg(sbB)]);
 
 		await Promise.all([
 			app.request(`/v1/sandboxes/${sbA}/files/home/user/shared.txt`, {
@@ -364,6 +402,7 @@ describe.skipIf(!DB_URL)("Postgres: cross-sandbox isolation — writes in A not 
 		const token = await makeToken();
 		const sbA = newId();
 		const sbB = newId();
+		await Promise.all([createSandboxInPg(sbA), createSandboxInPg(sbB)]);
 
 		await Promise.all([
 			app.request(`/v1/sandboxes/${sbA}/files/home/user/common.txt`, {
@@ -418,6 +457,7 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 		// so the write always succeeds regardless of whether mkdir ran first.
 		for (const label of ["mkdir-first", "write-first"] as const) {
 			const sbId = newId();
+			await createSandboxInPg(sbId);
 			const ops =
 				label === "mkdir-first"
 					? ([
@@ -446,8 +486,10 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 						] as const);
 
 			const [r1, r2] = await Promise.all(ops);
-			expect(r1.status, `${label} op1`).toBe(204);
-			// mkdir may return 409 EEXIST if write auto-created the dir first
+			// Both ops are concurrent and serialized by session mutex — either
+			// can win the race. Write always succeeds (PUT auto-creates parents).
+			// Mkdir may get 409 (EEXIST) if write's auto-mkdir ran first.
+			expect([204, 409], `${label} op1`).toContain(r1.status);
 			expect([204, 409], `${label} op2`).toContain(r2.status);
 
 			const paths = await treePaths(app, sbId, "/home/user/a", token);
@@ -544,6 +586,7 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 
 		for (const label of ["delete-first", "read-first"] as const) {
 			const sbId = newId();
+			await createSandboxInPg(sbId);
 			await app.request(`/v1/sandboxes/${sbId}/files/home/user/f.txt`, {
 				method: "PUT",
 				headers: { Authorization: `Bearer ${token}` },
@@ -573,13 +616,18 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 
 			const [first, second] = await Promise.all(ops);
 
+			// Both ops are concurrent and serialized by session mutex — either
+			// can acquire the lock first regardless of Promise.all position.
+			// DELETE always returns 204; GET returns 200 or 404 depending on race.
 			if (label === "delete-first") {
-				expect(first.status).toBe(204); // delete
-				expect(second.status).toBe(404); // read sees deleted file
+				expect(first.status).toBe(204); // delete always succeeds
+				expect([200, 404]).toContain(second.status); // read depends on race
 			} else {
-				expect(first.status).toBe(200); // read
-				expect(await first.text()).toBe("original");
-				expect(second.status).toBe(204); // delete
+				expect([200, 404]).toContain(first.status); // read depends on race
+				if (first.status === 200) {
+					expect(await first.text()).toBe("original");
+				}
+				expect(second.status).toBe(204); // delete always succeeds
 			}
 
 			const final = await app.request(`/v1/sandboxes/${sbId}/files/home/user/f.txt`, {

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -13,6 +13,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { InMemoryFs } from "just-bash";
 import { describe, expect, it } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { createMcpServer } from "../mcp/server.js";
 import { registerTools } from "../mcp/tools.js";
 import { SessionManager } from "../session-manager.js";
@@ -107,6 +108,13 @@ describe("MCP tool — sandbox_delete", () => {
 				return session;
 			},
 			getSession: (id: string): Session | undefined => sessions.get(id),
+			withSessionOrRehydrate: async <T>(id: string, fn: (session: Session) => Promise<T>): Promise<T> => {
+				const session = sessions.get(id);
+				if (session === undefined) {
+					throw Object.assign(new Error(`ENOENT: sandbox ${id} not found`), { code: "ENOENT" });
+				}
+				return fn(session);
+			},
 			persistSandboxMeta: async () => {},
 			destroy: async (id: string): Promise<boolean> => {
 				if (!sessions.has(id)) {
@@ -149,6 +157,9 @@ describe("MCP tool — sandbox_delete", () => {
 		const mockSessionManager = {
 			getOrCreate: async (id: string): Promise<Session> => ({ id, owner: "" }) as unknown as Session,
 			getSession: (_id: string): Session | undefined => undefined,
+			withSessionOrRehydrate: async <T>(_id: string, _fn: (session: Session) => Promise<T>): Promise<T> => {
+				throw Object.assign(new Error("ENOENT: sandbox not found"), { code: "ENOENT" });
+			},
 			persistSandboxMeta: async () => {},
 			destroy: async (_id: string): Promise<boolean> => {
 				throw Object.assign(new Error("ENOENT: sandbox not found"), { code: "ENOENT" });
@@ -172,6 +183,48 @@ describe("MCP tool — sandbox_delete", () => {
 		expect(typeof parsed.error).toBe("string");
 
 		await client.close();
+	});
+
+	it("rejects sandbox_delete on a cold replica when another owner created the sandbox", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		const serverA = createMcpServer();
+		registerTools(serverA, ownerManager, "user-a");
+		const [clientTransportA, serverTransportA] = InMemoryTransport.createLinkedPair();
+		const clientA = new Client({ name: "test-a", version: "1.0.0" });
+		await serverA.connect(serverTransportA);
+		await clientA.connect(clientTransportA);
+		const createResult = await clientA.callTool({ name: "sandbox_create", arguments: {} });
+		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+		await clientA.close();
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const serverB = createMcpServer();
+		registerTools(serverB, coldReplica, "user-b");
+		const [clientTransportB, serverTransportB] = InMemoryTransport.createLinkedPair();
+		const clientB = new Client({ name: "test-b", version: "1.0.0" });
+		await serverB.connect(serverTransportB);
+		await clientB.connect(clientTransportB);
+
+		const deleteResult = await clientB.callTool({ name: "sandbox_delete", arguments: { id: created.id } });
+		const parsed = JSON.parse((deleteResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+			ok: boolean;
+			error: string;
+		};
+		expect(parsed).toEqual({ ok: false, error: "forbidden" });
+
+		await clientB.close();
 	});
 });
 
@@ -272,6 +325,52 @@ describe("MCP tool — bash_exec", () => {
 		const parsed = JSON.parse(content[0]?.text ?? "") as { stdout: string; stderr: string; exitCode: number };
 		expect(parsed.stderr).toBe("forbidden");
 		expect(parsed.exitCode).toBe(1);
+
+		await clientB.close();
+	});
+
+	it("returns forbidden when a cold replica rehydrates a sandbox owned by another caller", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		const serverA = createMcpServer();
+		registerTools(serverA, ownerManager, "user-a");
+		const [clientTransportA, serverTransportA] = InMemoryTransport.createLinkedPair();
+		const clientA = new Client({ name: "test-a", version: "1.0.0" });
+		await serverA.connect(serverTransportA);
+		await clientA.connect(clientTransportA);
+		const createResult = await clientA.callTool({ name: "sandbox_create", arguments: {} });
+		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+		await clientA.close();
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const serverB = createMcpServer();
+		registerTools(serverB, coldReplica, "user-b");
+		const [clientTransportB, serverTransportB] = InMemoryTransport.createLinkedPair();
+		const clientB = new Client({ name: "test-b", version: "1.0.0" });
+		await serverB.connect(serverTransportB);
+		await clientB.connect(clientTransportB);
+
+		const execResult = await clientB.callTool({
+			name: "bash_exec",
+			arguments: { id: created.id, script: "echo hello" },
+		});
+		const parsed = JSON.parse((execResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+			stdout: string;
+			stderr: string;
+			exitCode: number;
+		};
+		expect(parsed).toEqual({ stdout: "", stderr: "forbidden", exitCode: 1 });
 
 		await clientB.close();
 	});

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -39,6 +39,7 @@ describe("MCP tool — sandbox_create", () => {
 				return session;
 			},
 			getSession: (id: string): Session | undefined => sessions.get(id),
+			persistSandboxMeta: async () => {},
 		};
 
 		const server = createMcpServer();
@@ -106,6 +107,7 @@ describe("MCP tool — sandbox_delete", () => {
 				return session;
 			},
 			getSession: (id: string): Session | undefined => sessions.get(id),
+			persistSandboxMeta: async () => {},
 			destroy: async (id: string): Promise<boolean> => {
 				if (!sessions.has(id)) {
 					throw Object.assign(new Error(`ENOENT: sandbox ${id} not found`), { code: "ENOENT" });
@@ -147,6 +149,7 @@ describe("MCP tool — sandbox_delete", () => {
 		const mockSessionManager = {
 			getOrCreate: async (id: string): Promise<Session> => ({ id, owner: "" }) as unknown as Session,
 			getSession: (_id: string): Session | undefined => undefined,
+			persistSandboxMeta: async () => {},
 			destroy: async (_id: string): Promise<boolean> => {
 				throw Object.assign(new Error("ENOENT: sandbox not found"), { code: "ENOENT" });
 			},

--- a/src/api/__tests__/sandboxes.test.ts
+++ b/src/api/__tests__/sandboxes.test.ts
@@ -7,6 +7,7 @@ import { SignJWT } from "jose";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { type AuthVariables, authMiddleware } from "../auth.js";
 import { sandboxRoutes } from "../routes/sandboxes.js";
 import { SessionManager } from "../session-manager.js";
@@ -132,6 +133,42 @@ describe("DELETE /v1/sandboxes/:id", () => {
 		const body = (await res.json()) as { error: string; code: string };
 		expect(body.error).toBe("not_found");
 		expect(body.code).toBe("SANDBOX_NOT_FOUND");
+	});
+
+	it("delete returns 403 on a cold replica when another owner created the sandbox", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		const ownerApp = makeTestApp(ownerManager);
+		const ownerToken = await makeToken("owner-a");
+		const createRes = await ownerApp.request("/v1/sandboxes", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${ownerToken}` },
+		});
+		const { id } = (await createRes.json()) as { id: string };
+
+		const coldReplica = new SessionManager({
+			backend: "memory",
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const otherToken = await makeToken("owner-b");
+
+		const res = await app.request(`/v1/sandboxes/${id}`, {
+			method: "DELETE",
+			headers: { Authorization: `Bearer ${otherToken}` },
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
 	});
 });
 

--- a/src/api/__tests__/session-manager.rehydrate.test.ts
+++ b/src/api/__tests__/session-manager.rehydrate.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for SessionManager.withSessionOrRehydrate().
+ *
+ * Tests the three code paths:
+ * 1. Warm hit: sandbox in pool -> execute immediately
+ * 2. Cold hit: sandbox in PG but not in pool -> rehydrate via getOrCreate
+ * 3. Cold miss: sandbox not in PG -> throw ENOENT
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../session-manager.js";
+
+let pgSandboxes: Set<string>;
+
+let createFsSpy: ReturnType<typeof vi.fn>;
+
+function makeSessionManager(): SessionManager {
+	pgSandboxes = new Set();
+	createFsSpy = vi.fn(
+		async (_backend: string, _sandboxId: string): Promise<IFileSystem> => {
+			return new InMemoryFs();
+		},
+	);
+	return new SessionManager({
+		backend: "memory",
+		createFs: createFsSpy,
+		sandboxExistsFn: async (sandboxId: string) => pgSandboxes.has(sandboxId),
+	});
+}
+
+describe("SessionManager.withSessionOrRehydrate()", () => {
+	let sm: SessionManager;
+
+	beforeEach(() => {
+		sm = makeSessionManager();
+	});
+
+	it("returns result from warm session without PG check", async () => {
+		// Warm the pool via withSession (which calls getOrCreate)
+		await sm.withSession("sb-1", async () => "warmed");
+
+		const result = await sm.withSessionOrRehydrate("sb-1", async (session) => {
+			return `hello from ${session.state}`;
+		});
+		expect(result).toBe("hello from active");
+		// createFs called only once (during warmup), not again
+		expect(createFsSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws ENOENT when sandbox does not exist in pool or PG", async () => {
+		await expect(
+			sm.withSessionOrRehydrate("nonexistent", async () => "nope"),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rehydrates from PG when sandbox exists in DB but not in pool", async () => {
+		// Simulate: sandbox was created on another replica (exists in PG)
+		pgSandboxes.add("sb-cold");
+
+		const result = await sm.withSessionOrRehydrate("sb-cold", async (session) => {
+			return session.state;
+		});
+		expect(result).toBe("active");
+		// createFs called once for the rehydration
+		expect(createFsSpy).toHaveBeenCalledWith("memory", "sb-cold");
+	});
+
+	it("rehydrated session is warm on subsequent calls", async () => {
+		pgSandboxes.add("sb-once");
+
+		// First call: rehydrates
+		await sm.withSessionOrRehydrate("sb-once", async () => "first");
+		// Second call: warm hit
+		await sm.withSessionOrRehydrate("sb-once", async () => "second");
+
+		// createFs called only once (rehydration), not twice
+		expect(createFsSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("destroyed sandbox stays ENOENT even if PG set still contains it", async () => {
+		pgSandboxes.add("sb-destroy");
+
+		// Rehydrate first
+		await sm.withSessionOrRehydrate("sb-destroy", async () => "alive");
+
+		// Destroy removes from pool (and in real PG would delete the row)
+		await sm.destroy("sb-destroy");
+
+		// Simulate PG row being gone (destroy deletes it)
+		pgSandboxes.delete("sb-destroy");
+
+		await expect(
+			sm.withSessionOrRehydrate("sb-destroy", async () => "ghost"),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("falls back to pool-only behavior when sandboxExistsFn is not set", async () => {
+		const smNoFn = new SessionManager({
+			backend: "memory",
+			createFs: createFsSpy,
+			// No sandboxExistsFn — strict pool-only mode
+		});
+
+		await expect(
+			smNoFn.withSessionOrRehydrate("cold-no-fn", async () => "nope"),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+});

--- a/src/api/__tests__/session-manager.rehydrate.test.ts
+++ b/src/api/__tests__/session-manager.rehydrate.test.ts
@@ -24,6 +24,9 @@ function makeSessionManager(): SessionManager {
 	return new SessionManager({
 		backend: "memory",
 		createFs: createFsSpy,
+		destroySandboxFn: async (_backend: string, sandboxId: string) => {
+			pgSandboxes.delete(sandboxId);
+		},
 		getSandboxMetaFn: async (sandboxId: string) => pgSandboxes.get(sandboxId) ?? null,
 		persistSandboxMetaFn: async (sandboxId: string, meta: SandboxMeta) => {
 			pgSandboxes.set(sandboxId, meta);
@@ -83,7 +86,6 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 		await sm.withSessionOrRehydrate("sb-destroy", async () => "alive");
 
 		await sm.destroy("sb-destroy");
-		pgSandboxes.delete("sb-destroy");
 
 		await expect(sm.withSessionOrRehydrate("sb-destroy", async () => "ghost")).rejects.toMatchObject({
 			code: "ENOENT",

--- a/src/api/__tests__/session-manager.rehydrate.test.ts
+++ b/src/api/__tests__/session-manager.rehydrate.test.ts
@@ -17,11 +17,9 @@ let createFsSpy: ReturnType<typeof vi.fn>;
 
 function makeSessionManager(): SessionManager {
 	pgSandboxes = new Set();
-	createFsSpy = vi.fn(
-		async (_backend: string, _sandboxId: string): Promise<IFileSystem> => {
-			return new InMemoryFs();
-		},
-	);
+	createFsSpy = vi.fn(async (_backend: string, _sandboxId: string): Promise<IFileSystem> => {
+		return new InMemoryFs();
+	});
 	return new SessionManager({
 		backend: "memory",
 		createFs: createFsSpy,
@@ -49,9 +47,9 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 	});
 
 	it("throws ENOENT when sandbox does not exist in pool or PG", async () => {
-		await expect(
-			sm.withSessionOrRehydrate("nonexistent", async () => "nope"),
-		).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(sm.withSessionOrRehydrate("nonexistent", async () => "nope")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 	});
 
 	it("rehydrates from PG when sandbox exists in DB but not in pool", async () => {
@@ -90,9 +88,9 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 		// Simulate PG row being gone (destroy deletes it)
 		pgSandboxes.delete("sb-destroy");
 
-		await expect(
-			sm.withSessionOrRehydrate("sb-destroy", async () => "ghost"),
-		).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(sm.withSessionOrRehydrate("sb-destroy", async () => "ghost")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 	});
 
 	it("falls back to pool-only behavior when sandboxExistsFn is not set", async () => {
@@ -102,8 +100,8 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 			// No sandboxExistsFn — strict pool-only mode
 		});
 
-		await expect(
-			smNoFn.withSessionOrRehydrate("cold-no-fn", async () => "nope"),
-		).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(smNoFn.withSessionOrRehydrate("cold-no-fn", async () => "nope")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 	});
 });

--- a/src/api/__tests__/session-manager.rehydrate.test.ts
+++ b/src/api/__tests__/session-manager.rehydrate.test.ts
@@ -9,23 +9,29 @@
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SandboxMeta } from "../../fs/sql-fs/types.js";
 import { SessionManager } from "../session-manager.js";
 
-let pgSandboxes: Set<string>;
+let pgSandboxes: Map<string, SandboxMeta>;
 
 let createFsSpy: ReturnType<typeof vi.fn>;
 
 function makeSessionManager(): SessionManager {
-	pgSandboxes = new Set();
+	pgSandboxes = new Map();
 	createFsSpy = vi.fn(async (_backend: string, _sandboxId: string): Promise<IFileSystem> => {
 		return new InMemoryFs();
 	});
 	return new SessionManager({
 		backend: "memory",
 		createFs: createFsSpy,
-		sandboxExistsFn: async (sandboxId: string) => pgSandboxes.has(sandboxId),
+		getSandboxMetaFn: async (sandboxId: string) => pgSandboxes.get(sandboxId) ?? null,
+		persistSandboxMetaFn: async (sandboxId: string, meta: SandboxMeta) => {
+			pgSandboxes.set(sandboxId, meta);
+		},
 	});
 }
+
+const DEFAULT_META: SandboxMeta = { owner: null, python: false, javascript: false };
 
 describe("SessionManager.withSessionOrRehydrate()", () => {
 	let sm: SessionManager;
@@ -53,39 +59,30 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 	});
 
 	it("rehydrates from PG when sandbox exists in DB but not in pool", async () => {
-		// Simulate: sandbox was created on another replica (exists in PG)
-		pgSandboxes.add("sb-cold");
+		pgSandboxes.set("sb-cold", DEFAULT_META);
 
 		const result = await sm.withSessionOrRehydrate("sb-cold", async (session) => {
 			return session.state;
 		});
 		expect(result).toBe("active");
-		// createFs called once for the rehydration
 		expect(createFsSpy).toHaveBeenCalledWith("memory", "sb-cold");
 	});
 
 	it("rehydrated session is warm on subsequent calls", async () => {
-		pgSandboxes.add("sb-once");
+		pgSandboxes.set("sb-once", DEFAULT_META);
 
-		// First call: rehydrates
 		await sm.withSessionOrRehydrate("sb-once", async () => "first");
-		// Second call: warm hit
 		await sm.withSessionOrRehydrate("sb-once", async () => "second");
 
-		// createFs called only once (rehydration), not twice
 		expect(createFsSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("destroyed sandbox stays ENOENT even if PG set still contains it", async () => {
-		pgSandboxes.add("sb-destroy");
+		pgSandboxes.set("sb-destroy", DEFAULT_META);
 
-		// Rehydrate first
 		await sm.withSessionOrRehydrate("sb-destroy", async () => "alive");
 
-		// Destroy removes from pool (and in real PG would delete the row)
 		await sm.destroy("sb-destroy");
-
-		// Simulate PG row being gone (destroy deletes it)
 		pgSandboxes.delete("sb-destroy");
 
 		await expect(sm.withSessionOrRehydrate("sb-destroy", async () => "ghost")).rejects.toMatchObject({
@@ -93,15 +90,57 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 		});
 	});
 
-	it("falls back to pool-only behavior when sandboxExistsFn is not set", async () => {
+	it("falls back to pool-only behavior when getSandboxMetaFn is not set", async () => {
 		const smNoFn = new SessionManager({
 			backend: "memory",
 			createFs: createFsSpy,
-			// No sandboxExistsFn — strict pool-only mode
 		});
 
 		await expect(smNoFn.withSessionOrRehydrate("cold-no-fn", async () => "nope")).rejects.toMatchObject({
 			code: "ENOENT",
 		});
+	});
+
+	it("restores owner from PG metadata on rehydration", async () => {
+		pgSandboxes.set("sb-owned", { owner: "user-a", python: false, javascript: false });
+
+		let capturedOwner = "";
+		await sm.withSessionOrRehydrate("sb-owned", async (session) => {
+			capturedOwner = session.owner;
+		});
+		expect(capturedOwner).toBe("user-a");
+	});
+
+	it("restores runtime options from PG metadata on rehydration", async () => {
+		pgSandboxes.set("sb-py", { owner: null, python: true, javascript: false });
+
+		let capturedRuntime = { python: false, javascript: false };
+		await sm.withSessionOrRehydrate("sb-py", async (session) => {
+			capturedRuntime = session.runtimeOptions;
+		});
+		expect(capturedRuntime).toEqual({ python: true, javascript: false });
+	});
+
+	it("persistSandboxMeta writes to store and is readable on rehydration", async () => {
+		await sm.withSession("sb-meta", async (session) => {
+			session.owner = "creator";
+			await sm.persistSandboxMeta("sb-meta", { owner: "creator", python: true, javascript: false });
+		});
+
+		// Simulate pool eviction by creating a new manager with same store
+		const sm2 = new SessionManager({
+			backend: "memory",
+			createFs: createFsSpy,
+			getSandboxMetaFn: async (sandboxId: string) => pgSandboxes.get(sandboxId) ?? null,
+		});
+
+		let owner = "";
+		let runtime = { python: false, javascript: false };
+		await sm2.withSessionOrRehydrate("sb-meta", async (session) => {
+			owner = session.owner;
+			runtime = session.runtimeOptions;
+		});
+		expect(owner).toBe("creator");
+		expect(runtime).toEqual({ python: true, javascript: false });
 	});
 });

--- a/src/api/__tests__/session-manager.test.ts
+++ b/src/api/__tests__/session-manager.test.ts
@@ -117,6 +117,26 @@ describe("SessionManager pathCache memory budget (US-075a)", () => {
 		vi.useRealTimers();
 	});
 
+	it("recomputes pathCacheBytes after writes on non-coherent backends", async () => {
+		const fs = new InMemoryFs();
+		const sm = new SessionManager({
+			backend: "memory",
+			createFs: async () => fs,
+		});
+
+		const session = await sm.getOrCreate("sandbox-budget-refresh");
+		const initialBytes = session.pathCacheBytes;
+
+		await sm.withSession("sandbox-budget-refresh", async (activeSession) => {
+			for (let i = 0; i < 4; i++) {
+				await activeSession.fs.writeFile(`/budget-${i}.txt`, "x");
+			}
+		});
+
+		const updated = sm.getSession("sandbox-budget-refresh");
+		expect(updated?.pathCacheBytes).toBeGreaterThan(initialBytes);
+	});
+
 	it("under-budget session stays resident after operations", async () => {
 		vi.useFakeTimers();
 		// Very large budget and very long idle — session should not be evicted

--- a/src/api/distributed-lock.ts
+++ b/src/api/distributed-lock.ts
@@ -39,15 +39,7 @@ const DEFAULTS: DistributedLockOptions = {
 	acquireRetryMs: 50,
 };
 
-/**
- * Fails fast on configurations that would silently break the mutex invariants.
- *
- * `renewMs >= leaseMs` lets the Redis key expire before the first heartbeat
- * can extend it, so another replica can acquire the lock while this caller's
- * critical section is still running. Non-positive values either make Redis
- * reject the command (`SET PX 0`) or turn the heartbeat/retry timers into
- * tight spin loops.
- */
+/** Fails fast on configs that would break mutex invariants (e.g. renewMs >= leaseMs lets the lease expire before renewal). */
 function assertLockOptions(opts: DistributedLockOptions): void {
 	if (opts.leaseMs <= 0) {
 		throw new Error(`DistributedLockOptions.leaseMs must be > 0 (got ${opts.leaseMs})`);

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -11,6 +11,7 @@
  * EISDIR         → 400  Bad Request
  * ENOTDIR        → 400  Bad Request
  * EPERM          → 403  Forbidden
+ * FORBIDDEN      → 403  Forbidden
  * ENOTEMPTY      → 409  Conflict
  * ESESSIONCLOSING→ 503  Service Unavailable (session being destroyed)
  * ELOOP          → 400  Bad Request (symlink loop)
@@ -31,6 +32,8 @@ export function mapFsErrorToStatus(err: Error): number {
 		case "ENOTDIR":
 			return 400;
 		case "EPERM":
+			return 403;
+		case "FORBIDDEN":
 			return 403;
 		case "ENOTEMPTY":
 			return 409;

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -56,6 +56,11 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			};
 			const session = await sessionManager.getOrCreate(id, runtimeOptions);
 			session.owner = owner;
+			await sessionManager.persistSandboxMeta(id, {
+				owner,
+				python: runtimeOptions.python,
+				javascript: runtimeOptions.javascript,
+			});
 			return {
 				content: [
 					{

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -26,18 +27,6 @@ function isValidRelativePath(p: string): boolean {
 		if (seg === "..") return false;
 	}
 	return true;
-}
-
-/**
- * Returns an error message if the caller does not own the sandbox, null if OK.
- * Matches HTTP route checkOwnership behavior: empty owner means no enforcement.
- */
-function checkMcpOwnership(sessionManager: SessionManager, sandboxId: string, caller: string): string | null {
-	const session = sessionManager.getSession(sandboxId);
-	if (session?.owner && session.owner !== caller) {
-		return "forbidden";
-	}
-	return null;
 }
 
 export function registerTools(server: McpServer, sessionManager: SessionManager, owner: string): void {
@@ -73,13 +62,8 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 	);
 
 	server.tool("sandbox_delete", "Delete a sandbox and all its files", { id: z.string() }, async (args) => {
-		const ownershipErr = checkMcpOwnership(sessionManager, args.id, owner);
-		if (ownershipErr) {
-			return {
-				content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
-			};
-		}
 		try {
+			await withOwnedSessionOrRehydrate(sessionManager, args.id, owner, async () => undefined);
 			const existed = await sessionManager.destroy(args.id);
 			if (!existed) {
 				return {
@@ -90,6 +74,17 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }],
 			};
 		} catch (err) {
+			const code = (err as Error & { code?: string }).code;
+			if (code === "FORBIDDEN") {
+				return {
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
+				};
+			}
+			if (code === "ENOENT") {
+				return {
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "sandbox not found" }) }],
+				};
+			}
 			const message = err instanceof Error ? err.message : String(err);
 			return {
 				content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
@@ -126,17 +121,10 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			timeout: z.number().int().positive().optional(),
 		},
 		async (args) => {
-			const ownershipErr = checkMcpOwnership(sessionManager, args.id, owner);
-			if (ownershipErr) {
-				return {
-					content: [{ type: "text" as const, text: JSON.stringify({ stdout: "", stderr: "forbidden", exitCode: 1 }) }],
-				};
-			}
-
 			const timeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
 			try {
-				const result = await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
+				const result = await withOwnedSessionOrRehydrate(sessionManager, args.id, owner, async (session) => {
 					const controller = new AbortController();
 					let timedOut = false;
 
@@ -168,6 +156,13 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				};
 			} catch (err) {
 				const code = (err as Error & { code?: string }).code;
+				if (code === "FORBIDDEN") {
+					return {
+						content: [
+							{ type: "text" as const, text: JSON.stringify({ stdout: "", stderr: "forbidden", exitCode: 1 }) },
+						],
+					};
+				}
 				if (code === "ENOENT") {
 					return {
 						content: [
@@ -211,15 +206,8 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				}
 			}
 
-			const ownershipErr = checkMcpOwnership(sessionManager, args.id, owner);
-			if (ownershipErr) {
-				return {
-					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
-				};
-			}
-
 			try {
-				await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
+				await withOwnedSessionOrRehydrate(sessionManager, args.id, owner, async (session) => {
 					for (const [relativePath, content] of Object.entries(args.files)) {
 						const absPath = `${basePath}/${relativePath}`;
 						const lastSlash = absPath.lastIndexOf("/");
@@ -238,6 +226,11 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				};
 			} catch (err) {
 				const code = (err as Error & { code?: string }).code;
+				if (code === "FORBIDDEN") {
+					return {
+						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
+					};
+				}
 				const message = code === "ENOENT" ? "sandbox not found" : err instanceof Error ? err.message : String(err);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
@@ -257,15 +250,8 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			const basePath = args.basePath ?? "/home/user";
 			const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
-			const ownershipErr = checkMcpOwnership(sessionManager, args.id, owner);
-			if (ownershipErr) {
-				return {
-					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
-				};
-			}
-
 			try {
-				const { files, errors } = await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
+				const { files, errors } = await withOwnedSessionOrRehydrate(sessionManager, args.id, owner, async (session) => {
 					const allPaths = session.fs.getAllPaths();
 					const prefix = basePath.endsWith("/") ? basePath : `${basePath}/`;
 					const result: Record<string, string> = Object.create(null);
@@ -306,6 +292,11 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				};
 			} catch (err) {
 				const code = (err as Error & { code?: string }).code;
+				if (code === "FORBIDDEN") {
+					return {
+						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
+					};
+				}
 				const message = code === "ENOENT" ? "sandbox not found" : err instanceof Error ? err.message : String(err);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -131,7 +131,7 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			const timeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
 			try {
-				const result = await sessionManager.withExistingSession(args.id, async (session) => {
+				const result = await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
 					const controller = new AbortController();
 					let timedOut = false;
 
@@ -214,7 +214,7 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			}
 
 			try {
-				await sessionManager.withExistingSession(args.id, async (session) => {
+				await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
 					for (const [relativePath, content] of Object.entries(args.files)) {
 						const absPath = `${basePath}/${relativePath}`;
 						const lastSlash = absPath.lastIndexOf("/");
@@ -260,7 +260,7 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			}
 
 			try {
-				const { files, errors } = await sessionManager.withExistingSession(args.id, async (session) => {
+				const { files, errors } = await sessionManager.withSessionOrRehydrate(args.id, async (session) => {
 					const allPaths = session.fs.getAllPaths();
 					const prefix = basePath.endsWith("/") ? basePath : `${basePath}/`;
 					const result: Record<string, string> = Object.create(null);

--- a/src/api/ownership.ts
+++ b/src/api/ownership.ts
@@ -1,0 +1,36 @@
+import type { RuntimeOptions, Session, SessionManager } from "./session-manager.js";
+
+export function createForbiddenError(): Error {
+	return Object.assign(new Error("forbidden"), { code: "FORBIDDEN" });
+}
+
+export function isForbiddenError(err: unknown): boolean {
+	return (err as Error & { code?: string })?.code === "FORBIDDEN";
+}
+
+export function forbiddenResponse(): Response {
+	return Response.json({ error: "forbidden", code: "FORBIDDEN" }, { status: 403 });
+}
+
+export function assertSessionOwner(session: Pick<Session, "owner">, caller: string): void {
+	if (session.owner && session.owner !== caller) {
+		throw createForbiddenError();
+	}
+}
+
+export async function withOwnedSessionOrRehydrate<T>(
+	sessionManager: SessionManager,
+	sandboxId: string,
+	caller: string,
+	fn: (session: Session) => Promise<T>,
+	runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+	return sessionManager.withSessionOrRehydrate(
+		sandboxId,
+		async (session) => {
+			assertSessionOwner(session, caller);
+			return fn(session);
+		},
+		runtimeOptions,
+	);
+}

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -62,7 +62,7 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type ExecSyncResult = { kind: "ok"; stdout: string; stderr: string; exitCode: number } | { kind: "timeout" };
 
-		const execResult = await sessionManager.withExistingSession<ExecSyncResult>(sandboxId, async (session) => {
+		const execResult = await sessionManager.withSessionOrRehydrate<ExecSyncResult>(sandboxId, async (session) => {
 			const controller = new AbortController();
 			let timedOut = false;
 
@@ -145,7 +145,7 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 				controller.abort();
 			}, timeoutMs);
 
-			await sessionManager.withExistingSession(sandboxId, async (session) => {
+			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 				try {
 					const result = await sessionManager.execWithRuntimeThrottle(session, body.script, {
 						signal: controller.signal,

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -9,6 +9,7 @@ import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
+import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -21,24 +22,12 @@ const execBodySchema = z.object({
 	timeoutMs: z.number().int().positive().optional(),
 });
 
-/** Returns 403 response if caller does not own the sandbox, undefined otherwise */
-function checkOwnership(sessionManager: SessionManager, sandboxId: string, caller: string): Response | undefined {
-	const session = sessionManager.getSession(sandboxId);
-	if (session?.owner && session.owner !== caller) {
-		return Response.json({ error: "forbidden", code: "FORBIDDEN" }, { status: 403 });
-	}
-	return undefined;
-}
-
 export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
 	// POST /v1/sandboxes/:id/exec-sync — buffered (non-streaming) bash execution
 	router.post("/:id/exec-sync", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		let body: z.infer<typeof execBodySchema>;
 		try {
 			const raw = await c.req.json();
@@ -62,41 +51,52 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type ExecSyncResult = { kind: "ok"; stdout: string; stderr: string; exitCode: number } | { kind: "timeout" };
 
-		const execResult = await sessionManager.withSessionOrRehydrate<ExecSyncResult>(sandboxId, async (session) => {
-			const controller = new AbortController();
-			let timedOut = false;
+		let execResult: ExecSyncResult;
+		try {
+			execResult = await withOwnedSessionOrRehydrate<ExecSyncResult>(
+				sessionManager,
+				sandboxId,
+				c.get("owner"),
+				async (session) => {
+					const controller = new AbortController();
+					let timedOut = false;
 
-			const timer = setTimeout(() => {
-				timedOut = true;
-				controller.abort();
-			}, timeoutMs);
+					const timer = setTimeout(() => {
+						timedOut = true;
+						controller.abort();
+					}, timeoutMs);
 
-			try {
-				const result = await sessionManager.execWithRuntimeThrottle(session, body.script, {
-					signal: controller.signal,
-					cwd: body.cwd,
-					env,
-				});
-				clearTimeout(timer);
+					try {
+						const result = await sessionManager.execWithRuntimeThrottle(session, body.script, {
+							signal: controller.signal,
+							cwd: body.cwd,
+							env,
+						});
+						clearTimeout(timer);
 
-				if (timedOut) {
-					return { kind: "timeout" };
-				}
+						if (timedOut) {
+							return { kind: "timeout" };
+						}
 
-				return {
-					kind: "ok",
-					stdout: result.stdout,
-					stderr: result.stderr,
-					exitCode: result.exitCode,
-				};
-			} catch (e) {
-				clearTimeout(timer);
-				if (timedOut) {
-					return { kind: "timeout" };
-				}
-				throw e;
-			}
-		});
+						return {
+							kind: "ok",
+							stdout: result.stdout,
+							stderr: result.stderr,
+							exitCode: result.exitCode,
+						};
+					} catch (e) {
+						clearTimeout(timer);
+						if (timedOut) {
+							return { kind: "timeout" };
+						}
+						throw e;
+					}
+				},
+			);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		if (execResult.kind === "timeout") {
 			return c.json({ error: "timeout", code: "EXEC_TIMEOUT" }, 408 as ContentfulStatusCode);
@@ -108,9 +108,6 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 	// POST /v1/sandboxes/:id/exec — SSE streaming bash execution
 	router.post("/:id/exec", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		let body: z.infer<typeof execBodySchema>;
 		try {
 			const raw = await c.req.json();
@@ -129,6 +126,12 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		const timeoutMs = Math.min(body.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;
+		try {
+			await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async () => undefined);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		return streamSSE(c, async (stream) => {
 			const controller = new AbortController();
@@ -145,7 +148,7 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 				controller.abort();
 			}, timeoutMs);
 
-			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
+			await sessionManager.withExistingSession(sandboxId, async (session) => {
 				try {
 					const result = await sessionManager.execWithRuntimeThrottle(session, body.script, {
 						signal: controller.signal,

--- a/src/api/routes/files.ts
+++ b/src/api/routes/files.ts
@@ -13,6 +13,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { FsStat } from "just-bash";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
+import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 // Simple extension → MIME type map (null-prototype to prevent prototype pollution)
@@ -76,23 +77,12 @@ function parentDir(filePath: string): string {
 	return lastSlash <= 0 ? "/" : filePath.slice(0, lastSlash);
 }
 
-/** Returns 403 response if caller does not own the sandbox, undefined otherwise */
-function checkOwnership(sessionManager: SessionManager, sandboxId: string, caller: string): Response | undefined {
-	const session = sessionManager.getSession(sandboxId);
-	if (session?.owner && session.owner !== caller) {
-		return Response.json({ error: "forbidden", code: "FORBIDDEN" }, { status: 403 });
-	}
-	return undefined;
-}
-
 export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
 	// GET /v1/sandboxes/:id/files/* — read file content
 	// Hono requires /:path{.*} to capture wildcard segments that may contain slashes
 	router.get("/:id/files/:path{.*}", async (c) => {
-		const ownershipErr = checkOwnership(sessionManager, c.req.param("id"), c.get("owner"));
-		if (ownershipErr) return ownershipErr;
 		const sandboxId = c.req.param("id");
 		const wildcard = c.req.param("path");
 		const filePath = `/${wildcard}`;
@@ -102,39 +92,50 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 			| { kind: "not_found" }
 			| { kind: "eisdir" };
 
-		const result = await sessionManager.withSessionOrRehydrate<ReadResult>(sandboxId, async (session) => {
-			let stat: FsStat;
-			try {
-				stat = await session.fs.stat(filePath);
-			} catch (e) {
-				const code = extractErrCode(e);
-				if (code === "ENOENT") return { kind: "not_found" };
-				throw e;
-			}
+		let result: ReadResult;
+		try {
+			result = await withOwnedSessionOrRehydrate<ReadResult>(
+				sessionManager,
+				sandboxId,
+				c.get("owner"),
+				async (session) => {
+					let stat: FsStat;
+					try {
+						stat = await session.fs.stat(filePath);
+					} catch (e) {
+						const code = extractErrCode(e);
+						if (code === "ENOENT") return { kind: "not_found" };
+						throw e;
+					}
 
-			if (stat.isDirectory) {
-				return { kind: "eisdir" };
-			}
+					if (stat.isDirectory) {
+						return { kind: "eisdir" };
+					}
 
-			const statHeader = {
-				kind: toKind(stat),
-				mode: stat.mode,
-				size: stat.size,
-				mtime: stat.mtime.toISOString(),
-			};
+					const statHeader = {
+						kind: toKind(stat),
+						mode: stat.mode,
+						size: stat.size,
+						mtime: stat.mtime.toISOString(),
+					};
 
-			// Use readFileBuffer if available (SqlFs), otherwise fall back to text-based readFile
-			const fs = session.fs as { readFileBuffer?: (path: string) => Promise<Uint8Array> };
-			let body: Uint8Array;
-			if (typeof fs.readFileBuffer === "function") {
-				body = await fs.readFileBuffer(filePath);
-			} else {
-				const content = await session.fs.readFile(filePath);
-				body = new TextEncoder().encode(content);
-			}
+					// Use readFileBuffer if available (SqlFs), otherwise fall back to text-based readFile
+					const fs = session.fs as { readFileBuffer?: (path: string) => Promise<Uint8Array> };
+					let body: Uint8Array;
+					if (typeof fs.readFileBuffer === "function") {
+						body = await fs.readFileBuffer(filePath);
+					} else {
+						const content = await session.fs.readFile(filePath);
+						body = new TextEncoder().encode(content);
+					}
 
-			return { kind: "ok", body, statHeader };
-		});
+					return { kind: "ok", body, statHeader };
+				},
+			);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		if (result.kind === "not_found") {
 			return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
@@ -154,26 +155,29 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 	// PUT /v1/sandboxes/:id/files/* — write raw file content
 	router.put("/:id/files/:path{.*}", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
 		const wildcard = c.req.param("path");
 		const filePath = `/${wildcard}`;
 
 		const buffer = await c.req.raw.arrayBuffer();
 		const content = new Uint8Array(buffer);
 
-		await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
-			const parent = parentDir(filePath);
-			if (parent !== "/") {
-				try {
-					await session.fs.mkdir(parent, { recursive: true });
-				} catch (e) {
-					const code = extractErrCode(e);
-					if (code !== "EEXIST") throw e;
+		try {
+			await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async (session) => {
+				const parent = parentDir(filePath);
+				if (parent !== "/") {
+					try {
+						await session.fs.mkdir(parent, { recursive: true });
+					} catch (e) {
+						const code = extractErrCode(e);
+						if (code !== "EEXIST") throw e;
+					}
 				}
-			}
-			await session.fs.writeFile(filePath, content);
-		});
+				await session.fs.writeFile(filePath, content);
+			});
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		return c.body(null, 204);
 	});
@@ -181,25 +185,34 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 	// DELETE /v1/sandboxes/:id/files/* — delete file or directory
 	router.delete("/:id/files/:path{.*}", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
 		const wildcard = c.req.param("path");
 		const filePath = `/${wildcard}`;
 		const recursive = c.req.query("recursive") === "true";
 
 		type DeleteResult = { kind: "ok" } | { kind: "not_found" } | { kind: "not_empty" };
 
-		const result = await sessionManager.withSessionOrRehydrate<DeleteResult>(sandboxId, async (session) => {
-			try {
-				await session.fs.rm(filePath, { recursive });
-				return { kind: "ok" };
-			} catch (e) {
-				const code = extractErrCode(e);
-				if (code === "ENOENT") return { kind: "not_found" };
-				if (code === "ENOTEMPTY") return { kind: "not_empty" };
-				throw e;
-			}
-		});
+		let result: DeleteResult;
+		try {
+			result = await withOwnedSessionOrRehydrate<DeleteResult>(
+				sessionManager,
+				sandboxId,
+				c.get("owner"),
+				async (session) => {
+					try {
+						await session.fs.rm(filePath, { recursive });
+						return { kind: "ok" };
+					} catch (e) {
+						const code = extractErrCode(e);
+						if (code === "ENOENT") return { kind: "not_found" };
+						if (code === "ENOTEMPTY") return { kind: "not_empty" };
+						throw e;
+					}
+				},
+			);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		if (result.kind === "not_found") {
 			return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
@@ -218,9 +231,6 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 	router.post("/:id/writeFiles", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		let body: z.infer<typeof writeFilesBodySchema>;
 		try {
 			const raw = await c.req.json();
@@ -239,20 +249,25 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		const { files } = body;
 
-		await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
-			for (const [filePath, content] of Object.entries(files)) {
-				const parent = parentDir(filePath);
-				if (parent !== "/") {
-					try {
-						await session.fs.mkdir(parent, { recursive: true });
-					} catch (e) {
-						const code = extractErrCode(e);
-						if (code !== "EEXIST") throw e;
+		try {
+			await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async (session) => {
+				for (const [filePath, content] of Object.entries(files)) {
+					const parent = parentDir(filePath);
+					if (parent !== "/") {
+						try {
+							await session.fs.mkdir(parent, { recursive: true });
+						} catch (e) {
+							const code = extractErrCode(e);
+							if (code !== "EEXIST") throw e;
+						}
 					}
+					await session.fs.writeFile(filePath, content);
 				}
-				await session.fs.writeFile(filePath, content);
-			}
-		});
+			});
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		return c.body(null, 204);
 	});
@@ -265,9 +280,6 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 	router.post("/:id/mkdir", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		let body: z.infer<typeof mkdirBodySchema>;
 		try {
 			const raw = await c.req.json();
@@ -288,16 +300,27 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type MkdirResult = { kind: "ok" } | { kind: "exists" };
 
-		const result = await sessionManager.withSessionOrRehydrate<MkdirResult>(sandboxId, async (session) => {
-			try {
-				await session.fs.mkdir(dirPath, { recursive });
-				return { kind: "ok" };
-			} catch (e) {
-				const code = extractErrCode(e);
-				if (code === "EEXIST") return { kind: "exists" };
-				throw e;
-			}
-		});
+		let result: MkdirResult;
+		try {
+			result = await withOwnedSessionOrRehydrate<MkdirResult>(
+				sessionManager,
+				sandboxId,
+				c.get("owner"),
+				async (session) => {
+					try {
+						await session.fs.mkdir(dirPath, { recursive });
+						return { kind: "ok" };
+					} catch (e) {
+						const code = extractErrCode(e);
+						if (code === "EEXIST") return { kind: "exists" };
+						throw e;
+					}
+				},
+			);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		if (result.kind === "exists") {
 			return c.json({ error: "already_exists", code: "EEXIST" }, 409 as ContentfulStatusCode);
@@ -314,9 +337,6 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 	router.get("/:id/tree", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		const queryResult = treeQuerySchema.safeParse(c.req.query());
 		if (!queryResult.success) {
 			const details = queryResult.error.issues.map((i) => i.message);
@@ -329,41 +349,52 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type TreeEntry = { path: string; kind: string; size: number; mtime: string };
 
-		const entries = await sessionManager.withSessionOrRehydrate<TreeEntry[]>(sandboxId, async (session) => {
-			const allPaths = session.fs.getAllPaths();
-			const result: TreeEntry[] = [];
+		let entries: TreeEntry[];
+		try {
+			entries = await withOwnedSessionOrRehydrate<TreeEntry[]>(
+				sessionManager,
+				sandboxId,
+				c.get("owner"),
+				async (session) => {
+					const allPaths = session.fs.getAllPaths();
+					const result: TreeEntry[] = [];
 
-			for (const p of allPaths) {
-				// Skip the prefix dir itself
-				if (p === normalizedPrefix) continue;
+					for (const p of allPaths) {
+						// Skip the prefix dir itself
+						if (p === normalizedPrefix) continue;
 
-				// Filter by prefix
-				if (normalizedPrefix !== "/") {
-					if (!p.startsWith(`${normalizedPrefix}/`)) continue;
-				}
+						// Filter by prefix
+						if (normalizedPrefix !== "/") {
+							if (!p.startsWith(`${normalizedPrefix}/`)) continue;
+						}
 
-				// Filter by depth (relative segments below prefix)
-				if (depth !== undefined) {
-					const relative = normalizedPrefix === "/" ? p.slice(1) : p.slice(normalizedPrefix.length + 1);
-					const segments = relative.split("/").filter(Boolean).length;
-					if (segments > depth) continue;
-				}
+						// Filter by depth (relative segments below prefix)
+						if (depth !== undefined) {
+							const relative = normalizedPrefix === "/" ? p.slice(1) : p.slice(normalizedPrefix.length + 1);
+							const segments = relative.split("/").filter(Boolean).length;
+							if (segments > depth) continue;
+						}
 
-				try {
-					const stat = await session.fs.stat(p);
-					result.push({
-						path: p,
-						kind: toKind(stat),
-						size: stat.size,
-						mtime: stat.mtime.toISOString(),
-					});
-				} catch {
-					// Skip paths that can't be stat'd
-				}
-			}
+						try {
+							const stat = await session.fs.stat(p);
+							result.push({
+								path: p,
+								kind: toKind(stat),
+								size: stat.size,
+								mtime: stat.mtime.toISOString(),
+							});
+						} catch {
+							// Skip paths that can't be stat'd
+						}
+					}
 
-			return result;
-		});
+					return result;
+				},
+			);
+		} catch (err) {
+			if (isForbiddenError(err)) return forbiddenResponse();
+			throw err;
+		}
 
 		return c.json(entries);
 	});

--- a/src/api/routes/files.ts
+++ b/src/api/routes/files.ts
@@ -102,7 +102,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 			| { kind: "not_found" }
 			| { kind: "eisdir" };
 
-		const result = await sessionManager.withExistingSession<ReadResult>(sandboxId, async (session) => {
+		const result = await sessionManager.withSessionOrRehydrate<ReadResult>(sandboxId, async (session) => {
 			let stat: FsStat;
 			try {
 				stat = await session.fs.stat(filePath);
@@ -162,7 +162,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		const buffer = await c.req.raw.arrayBuffer();
 		const content = new Uint8Array(buffer);
 
-		await sessionManager.withExistingSession(sandboxId, async (session) => {
+		await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 			const parent = parentDir(filePath);
 			if (parent !== "/") {
 				try {
@@ -189,7 +189,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type DeleteResult = { kind: "ok" } | { kind: "not_found" } | { kind: "not_empty" };
 
-		const result = await sessionManager.withExistingSession<DeleteResult>(sandboxId, async (session) => {
+		const result = await sessionManager.withSessionOrRehydrate<DeleteResult>(sandboxId, async (session) => {
 			try {
 				await session.fs.rm(filePath, { recursive });
 				return { kind: "ok" };
@@ -239,7 +239,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		const { files } = body;
 
-		await sessionManager.withExistingSession(sandboxId, async (session) => {
+		await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 			for (const [filePath, content] of Object.entries(files)) {
 				const parent = parentDir(filePath);
 				if (parent !== "/") {
@@ -288,7 +288,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type MkdirResult = { kind: "ok" } | { kind: "exists" };
 
-		const result = await sessionManager.withExistingSession<MkdirResult>(sandboxId, async (session) => {
+		const result = await sessionManager.withSessionOrRehydrate<MkdirResult>(sandboxId, async (session) => {
 			try {
 				await session.fs.mkdir(dirPath, { recursive });
 				return { kind: "ok" };
@@ -329,7 +329,7 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		type TreeEntry = { path: string; kind: string; size: number; mtime: string };
 
-		const entries = await sessionManager.withExistingSession<TreeEntry[]>(sandboxId, async (session) => {
+		const entries = await sessionManager.withSessionOrRehydrate<TreeEntry[]>(sandboxId, async (session) => {
 			const allPaths = session.fs.getAllPaths();
 			const result: TreeEntry[] = [];
 

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
+import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 // Validates that a basePath is a safe absolute path (no shell metacharacters)
@@ -27,24 +28,12 @@ function isValidRelativePath(p: string): boolean {
 	return true;
 }
 
-/** Returns 403 response if caller does not own the sandbox, undefined otherwise */
-function checkOwnership(sessionManager: SessionManager, sandboxId: string, caller: string): Response | undefined {
-	const session = sessionManager.getSession(sandboxId);
-	if (session?.owner && session.owner !== caller) {
-		return Response.json({ error: "forbidden", code: "FORBIDDEN" }, { status: 403 });
-	}
-	return undefined;
-}
-
 export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
 	// POST /v1/sandboxes/:id/ingest — upload tar.gz and extract into sandbox
 	router.post("/:id/ingest", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		const body = await c.req.parseBody();
 		const archiveField = body.archive;
 		const basePathField = body.basePath;
@@ -68,7 +57,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 		const archiveBuffer = new Uint8Array(await archiveField.arrayBuffer());
 
 		try {
-			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
+			await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async (session) => {
 				// Ensure /tmp exists before writing archive
 				try {
 					await session.fs.mkdir("/tmp", { recursive: true });
@@ -93,6 +82,9 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			});
 		} catch (e) {
 			const code = (e as Error & { code?: string }).code;
+			if (isForbiddenError(e)) {
+				return forbiddenResponse();
+			}
 			if (code === "ENOENT") {
 				return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
 			}
@@ -110,9 +102,6 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 	router.post("/:id/ingest-files", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		let raw: unknown;
 		try {
 			raw = await c.req.json();
@@ -159,7 +148,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 		const fileCount = Object.keys(files).length;
 
 		try {
-			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
+			await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async (session) => {
 				for (const [relativePath, base64Content] of Object.entries(files)) {
 					const absPath = `${basePath}/${relativePath}`.replace(/\/+/g, "/");
 					const lastSlash = absPath.lastIndexOf("/");
@@ -180,6 +169,9 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			});
 		} catch (e) {
 			const code = (e as Error & { code?: string }).code;
+			if (isForbiddenError(e)) {
+				return forbiddenResponse();
+			}
 			if (code === "ENOENT") {
 				return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
 			}
@@ -192,9 +184,6 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 	// GET /v1/sandboxes/:id/export — download sandbox contents as tar.gz
 	router.get("/:id/export", async (c) => {
 		const sandboxId = c.req.param("id");
-		const ownershipErr = checkOwnership(sessionManager, sandboxId, c.get("owner"));
-		if (ownershipErr) return ownershipErr;
-
 		const basePath = c.req.query("basePath") ?? "/home/user";
 
 		if (!isValidBasePath(basePath)) {
@@ -206,7 +195,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 		let archiveBytes: Uint8Array;
 		try {
-			archiveBytes = await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
+			archiveBytes = await withOwnedSessionOrRehydrate(sessionManager, sandboxId, c.get("owner"), async (session) => {
 				// Check basePath exists
 				const exists = await session.fs.exists(basePath);
 				if (!exists) {
@@ -242,6 +231,9 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			});
 		} catch (e) {
 			const code = (e as Error & { code?: string }).code;
+			if (isForbiddenError(e)) {
+				return forbiddenResponse();
+			}
 			if (code === "ENOENT") {
 				return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
 			}

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -68,7 +68,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 		const archiveBuffer = new Uint8Array(await archiveField.arrayBuffer());
 
 		try {
-			await sessionManager.withExistingSession(sandboxId, async (session) => {
+			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 				// Ensure /tmp exists before writing archive
 				try {
 					await session.fs.mkdir("/tmp", { recursive: true });
@@ -159,7 +159,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 		const fileCount = Object.keys(files).length;
 
 		try {
-			await sessionManager.withExistingSession(sandboxId, async (session) => {
+			await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 				for (const [relativePath, base64Content] of Object.entries(files)) {
 					const absPath = `${basePath}/${relativePath}`.replace(/\/+/g, "/");
 					const lastSlash = absPath.lastIndexOf("/");
@@ -206,7 +206,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 		let archiveBytes: Uint8Array;
 		try {
-			archiveBytes = await sessionManager.withExistingSession(sandboxId, async (session) => {
+			archiveBytes = await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
 				// Check basePath exists
 				const exists = await session.fs.exists(basePath);
 				if (!exists) {

--- a/src/api/routes/sandboxes.ts
+++ b/src/api/routes/sandboxes.ts
@@ -50,6 +50,7 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 			async (session) => {
 				session.owner = owner;
 				session.createdAt = createdAt;
+				await sessionManager.persistSandboxMeta(sandboxId, { owner, python, javascript });
 				if (files !== undefined) {
 					for (const [path, content] of Object.entries(files)) {
 						await session.fs.writeFile(path, content);

--- a/src/api/routes/sandboxes.ts
+++ b/src/api/routes/sandboxes.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
+import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const createBodySchema = z.object({
@@ -84,13 +85,17 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 
 	router.delete("/:id", async (c) => {
 		const id = c.req.param("id");
-		// Check ownership before destroying
-		const session = sessionManager.getSession(id);
-		if (session !== undefined) {
-			const caller = c.get("owner");
-			if (session.owner && session.owner !== caller) {
-				return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
+		try {
+			await withOwnedSessionOrRehydrate(sessionManager, id, c.get("owner"), async () => undefined);
+		} catch (err) {
+			const code = (err as Error & { code?: string }).code;
+			if (isForbiddenError(err)) {
+				return forbiddenResponse();
 			}
+			if (code === "ENOENT") {
+				return c.json({ error: "not_found", code: "SANDBOX_NOT_FOUND" }, 404 as ContentfulStatusCode);
+			}
+			throw err;
 		}
 		const found = await sessionManager.destroy(id);
 		if (!found) {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -148,6 +148,7 @@ app.onError((err, c) => {
 		"EISDIR",
 		"ENOTDIR",
 		"EPERM",
+		"FORBIDDEN",
 		"ENOTEMPTY",
 		"ESESSIONCLOSING",
 		"ELOOP",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -49,29 +49,36 @@ const pathSnapshot =
 
 const backend = (process.env.FS_BACKEND as StorageBackend | undefined) ?? "memory";
 
-// Postgres existence check for session rehydration on cold replicas.
+// Postgres metadata functions for session rehydration on cold replicas.
 // Uses a single long-lived dialect (connection-pooled internally by the postgres driver).
-let sandboxExistsFn: ((sandboxId: string) => Promise<boolean>) | undefined;
-if (backend === "postgres" && process.env.DATABASE_URL) {
-	const existsDialect = new PostgresDialect(process.env.DATABASE_URL);
+const metaFns = (() => {
+	if (backend !== "postgres" || !process.env.DATABASE_URL) return {};
+	const metaDialect = new PostgresDialect(process.env.DATABASE_URL);
 	let connected = false;
-	sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+	const ensureConnected = async (): Promise<void> => {
 		if (!connected) {
-			await existsDialect.connect();
+			await metaDialect.connect();
 			connected = true;
 		}
-		return existsDialect.transaction(async (tx) => {
-			return existsDialect.sandboxExists(tx, sandboxId);
-		});
 	};
-}
+	return {
+		getSandboxMetaFn: async (sandboxId: string) => {
+			await ensureConnected();
+			return metaDialect.transaction((tx) => metaDialect.getSandboxMeta(tx, sandboxId));
+		},
+		persistSandboxMetaFn: async (sandboxId: string, meta: import("../fs/sql-fs/types.js").SandboxMeta) => {
+			await ensureConnected();
+			await metaDialect.transaction((tx) => metaDialect.updateSandboxMeta(tx, sandboxId, meta));
+		},
+	};
+})();
 
 const sessionManager = new SessionManager({
 	backend,
 	redis: redisClient,
 	execLockOptions,
 	pathSnapshot,
-	sandboxExistsFn,
+	...metaFns,
 });
 
 // ── Auth middleware (all /v1/* routes) ────────────────────────────────────────

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -7,6 +7,7 @@ import { serve } from "@hono/node-server";
 import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { PostgresDialect } from "../fs/sql-fs/dialects/postgres.js";
 import type { StorageBackend } from "../fs/sql-fs/index.js";
 import { RedisPathSnapshot } from "../fs/sql-fs/redis-path-snapshot.js";
 import { getRedisClient } from "../redis/client.js";
@@ -46,11 +47,31 @@ const pathSnapshot =
 			})
 		: undefined;
 
+const backend = (process.env.FS_BACKEND as StorageBackend | undefined) ?? "memory";
+
+// Postgres existence check for session rehydration on cold replicas.
+// Uses a single long-lived dialect (connection-pooled internally by the postgres driver).
+let sandboxExistsFn: ((sandboxId: string) => Promise<boolean>) | undefined;
+if (backend === "postgres" && process.env.DATABASE_URL) {
+	const existsDialect = new PostgresDialect(process.env.DATABASE_URL);
+	let connected = false;
+	sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+		if (!connected) {
+			await existsDialect.connect();
+			connected = true;
+		}
+		return existsDialect.transaction(async (tx) => {
+			return existsDialect.sandboxExists(tx, sandboxId);
+		});
+	};
+}
+
 const sessionManager = new SessionManager({
-	backend: (process.env.FS_BACKEND as StorageBackend | undefined) ?? "memory",
+	backend,
 	redis: redisClient,
 	execLockOptions,
 	pathSnapshot,
+	sandboxExistsFn,
 });
 
 // ── Auth middleware (all /v1/* routes) ────────────────────────────────────────

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -60,10 +60,21 @@ const { closeMetaFns, ...sessionMetaFns } = (() => {
 	}
 	const metaDialect = new PostgresDialect(process.env.DATABASE_URL);
 	let connected = false;
+	let connectPromise: Promise<void> | undefined;
 	const ensureConnected = async (): Promise<void> => {
-		if (!connected) {
+		if (connected) return;
+		if (connectPromise) {
+			await connectPromise;
+			return;
+		}
+		connectPromise = (async () => {
 			await metaDialect.connect();
 			connected = true;
+		})();
+		try {
+			await connectPromise;
+		} finally {
+			connectPromise = undefined;
 		}
 	};
 	return {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -48,7 +48,20 @@ const pathSnapshot =
 			})
 		: undefined;
 
-const backend = (process.env.FS_BACKEND as StorageBackend | undefined) ?? "memory";
+const VALID_BACKENDS = ["postgres", "memory"] as const satisfies readonly StorageBackend[];
+
+function isStorageBackend(value: string): value is StorageBackend {
+	return (VALID_BACKENDS as readonly string[]).includes(value);
+}
+
+const fsBackend = process.env.FS_BACKEND;
+if (fsBackend !== undefined && !isStorageBackend(fsBackend)) {
+	throw Object.assign(
+		new Error(`FS_BACKEND '${fsBackend}' is not a valid backend. Valid values: ${VALID_BACKENDS.join(", ")}`),
+		{ code: "EINVAL" },
+	);
+}
+const backend: StorageBackend = fsBackend ?? "memory";
 
 // Postgres metadata functions for session rehydration on cold replicas.
 // Uses a single long-lived dialect (connection-pooled internally by the postgres driver).

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,6 +8,7 @@ import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { PostgresDialect } from "../fs/sql-fs/dialects/postgres.js";
+import { translateSqlError } from "../fs/sql-fs/errors.js";
 import type { StorageBackend } from "../fs/sql-fs/index.js";
 import { RedisPathSnapshot } from "../fs/sql-fs/redis-path-snapshot.js";
 import { getRedisClient } from "../redis/client.js";
@@ -51,8 +52,12 @@ const backend = (process.env.FS_BACKEND as StorageBackend | undefined) ?? "memor
 
 // Postgres metadata functions for session rehydration on cold replicas.
 // Uses a single long-lived dialect (connection-pooled internally by the postgres driver).
-const metaFns = (() => {
-	if (backend !== "postgres" || !process.env.DATABASE_URL) return {};
+const { closeMetaFns, ...sessionMetaFns } = (() => {
+	if (backend !== "postgres" || !process.env.DATABASE_URL) {
+		return {
+			closeMetaFns: async (): Promise<void> => {},
+		};
+	}
 	const metaDialect = new PostgresDialect(process.env.DATABASE_URL);
 	let connected = false;
 	const ensureConnected = async (): Promise<void> => {
@@ -64,11 +69,24 @@ const metaFns = (() => {
 	return {
 		getSandboxMetaFn: async (sandboxId: string) => {
 			await ensureConnected();
-			return metaDialect.transaction((tx) => metaDialect.getSandboxMeta(tx, sandboxId));
+			try {
+				return await metaDialect.transaction((tx) => metaDialect.getSandboxMeta(tx, sandboxId));
+			} catch (err) {
+				throw translateSqlError(err, sandboxId);
+			}
 		},
 		persistSandboxMetaFn: async (sandboxId: string, meta: import("../fs/sql-fs/types.js").SandboxMeta) => {
 			await ensureConnected();
-			await metaDialect.transaction((tx) => metaDialect.updateSandboxMeta(tx, sandboxId, meta));
+			try {
+				await metaDialect.transaction((tx) => metaDialect.updateSandboxMeta(tx, sandboxId, meta));
+			} catch (err) {
+				throw translateSqlError(err, sandboxId);
+			}
+		},
+		closeMetaFns: async (): Promise<void> => {
+			if (!connected) return;
+			connected = false;
+			await metaDialect.disconnect();
 		},
 	};
 })();
@@ -78,7 +96,7 @@ const sessionManager = new SessionManager({
 	redis: redisClient,
 	execLockOptions,
 	pathSnapshot,
-	...metaFns,
+	...sessionMetaFns,
 });
 
 // ── Auth middleware (all /v1/* routes) ────────────────────────────────────────
@@ -167,7 +185,22 @@ const isMain = process.argv[1] !== undefined && import.meta.url.endsWith(process
 
 if (isMain) {
 	const port = Number(process.env.PORT ?? "8080");
-	serve({ fetch: app.fetch, port }, () => {
+	const server = serve({ fetch: app.fetch, port }, () => {
 		console.log(JSON.stringify({ event: "server_start", port }));
 	});
+
+	let shuttingDown = false;
+	const shutdown = (): void => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		server.close(async () => {
+			try {
+				await closeMetaFns();
+			} finally {
+				process.exit(0);
+			}
+		});
+	};
+	process.once("SIGINT", shutdown);
+	process.once("SIGTERM", shutdown);
 }

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -10,26 +10,15 @@ import type { ExecOptions, IFileSystem } from "just-bash";
 import type { BashExecResult } from "just-bash";
 import { createSandboxFs, destroySandbox } from "../fs/sql-fs/index.js";
 import type { StorageBackend } from "../fs/sql-fs/index.js";
-import type { RedisPathSnapshot } from "../fs/sql-fs/redis-path-snapshot.js";
+import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import type { ICoherentFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 
-/**
- * Internal structural type: the subset of `SqlFs` the session manager touches
- * for Phase E snapshot writes. Declared here (rather than exported from sql-fs)
- * to keep the cross-module surface narrow.
- */
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
 
-/** Narrowing helper: returns the fs as a snapshot writer if the hook is present. */
 function asSnapshotWriter(fs: ICoherentFs): SnapshotWriterFs | undefined {
 	return typeof (fs as Partial<SnapshotWriterFs>)._getPathCache === "function" ? (fs as SnapshotWriterFs) : undefined;
-}
-
-/** Redis key template for the per-sandbox monotonic version counter (Phase D). */
-function versionKey(sandboxId: string): string {
-	return `vfs:ver:${sandboxId}`;
 }
 
 /**
@@ -298,16 +287,7 @@ export class SessionManager {
 		return withDistributedLock(this.redis, execLockKey(sandboxId), fn, this.execLockOptions);
 	}
 
-	/**
-	 * Shared entry logic for all session wrappers.
-	 * Must be called inside the distributed exec lock.
-	 *
-	 * 1. Checks session isn't closing
-	 * 2. Runs cross-replica cache coherence (Phase D)
-	 * 3. Acquires local mutex, tracks inFlight
-	 * 4. Calls fn(session)
-	 * 5. Publishes version if dirty (Phase D/E)
-	 */
+	/** Shared entry logic for all session wrappers. Must be called inside the distributed exec lock. */
 	private async withSessionEntry<T>(
 		sandboxId: string,
 		session: Session,
@@ -328,6 +308,7 @@ export class SessionManager {
 			try {
 				return await fn(session);
 			} finally {
+				const wasDirty = asCoherentFs(session.fs)?.wasDirty() ?? false;
 				try {
 					await this.publishVersionIfDirty(sandboxId, session);
 				} catch (err) {
@@ -340,8 +321,10 @@ export class SessionManager {
 					);
 				}
 				session.inFlight--;
-				session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
-				session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+				if (wasDirty) {
+					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
+					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+				}
 			}
 		});
 	}
@@ -477,34 +460,15 @@ export class SessionManager {
 	 * Like withExistingSession, but falls back to Postgres to check if the sandbox
 	 * exists before throwing ENOENT. If the sandbox is in Postgres but not in the
 	 * pool (evicted by reaper, or created on another replica), rehydrates it via
-	 * getOrCreate — leveraging Phase E snapshot for fast cold-start.
-	 *
-	 * Fast path: pool check outside distributed lock (no Redis RTT for warm hits).
-	 * Cold path: lock -> double-check -> PG exists -> getOrCreate.
-	 *
-	 * Falls back to withExistingSession behavior when sandboxExistsFn is undefined.
+	 * getOrCreate. Falls back to withExistingSession behavior when sandboxExistsFn
+	 * is undefined.
 	 */
 	async withSessionOrRehydrate<T>(
 		sandboxId: string,
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		// Fast path: warm pool hit — skip straight to exec lock + entry
-		const warm = this.sessions.get(sandboxId);
-		if (warm !== undefined && warm.state !== "closing") {
-			return this.withExecLock(sandboxId, async () => {
-				// Re-check under lock (may have been evicted between check and lock acquisition)
-				const session = this.sessions.get(sandboxId);
-				if (session !== undefined && session.state !== "closing") {
-					return this.withSessionEntry(sandboxId, session, fn);
-				}
-				return this.rehydrateAndExec(sandboxId, fn, runtimeOptions);
-			});
-		}
-
-		// Cold path: need to check Postgres
 		return this.withExecLock(sandboxId, async () => {
-			// Double-check under lock
 			const session = this.sessions.get(sandboxId);
 			if (session !== undefined && session.state !== "closing") {
 				return this.withSessionEntry(sandboxId, session, fn);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -124,6 +124,12 @@ export interface SessionManagerOptions {
 	 * on sandbox destroy.
 	 */
 	readonly pathSnapshot?: RedisPathSnapshot;
+	/**
+	 * Checks whether a sandbox exists in the persistent store (Postgres).
+	 * Required for withSessionOrRehydrate to distinguish "evicted" from "deleted".
+	 * When undefined, withSessionOrRehydrate falls back to withExistingSession behavior.
+	 */
+	readonly sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
 }
 
 /** Internal FIFO-semaphore state shared by the python and js throttles. */
@@ -146,6 +152,7 @@ export class SessionManager {
 	private readonly redis: Redis | undefined;
 	private readonly execLockOptions: Partial<DistributedLockOptions> | undefined;
 	private readonly pathSnapshot: RedisPathSnapshot | undefined;
+	private readonly sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
 
 	// --- Runtime throttle semaphores (US-080a) ---
 	/** Python runtime semaphore — caps CPython WASM workers (~80MB each). */
@@ -168,6 +175,7 @@ export class SessionManager {
 		redis,
 		execLockOptions,
 		pathSnapshot,
+		sandboxExistsFn,
 	}: SessionManagerOptions) {
 		this.backend = backend;
 		this.createFs = createFs ?? createSandboxFs;
@@ -177,6 +185,7 @@ export class SessionManager {
 		this.redis = redis;
 		this.execLockOptions = execLockOptions;
 		this.pathSnapshot = pathSnapshot;
+		this.sandboxExistsFn = sandboxExistsFn;
 		this.pythonSem = {
 			limit: maxConcurrentPython ?? Number(process.env.MAX_CONCURRENT_PYTHON ?? "5"),
 			inFlight: 0,
@@ -290,6 +299,54 @@ export class SessionManager {
 	}
 
 	/**
+	 * Shared entry logic for all session wrappers.
+	 * Must be called inside the distributed exec lock.
+	 *
+	 * 1. Checks session isn't closing
+	 * 2. Runs cross-replica cache coherence (Phase D)
+	 * 3. Acquires local mutex, tracks inFlight
+	 * 4. Calls fn(session)
+	 * 5. Publishes version if dirty (Phase D/E)
+	 */
+	private async withSessionEntry<T>(
+		sandboxId: string,
+		session: Session,
+		fn: (session: Session) => Promise<T>,
+	): Promise<T> {
+		if (session.state === "closing") {
+			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+		}
+
+		await this.ensureFreshCache(sandboxId, session);
+
+		return session.mutex.runExclusive(async () => {
+			if (session.state === "closing") {
+				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+			}
+			session.inFlight++;
+			session.lastUsed = Date.now();
+			try {
+				return await fn(session);
+			} finally {
+				try {
+					await this.publishVersionIfDirty(sandboxId, session);
+				} catch (err) {
+					console.error(
+						JSON.stringify({
+							event: "publish_version_finally_error",
+							sandboxId,
+							error: (err as Error).message,
+						}),
+					);
+				}
+				session.inFlight--;
+				session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
+				session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+			}
+		});
+	}
+
+	/**
 	 * Cross-replica cache coherence (Phase D):
 	 * Compares the session's `lastSeenVersion` against the shared Redis counter
 	 * and reloads the filesystem cache if another replica has mutated state
@@ -395,52 +452,7 @@ export class SessionManager {
 	): Promise<T> {
 		return this.withExecLock(sandboxId, async () => {
 			const session = await this.getOrCreate(sandboxId, runtimeOptions);
-
-			// Fast-fail: session is being destroyed — don't queue in the mutex
-			if (session.state === "closing") {
-				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-			}
-
-			// Cross-replica cache check — done inside the exec lock but outside
-			// the session mutex so a reload cannot race with another turn on
-			// this replica; we already hold the distributed lock which serializes
-			// turns across replicas.
-			await this.ensureFreshCache(sandboxId, session);
-
-			return session.mutex.runExclusive(async () => {
-				// Re-check inside mutex in case destroy was called between the check above and acquiring the lock
-				if (session.state === "closing") {
-					throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-				}
-				session.inFlight++;
-				try {
-					return await fn(session);
-				} finally {
-					// Publish even when fn threw: each SqlFs mutation is already
-					// committed to Postgres before its dirty bit flips, so a
-					// partially-completed exec can leave the DB ahead of every
-					// peer's cache. Skipping the bump here would leave other
-					// replicas serving stale reads until this replica happens to
-					// run another successful turn.
-					try {
-						await this.publishVersionIfDirty(sandboxId, session);
-					} catch (err) {
-						// Defensive: publishVersionIfDirty already swallows INCR
-						// errors internally, but never let a finally-block hide
-						// the primary error from fn.
-						console.error(
-							JSON.stringify({
-								event: "publish_version_finally_error",
-								sandboxId,
-								error: (err as Error).message,
-							}),
-						);
-					}
-					session.inFlight--;
-					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
-					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
-				}
-			});
+			return this.withSessionEntry(sandboxId, session, fn);
 		});
 	}
 
@@ -457,40 +469,73 @@ export class SessionManager {
 			if (session === undefined) {
 				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 			}
-
-			if (session.state === "closing") {
-				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-			}
-
-			await this.ensureFreshCache(sandboxId, session);
-
-			return session.mutex.runExclusive(async () => {
-				if (session.state === "closing") {
-					throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-				}
-				session.inFlight++;
-				session.lastUsed = Date.now();
-				try {
-					return await fn(session);
-				} finally {
-					// Publish even when fn threw — see comment in withSession.
-					try {
-						await this.publishVersionIfDirty(sandboxId, session);
-					} catch (err) {
-						console.error(
-							JSON.stringify({
-								event: "publish_version_finally_error",
-								sandboxId,
-								error: (err as Error).message,
-							}),
-						);
-					}
-					session.inFlight--;
-					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
-					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
-				}
-			});
+			return this.withSessionEntry(sandboxId, session, fn);
 		});
+	}
+
+	/**
+	 * Like withExistingSession, but falls back to Postgres to check if the sandbox
+	 * exists before throwing ENOENT. If the sandbox is in Postgres but not in the
+	 * pool (evicted by reaper, or created on another replica), rehydrates it via
+	 * getOrCreate — leveraging Phase E snapshot for fast cold-start.
+	 *
+	 * Fast path: pool check outside distributed lock (no Redis RTT for warm hits).
+	 * Cold path: lock -> double-check -> PG exists -> getOrCreate.
+	 *
+	 * Falls back to withExistingSession behavior when sandboxExistsFn is undefined.
+	 */
+	async withSessionOrRehydrate<T>(
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		// Fast path: warm pool hit — skip straight to exec lock + entry
+		const warm = this.sessions.get(sandboxId);
+		if (warm !== undefined && warm.state !== "closing") {
+			return this.withExecLock(sandboxId, async () => {
+				// Re-check under lock (may have been evicted between check and lock acquisition)
+				const session = this.sessions.get(sandboxId);
+				if (session !== undefined && session.state !== "closing") {
+					return this.withSessionEntry(sandboxId, session, fn);
+				}
+				return this.rehydrateAndExec(sandboxId, fn, runtimeOptions);
+			});
+		}
+
+		// Cold path: need to check Postgres
+		return this.withExecLock(sandboxId, async () => {
+			// Double-check under lock
+			const session = this.sessions.get(sandboxId);
+			if (session !== undefined && session.state !== "closing") {
+				return this.withSessionEntry(sandboxId, session, fn);
+			}
+			return this.rehydrateAndExec(sandboxId, fn, runtimeOptions);
+		});
+	}
+
+	/**
+	 * Cold-path helper: checks PG existence, rehydrates via getOrCreate, then executes.
+	 * Must be called inside the distributed exec lock.
+	 */
+	private async rehydrateAndExec<T>(
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		if (this.sandboxExistsFn !== undefined) {
+			const exists = await this.sandboxExistsFn(sandboxId);
+			if (!exists) {
+				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+			}
+		} else {
+			// No existence check configured — strict pool-only behavior
+			const session = this.sessions.get(sandboxId);
+			if (session === undefined) {
+				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+			}
+		}
+		const session = await this.getOrCreate(sandboxId, runtimeOptions);
+		return this.withSessionEntry(sandboxId, session, fn);
 	}
 
 	/**

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -502,14 +502,11 @@ export class SessionManager {
 			}
 		} else {
 			// No metadata function configured — strict pool-only behavior
-			const session = this.sessions.get(sandboxId);
-			if (session === undefined) {
-				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
-			}
+			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 		}
 		const resolvedRuntime: RuntimeOptions = meta
 			? { python: meta.python, javascript: meta.javascript }
-			: runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS;
+			: (runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS);
 		const session = await this.getOrCreate(sandboxId, resolvedRuntime);
 		if (meta?.owner) {
 			session.owner = meta.owner;

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -12,7 +12,7 @@ import { createSandboxFs, destroySandbox } from "../fs/sql-fs/index.js";
 import type { StorageBackend } from "../fs/sql-fs/index.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import type { ICoherentFs } from "../fs/sql-fs/sql-fs.js";
-import type { PathCacheEntry } from "../fs/sql-fs/types.js";
+import type { PathCacheEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
@@ -114,11 +114,16 @@ export interface SessionManagerOptions {
 	 */
 	readonly pathSnapshot?: RedisPathSnapshot;
 	/**
-	 * Checks whether a sandbox exists in the persistent store (Postgres).
-	 * Required for withSessionOrRehydrate to distinguish "evicted" from "deleted".
-	 * When undefined, withSessionOrRehydrate falls back to withExistingSession behavior.
+	 * Reads sandbox metadata from the persistent store (Postgres).
+	 * Returns null when the sandbox doesn't exist. Required for
+	 * withSessionOrRehydrate to restore owner + runtimeOptions on cold replicas.
 	 */
-	readonly sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
+	readonly getSandboxMetaFn?: (sandboxId: string) => Promise<SandboxMeta | null>;
+	/**
+	 * Persists sandbox metadata (owner, runtime flags) to the persistent store.
+	 * Called from `persistSandboxMeta` after sandbox creation.
+	 */
+	readonly persistSandboxMetaFn?: (sandboxId: string, meta: SandboxMeta) => Promise<void>;
 }
 
 /** Internal FIFO-semaphore state shared by the python and js throttles. */
@@ -141,7 +146,8 @@ export class SessionManager {
 	private readonly redis: Redis | undefined;
 	private readonly execLockOptions: Partial<DistributedLockOptions> | undefined;
 	private readonly pathSnapshot: RedisPathSnapshot | undefined;
-	private readonly sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
+	private readonly getSandboxMetaFn?: (sandboxId: string) => Promise<SandboxMeta | null>;
+	private readonly persistSandboxMetaFn?: (sandboxId: string, meta: SandboxMeta) => Promise<void>;
 
 	// --- Runtime throttle semaphores (US-080a) ---
 	/** Python runtime semaphore — caps CPython WASM workers (~80MB each). */
@@ -164,7 +170,8 @@ export class SessionManager {
 		redis,
 		execLockOptions,
 		pathSnapshot,
-		sandboxExistsFn,
+		getSandboxMetaFn,
+		persistSandboxMetaFn,
 	}: SessionManagerOptions) {
 		this.backend = backend;
 		this.createFs = createFs ?? createSandboxFs;
@@ -174,7 +181,8 @@ export class SessionManager {
 		this.redis = redis;
 		this.execLockOptions = execLockOptions;
 		this.pathSnapshot = pathSnapshot;
-		this.sandboxExistsFn = sandboxExistsFn;
+		this.getSandboxMetaFn = getSandboxMetaFn;
+		this.persistSandboxMetaFn = persistSandboxMetaFn;
 		this.pythonSem = {
 			limit: maxConcurrentPython ?? Number(process.env.MAX_CONCURRENT_PYTHON ?? "5"),
 			inFlight: 0,
@@ -349,11 +357,11 @@ export class SessionManager {
 			const raw = await this.redis.get(versionKey(sandboxId));
 			current = raw === null ? 0 : Number(raw) || 0;
 		} catch (err) {
-			// Redis transiently unavailable — freshness check is a best-effort
-			// optimization. Skip the reload and let publishVersionIfDirty retry
-			// the INCR at end-of-turn. Preserve any outstanding dirty bit so a
-			// prior failed publish retries instead of being masked.
+			// Redis unavailable — can't determine whether the cache is fresh.
+			// Reload from Postgres so we don't serve stale data. Leave
+			// lastSeenVersion unchanged so the next turn retries the check.
 			console.error(JSON.stringify({ event: "version_get_error", sandboxId, error: (err as Error).message }));
+			await coherent.reload();
 			return;
 		}
 
@@ -486,20 +494,38 @@ export class SessionManager {
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		if (this.sandboxExistsFn !== undefined) {
-			const exists = await this.sandboxExistsFn(sandboxId);
-			if (!exists) {
+		let meta: SandboxMeta | null | undefined;
+		if (this.getSandboxMetaFn !== undefined) {
+			meta = await this.getSandboxMetaFn(sandboxId);
+			if (meta === null) {
 				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 			}
 		} else {
-			// No existence check configured — strict pool-only behavior
+			// No metadata function configured — strict pool-only behavior
 			const session = this.sessions.get(sandboxId);
 			if (session === undefined) {
 				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 			}
 		}
-		const session = await this.getOrCreate(sandboxId, runtimeOptions);
+		const resolvedRuntime: RuntimeOptions = meta
+			? { python: meta.python, javascript: meta.javascript }
+			: runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS;
+		const session = await this.getOrCreate(sandboxId, resolvedRuntime);
+		if (meta?.owner) {
+			session.owner = meta.owner;
+		}
 		return this.withSessionEntry(sandboxId, session, fn);
+	}
+
+	/**
+	 * Persists sandbox metadata (owner, runtime flags) to the persistent store.
+	 * Call from route handlers after creating a sandbox to ensure cold replicas
+	 * can restore ownership and runtime support on rehydration.
+	 */
+	async persistSandboxMeta(sandboxId: string, meta: SandboxMeta): Promise<void> {
+		if (this.persistSandboxMetaFn !== undefined) {
+			await this.persistSandboxMetaFn(sandboxId, meta);
+		}
 	}
 
 	/**

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -316,7 +316,8 @@ export class SessionManager {
 			try {
 				return await fn(session);
 			} finally {
-				const wasDirty = asCoherentFs(session.fs)?.wasDirty() ?? false;
+				const coherent = asCoherentFs(session.fs);
+				const shouldRefreshPathBudget = coherent === undefined || coherent.wasDirty();
 				try {
 					await this.publishVersionIfDirty(sandboxId, session);
 				} catch (err) {
@@ -329,7 +330,7 @@ export class SessionManager {
 					);
 				}
 				session.inFlight--;
-				if (wasDirty) {
+				if (shouldRefreshPathBudget) {
 					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
 					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
 				}

--- a/src/api/session-manager.version-counter.test.ts
+++ b/src/api/session-manager.version-counter.test.ts
@@ -349,7 +349,7 @@ describe("SessionManager version counter (Phase D)", () => {
 		expect(stub.dirty).toBe(false);
 	});
 
-	it("ensureFreshCache tolerates transient GET error without failing the turn", async () => {
+	it("ensureFreshCache reloads from PG on transient GET error without failing the turn", async () => {
 		const redis = new FakeRedis();
 		const stub = new StubCoherentFs();
 		const sm = new SessionManager({
@@ -361,8 +361,8 @@ describe("SessionManager version counter (Phase D)", () => {
 		// Warm the session.
 		await sm.withSession("sbx", async () => {});
 
-		// First GET fails (stub; getOrCreate already succeeded, so no
-		// fallback-on-init interaction). The subsequent INCR for the mutation
+		// First GET fails — ensureFreshCache falls back to reload from PG
+		// so we don't serve stale data. The subsequent INCR for the mutation
 		// should still succeed and advance the counter.
 		const getSpy = vi.spyOn(redis, "get").mockRejectedValueOnce(new Error("ECONNRESET"));
 
@@ -374,8 +374,8 @@ describe("SessionManager version counter (Phase D)", () => {
 
 		getSpy.mockRestore();
 
-		// Reload was skipped (no throw, no reload count bump on best-effort GET failure).
-		expect(stub.reloadCount).toBe(0);
+		// Reload happened because version couldn't be checked.
+		expect(stub.reloadCount).toBe(1);
 		// INCR still ran at end-of-turn.
 		expect(redis.store.get("vfs:ver:sbx")?.value).toBe("1");
 	});

--- a/src/fs/sql-fs/dialects/postgres.advisory-lock.test.ts
+++ b/src/fs/sql-fs/dialects/postgres.advisory-lock.test.ts
@@ -31,6 +31,11 @@ function makeFakeTx(): { tx: postgres.TransactionSql; calls: RecordedCall[] } {
 	return { tx: fn as unknown as postgres.TransactionSql, calls };
 }
 
+function makeRejectingTx(error: Error & { code?: string }): postgres.TransactionSql {
+	const fn = (): Promise<never> => Promise.reject(error);
+	return fn as unknown as postgres.TransactionSql;
+}
+
 describe("PostgresDialect.setSandboxContext — read-only, no advisory lock", () => {
 	it("issues only SET LOCAL app.sandbox_id and does NOT acquire the advisory lock", async () => {
 		const dialect = new PostgresDialect("postgres://stub");
@@ -111,5 +116,43 @@ describe("PostgresDialect.deleteSandbox — advisory lock", () => {
 		const destroyLockSql = normalize(destroyPath.calls[0]!.sql);
 
 		expect(writeLockSql).toBe(destroyLockSql);
+	});
+});
+
+describe("PostgresDialect metadata helpers — SQL error translation", () => {
+	it("sandboxExists translates raw SQL errors", async () => {
+		const dialect = new PostgresDialect("postgres://stub");
+		const tx = makeRejectingTx(Object.assign(new Error("duplicate key"), { code: "23505" }));
+
+		await expect(dialect.sandboxExists(tx, "sandbox-meta")).rejects.toMatchObject({ code: "EEXIST" });
+	});
+
+	it("getSandboxMeta translates raw SQL errors", async () => {
+		const dialect = new PostgresDialect("postgres://stub");
+		const tx = makeRejectingTx(new Error("failed to connect: postgres://user:secret@db.example.com:5432/app"));
+
+		await expect(dialect.getSandboxMeta(tx, "sandbox-meta")).rejects.toMatchObject({
+			message: expect.stringContaining("[redacted]"),
+		});
+	});
+
+	it("updateSandboxMeta preserves ENOENT when no row was updated", async () => {
+		const dialect = new PostgresDialect("postgres://stub");
+		const { tx } = makeFakeTx();
+
+		await expect(
+			dialect.updateSandboxMeta(tx, "sandbox-missing", { owner: null, python: false, javascript: false }),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("updateSandboxMeta translates raw SQL errors", async () => {
+		const dialect = new PostgresDialect("postgres://stub");
+		const tx = makeRejectingTx(new Error("permission denied on /var/lib/postgresql/data/base"));
+
+		await expect(
+			dialect.updateSandboxMeta(tx, "sandbox-meta", { owner: null, python: false, javascript: false }),
+		).rejects.toMatchObject({
+			message: expect.stringContaining("[redacted]"),
+		});
 	});
 });

--- a/src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts
+++ b/src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PostgresDialect } from "./postgres.js";
+
+const DB_URL = process.env.DATABASE_URL;
+
+describe.skipIf(!DB_URL)("PostgresDialect.sandboxExists()", () => {
+	let dialect: PostgresDialect;
+	const testSandboxId = `test-exists-${crypto.randomUUID()}`;
+
+	beforeAll(async () => {
+		dialect = new PostgresDialect(DB_URL!);
+		await dialect.connect();
+	});
+
+	afterAll(async () => {
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.deleteSandbox(tx, testSandboxId);
+			});
+		} catch {
+			/* ignore if already gone */
+		}
+		await dialect.disconnect();
+	});
+
+	it("returns false for a sandbox that does not exist", async () => {
+		const nonExistentId = `nonexistent-${crypto.randomUUID()}`;
+		const exists = await dialect.transaction(async (tx) => {
+			return dialect.sandboxExists(tx, nonExistentId);
+		});
+		expect(exists).toBe(false);
+	});
+
+	it("returns true after sandbox is created", async () => {
+		await dialect.transaction(async (tx) => {
+			await dialect.createSandbox(tx, testSandboxId);
+		});
+
+		const exists = await dialect.transaction(async (tx) => {
+			return dialect.sandboxExists(tx, testSandboxId);
+		});
+		expect(exists).toBe(true);
+	});
+
+	it("returns false after sandbox is deleted", async () => {
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.createSandbox(tx, testSandboxId);
+			});
+		} catch {
+			/* ignore 23505 if already exists */
+		}
+
+		await dialect.transaction(async (tx) => {
+			await dialect.deleteSandbox(tx, testSandboxId);
+		});
+
+		const exists = await dialect.transaction(async (tx) => {
+			return dialect.sandboxExists(tx, testSandboxId);
+		});
+		expect(exists).toBe(false);
+	});
+
+	it("does not require sandbox context (no RLS dependency)", async () => {
+		const exists = await dialect.transaction(async (tx) => {
+			return dialect.sandboxExists(tx, testSandboxId);
+		});
+		expect(typeof exists).toBe("boolean");
+	});
+});

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -110,6 +110,13 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		await tx`DELETE FROM sandboxes WHERE id = ${sandboxId}`;
 	}
 
+	async sandboxExists(tx: PgTx, sandboxId: string): Promise<boolean> {
+		const rows = await tx<{ exists: boolean }[]>`
+			SELECT EXISTS(SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
+		`;
+		return rows[0]?.exists ?? false;
+	}
+
 	/** Inserts a kind=2 inode and links it under `parentInodeId` with `name`. Returns new inode id. */
 	async #createDirInode(tx: PgTx, sandboxId: string, parentInodeId: bigint, name: string): Promise<bigint> {
 		const rows = await tx<{ id: string }[]>`

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -112,28 +112,41 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	}
 
 	async sandboxExists(tx: PgTx, sandboxId: string): Promise<boolean> {
-		const rows = await tx<{ exists: boolean }[]>`
-			SELECT EXISTS(SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
-		`;
-		return rows[0]?.exists ?? false;
+		try {
+			const rows = await tx<{ exists: boolean }[]>`
+				SELECT EXISTS(SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
+			`;
+			return rows[0]?.exists ?? false;
+		} catch (err) {
+			throw translateSqlError(err, sandboxId);
+		}
 	}
 
 	async getSandboxMeta(tx: PgTx, sandboxId: string): Promise<SandboxMeta | null> {
-		const rows = await tx<{ owner: string | null; python: boolean; javascript: boolean }[]>`
-			SELECT owner, python, javascript FROM sandboxes WHERE id = ${sandboxId}
-		`;
-		if (rows.length === 0) return null;
-		const r = rows[0]!;
-		return { owner: r.owner, python: r.python, javascript: r.javascript };
+		try {
+			const rows = await tx<{ owner: string | null; python: boolean; javascript: boolean }[]>`
+				SELECT owner, python, javascript FROM sandboxes WHERE id = ${sandboxId}
+			`;
+			if (rows.length === 0) return null;
+			const r = rows[0]!;
+			return { owner: r.owner, python: r.python, javascript: r.javascript };
+		} catch (err) {
+			throw translateSqlError(err, sandboxId);
+		}
 	}
 
 	async updateSandboxMeta(tx: PgTx, sandboxId: string, meta: SandboxMeta): Promise<void> {
-		const rows = await tx<{ id: string }[]>`
-			UPDATE sandboxes
-			SET owner = ${meta.owner}, python = ${meta.python}, javascript = ${meta.javascript}
-			WHERE id = ${sandboxId}
-			RETURNING id
-		`;
+		let rows: Array<{ id: string }>;
+		try {
+			rows = await tx<{ id: string }[]>`
+				UPDATE sandboxes
+				SET owner = ${meta.owner}, python = ${meta.python}, javascript = ${meta.javascript}
+				WHERE id = ${sandboxId}
+				RETURNING id
+			`;
+		} catch (err) {
+			throw translateSqlError(err, sandboxId);
+		}
 		if (rows.length === 0) {
 			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 		}

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -15,6 +15,7 @@ import type {
 	InodeKind,
 	InodeRow,
 	PathCacheEntry,
+	SandboxMeta,
 	SqlDialect,
 	UpdateInodeOpts,
 } from "../types.js";
@@ -115,6 +116,23 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 			SELECT EXISTS(SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
 		`;
 		return rows[0]?.exists ?? false;
+	}
+
+	async getSandboxMeta(tx: PgTx, sandboxId: string): Promise<SandboxMeta | null> {
+		const rows = await tx<{ owner: string | null; python: boolean; javascript: boolean }[]>`
+			SELECT owner, python, javascript FROM sandboxes WHERE id = ${sandboxId}
+		`;
+		if (rows.length === 0) return null;
+		const r = rows[0]!;
+		return { owner: r.owner, python: r.python, javascript: r.javascript };
+	}
+
+	async updateSandboxMeta(tx: PgTx, sandboxId: string, meta: SandboxMeta): Promise<void> {
+		await tx`
+			UPDATE sandboxes
+			SET owner = ${meta.owner}, python = ${meta.python}, javascript = ${meta.javascript}
+			WHERE id = ${sandboxId}
+		`;
 	}
 
 	/** Inserts a kind=2 inode and links it under `parentInodeId` with `name`. Returns new inode id. */

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -128,11 +128,15 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	}
 
 	async updateSandboxMeta(tx: PgTx, sandboxId: string, meta: SandboxMeta): Promise<void> {
-		await tx`
+		const rows = await tx<{ id: string }[]>`
 			UPDATE sandboxes
 			SET owner = ${meta.owner}, python = ${meta.python}, javascript = ${meta.javascript}
 			WHERE id = ${sandboxId}
+			RETURNING id
 		`;
+		if (rows.length === 0) {
+			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+		}
 	}
 
 	/** Inserts a kind=2 inode and links it under `parentInodeId` with `name`. Returns new inode id. */

--- a/src/fs/sql-fs/migrations/postgres/0002_sandbox_meta.sql
+++ b/src/fs/sql-fs/migrations/postgres/0002_sandbox_meta.sql
@@ -1,0 +1,7 @@
+-- Migration 0002: Add runtime-option columns to sandboxes for rehydration.
+-- The `owner` column already exists from 0000; these two columns let
+-- cold-starting replicas reconstruct Bash with the correct runtimes.
+
+ALTER TABLE sandboxes
+    ADD COLUMN IF NOT EXISTS python     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS javascript BOOLEAN NOT NULL DEFAULT false;

--- a/src/fs/sql-fs/redis-path-snapshot.ts
+++ b/src/fs/sql-fs/redis-path-snapshot.ts
@@ -13,6 +13,11 @@ import { decode, encode } from "@msgpack/msgpack";
 import type { Redis } from "ioredis";
 import type { PathCacheEntry } from "./types.js";
 
+/** Redis key for the per-sandbox monotonic version counter. */
+export function versionKey(sandboxId: string): string {
+	return `vfs:ver:${sandboxId}`;
+}
+
 /**
  * Bump when the on-the-wire layout of `Snapshot` or `EncodedEntry` changes.
  * Old snapshots with a mismatched version are treated as a miss (Edge Case §8).

--- a/src/fs/sql-fs/sql-fs.cache.test.ts
+++ b/src/fs/sql-fs/sql-fs.cache.test.ts
@@ -62,6 +62,7 @@ describe("SqlFs.ready() — pathCache initialization", () => {
 			loadAllPaths: loadAllPathsMock,
 			createSandbox: vi.fn(),
 			deleteSandbox: vi.fn(),
+			sandboxExists: vi.fn(),
 			createInode: vi.fn(),
 			getInode: vi.fn(),
 			updateInode: vi.fn(),

--- a/src/fs/sql-fs/sql-fs.cache.test.ts
+++ b/src/fs/sql-fs/sql-fs.cache.test.ts
@@ -63,6 +63,8 @@ describe("SqlFs.ready() — pathCache initialization", () => {
 			createSandbox: vi.fn(),
 			deleteSandbox: vi.fn(),
 			sandboxExists: vi.fn(),
+			getSandboxMeta: vi.fn(),
+			updateSandboxMeta: vi.fn(),
 			createInode: vi.fn(),
 			getInode: vi.fn(),
 			updateInode: vi.fn(),

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -21,7 +21,7 @@ import {
 	createEnotempty,
 	createEperm,
 } from "./errors.js";
-import type { RedisPathSnapshot } from "./redis-path-snapshot.js";
+import { type RedisPathSnapshot, versionKey } from "./redis-path-snapshot.js";
 import { INODE_KIND, type PathCacheEntry, type SqlDialect } from "./types.js";
 
 /**
@@ -68,18 +68,9 @@ interface SqlFsOptions<Tx> {
 	readonly contentCacheMaxBytes?: number;
 	/** Allow symlink() to create symlinks. Default: false (EPERM). */
 	readonly allowSymlinks?: boolean;
-	/**
-	 * Optional Redis client used to read the per-sandbox version counter
-	 * (`vfs:ver:{sandboxId}`) during cold-start / reload. Required together
-	 * with `pathSnapshot` for snapshot-backed cold starts (Phase E).
-	 */
+	/** Redis client for reading the version counter during snapshot-backed cold starts. */
 	readonly redis?: Redis;
-	/**
-	 * Optional Redis path snapshot. When both `redis` and `pathSnapshot` are
-	 * provided, `#loadFreshPathCache` attempts a snapshot read before falling
-	 * back to `dialect.loadAllPaths`. Strict version equality against the
-	 * counter is required (Edge Case §3).
-	 */
+	/** Redis path snapshot — tried before `loadAllPaths` when `redis` is also set. */
 	readonly pathSnapshot?: RedisPathSnapshot;
 }
 
@@ -263,20 +254,15 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	}
 
 	/**
-	 * Loads the full path tree from the DB without touching in-memory caches.
-	 * Used by `ready()` (initial load) and `reload()` (cross-replica refresh).
-	 * On error the caller's caches are left untouched.
-	 *
-	 * Phase E: when `redis` and `pathSnapshot` are both configured, try a
-	 * snapshot read first. The embedded `version` must equal the current
-	 * `vfs:ver:{sandboxId}` counter exactly (Edge Case §3); any mismatch,
-	 * miss, or Redis error falls through to `dialect.loadAllPaths`.
+	 * Loads the full path tree without touching in-memory caches.
+	 * Tries Redis snapshot first (strict version equality); falls through
+	 * to `dialect.loadAllPaths` on miss, mismatch, or error.
 	 */
 	async #loadFreshPathCache(): Promise<Map<string, PathCacheEntry>> {
 		let missReason: "disabled" | "no_key" | "version_mismatch" | "error" = "disabled";
 		if (this.#redis !== undefined && this.#pathSnapshot !== undefined) {
 			try {
-				const raw = await this.#redis.get(`vfs:ver:${this.#sandboxId}`);
+				const raw = await this.#redis.get(versionKey(this.#sandboxId));
 				const currentVersion = raw === null ? 0 : Number(raw) || 0;
 				const snap = await this.#pathSnapshot.read(this.#sandboxId);
 				if (snap === null) {

--- a/src/fs/sql-fs/types.ts
+++ b/src/fs/sql-fs/types.ts
@@ -57,6 +57,13 @@ export interface PathCacheEntry {
 	readonly symlinkTarget: string | null;
 }
 
+/** Persisted sandbox metadata needed for session rehydration on cold replicas. */
+export interface SandboxMeta {
+	readonly owner: string | null;
+	readonly python: boolean;
+	readonly javascript: boolean;
+}
+
 /** Options for creating a new inode row */
 export interface CreateInodeOpts {
 	readonly sandboxId: string;
@@ -151,6 +158,12 @@ export interface SqlDialect<Tx = unknown> {
 	 * Does not require sandbox context (no RLS dependency) — queries sandboxes table directly.
 	 */
 	sandboxExists(tx: Tx, sandboxId: string): Promise<boolean>;
+
+	/** Returns persisted metadata for a sandbox, or null if the sandbox doesn't exist. */
+	getSandboxMeta(tx: Tx, sandboxId: string): Promise<SandboxMeta | null>;
+
+	/** Writes owner and runtime-option metadata to the sandbox row. */
+	updateSandboxMeta(tx: Tx, sandboxId: string, meta: SandboxMeta): Promise<void>;
 
 	// ── Inode CRUD ────────────────────────────────────────────────────────────────
 

--- a/src/fs/sql-fs/types.ts
+++ b/src/fs/sql-fs/types.ts
@@ -146,6 +146,12 @@ export interface SqlDialect<Tx = unknown> {
 	 */
 	deleteSandbox(tx: Tx, sandboxId: string): Promise<void>;
 
+	/**
+	 * Returns true if a sandbox row with the given ID exists in the database.
+	 * Does not require sandbox context (no RLS dependency) — queries sandboxes table directly.
+	 */
+	sandboxExists(tx: Tx, sandboxId: string): Promise<boolean>;
+
 	// ── Inode CRUD ────────────────────────────────────────────────────────────────
 
 	/**

--- a/src/redis/config.ts
+++ b/src/redis/config.ts
@@ -1,31 +1,12 @@
 /**
- * Startup-time parsing + validation for Redis-related numeric env vars.
- *
- * Using `Number(process.env.X ?? default)` directly is unsafe: a malformed
- * value (e.g., `FOO=abc`) yields `NaN`, which silently breaks downstream
- * `setTimeout` / `setInterval` / `PEXPIRE` instead of failing fast.
- *
- * These helpers validate once at startup and throw a clear `Error` naming
- * the offending env var so the process aborts before accepting traffic.
- */
-
-/**
- * Parses a non-negative finite integer from an env var. Returns the default
- * when the var is unset or empty. Throws when the value is present but not
- * a finite, non-negative integer — floats, NaN, and Infinity are all rejected.
- *
- * Integer-only because every consumer feeds the result into APIs that silently
- * truncate fractional parts (`setInterval`/`setTimeout`, Redis `PX`/`PEXPIRE`,
- * byte-size comparisons). Accepting floats would turn `REDIS_BLOB_MAX_BYTES=1.5`
- * into a byte cap of 1, which is the kind of config drift this helper exists
- * to prevent.
+ * Parses a non-negative integer from an env var, or returns `defaultValue`
+ * when unset. Throws on malformed values so the process fails at startup
+ * rather than silently passing NaN to setTimeout/Redis PX.
  */
 export function parseNonNegativeInt(envVar: string, defaultValue: number): number {
 	const raw = process.env[envVar];
 	if (raw === undefined || raw === "") return defaultValue;
 	const parsed = Number(raw);
-	// `Number.isInteger` already implies finiteness and excludes NaN/Infinity,
-	// so the earlier `isFinite` check is subsumed.
 	if (!Number.isInteger(parsed) || parsed < 0) {
 		throw new Error(`Invalid value for ${envVar}: "${raw}" — expected a non-negative integer (got ${parsed}).`);
 	}

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -1,0 +1,881 @@
+---
+date: 2026-04-24T21:34:03+09:30
+researcher: quangnguyentechno@gmail.com
+git_commit: 571a99d9897e858797bf80ed52969503f9c16378
+branch: feat/multi-replica-redis
+repository: virtualFS
+task: "GitHub Issue #10: Fix multi-replica session rehydration gap (TDD)"
+tags: [implementation-plan, session-manager, multi-replica, redis, rehydration, tdd]
+status: draft
+last_updated: 2026-04-24
+last_updated_by: quangnguyentechno@gmail.com
+---
+
+# Session Rehydration Gap — TDD Implementation Plan
+
+## Overview
+
+Fix the session rehydration gap (GitHub Issue #10) where `withExistingSession` throws ENOENT for sandboxes that exist in Postgres but aren't in the current replica's in-memory pool. This occurs in multi-replica deployments (LB routes request to a cold replica) and after server restarts (pool is empty).
+
+The fix adds a `withSessionOrRehydrate` method that checks Postgres before giving up, extracts shared lock/coherence/mutex logic into a `withSessionEntry` helper to eliminate duplication, and rewires all 11 HTTP/MCP route call sites.
+
+## Current State Analysis
+
+### The ENOENT Source
+`src/api/session-manager.ts:454-494` — `withExistingSession` does a pool-only `Map.get()`:
+```typescript
+const session = this.sessions.get(sandboxId);
+if (session === undefined) {
+    throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+}
+```
+
+### Code Duplication
+`withSession` (lines 396-444) and `withExistingSession` (lines 455-493) share ~35 lines of identical inner logic:
+- closing-state check
+- `ensureFreshCache` coherence check
+- `mutex.runExclusive` with inFlight tracking
+- `publishVersionIfDirty` in finally block
+- pathCacheBytes estimation
+
+### Existing Failing Tests
+`src/api/__tests__/integration/concurrency.pg.test.ts` — 17 tests that generate fresh sandbox IDs and hit HTTP routes without warming the pool. These currently fail with ENOENT and will serve as the acceptance criterion for this fix.
+
+### Key Discoveries
+- No `sandboxExists` method on `SqlDialect` interface (`src/fs/sql-fs/types.ts:92-282`)
+- No `withSessionOrRehydrate` method exists yet
+- Phase E snapshot makes rehydration cheap (~5ms for 1k paths via Redis snapshot)
+- Idle reaper evicts from pool but leaves sandbox in Postgres (rehydratable)
+- `destroy()` removes from both pool AND Postgres (permanent deletion)
+- Mock dialect pattern established in `src/fs/sql-fs/sql-fs.cache.test.ts:56-82`
+
+## Desired End State
+
+After this plan is complete:
+1. All 11 HTTP/MCP route call sites use `withSessionOrRehydrate` instead of `withExistingSession`
+2. Cold replicas transparently rehydrate sessions from Postgres on first access (~10ms one-time cost)
+3. Deleted sandboxes still return ENOENT (PG existence gate prevents resurrection)
+4. The 17 failing tests in `concurrency.pg.test.ts` pass
+5. All existing tests continue to pass (no regressions)
+6. `withSession`, `withExistingSession`, and `withSessionOrRehydrate` share a `withSessionEntry` helper
+
+### Verification
+- `pnpm typecheck` passes
+- `pnpm lint:fix` passes
+- `pnpm test:unit` passes
+- `pnpm test:integration` passes (17 previously-failing tests now green)
+
+## What We're NOT Doing
+
+- **MySQL/Azure SQL dialects**: `sandboxExists` is Postgres-only for V1
+- **Ownership verification on rehydrate**: Matching current auth model (bearer token validated by middleware, no per-operation owner check)
+- **Metrics/observability**: `vfs.session.rehydrate_total` deferred to follow-up
+- **Runtime options passthrough**: No current call site needs it; the signature accepts optional `runtimeOptions` for future use but tests don't exercise it
+
+## Implementation Approach
+
+Following TDD RED-GREEN-REFACTOR methodology:
+1. **Phase 1 (RED)**: Write failing tests for `sandboxExists` dialect method
+2. **Phase 2 (GREEN)**: Implement `sandboxExists` to make tests pass
+3. **Phase 3 (RED)**: Write failing tests for `withSessionEntry` + `withSessionOrRehydrate`
+4. **Phase 4 (GREEN)**: Implement the refactor + new method
+5. **Phase 5 (GREEN)**: Rewire route call sites
+6. **Phase 6 (VERIFY)**: Run full test suite including the 17 previously-failing integration tests
+
+---
+
+## Phase 1: RED — Tests for `sandboxExists` Dialect Method
+
+### Phase 1: Overview
+Write unit tests that define the expected behavior of `sandboxExists` on the `SqlDialect` interface and `PostgresDialect` implementation. These tests will fail because the method doesn't exist yet.
+
+### Phase 1: Changes Required
+
+#### 1. Update mock dialect in existing test file
+**File**: `src/fs/sql-fs/sql-fs.cache.test.ts`
+**Changes**: Add `sandboxExists: vi.fn()` to the mock dialect object so that the mock stays in sync with the interface after Phase 2 adds the method. This prevents a type error in existing tests.
+
+```typescript
+// In the beforeEach mock dialect (after line 64):
+sandboxExists: vi.fn(),
+```
+
+#### 2. Create new unit test file for sandboxExists
+**File**: `src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts` (NEW)
+**Changes**: Write integration tests against real Postgres for `sandboxExists`.
+
+```typescript
+/**
+ * Integration tests for PostgresDialect.sandboxExists().
+ * Skips when DATABASE_URL is not set.
+ */
+import { afterEach, beforeAll, afterAll, describe, expect, it } from "vitest";
+import { PostgresDialect } from "./postgres.js";
+
+const DB_URL = process.env.DATABASE_URL;
+
+describe.skipIf(!DB_URL)("PostgresDialect.sandboxExists()", () => {
+    let dialect: PostgresDialect;
+    const testSandboxId = `test-exists-${crypto.randomUUID()}`;
+
+    beforeAll(async () => {
+        dialect = new PostgresDialect(DB_URL!);
+        await dialect.connect();
+    });
+
+    afterAll(async () => {
+        // Clean up: delete test sandbox if it exists
+        try {
+            await dialect.transaction(async (tx) => {
+                await dialect.deleteSandbox(tx, testSandboxId);
+            });
+        } catch { /* ignore if already gone */ }
+        await dialect.disconnect();
+    });
+
+    it("returns false for a sandbox that does not exist", async () => {
+        const nonExistentId = `nonexistent-${crypto.randomUUID()}`;
+        const exists = await dialect.transaction(async (tx) => {
+            return dialect.sandboxExists(tx, nonExistentId);
+        });
+        expect(exists).toBe(false);
+    });
+
+    it("returns true after sandbox is created", async () => {
+        await dialect.transaction(async (tx) => {
+            await dialect.createSandbox(tx, testSandboxId);
+        });
+
+        const exists = await dialect.transaction(async (tx) => {
+            return dialect.sandboxExists(tx, testSandboxId);
+        });
+        expect(exists).toBe(true);
+    });
+
+    it("returns false after sandbox is deleted", async () => {
+        // Ensure sandbox exists first
+        try {
+            await dialect.transaction(async (tx) => {
+                await dialect.createSandbox(tx, testSandboxId);
+            });
+        } catch { /* ignore 23505 if already exists */ }
+
+        await dialect.transaction(async (tx) => {
+            await dialect.deleteSandbox(tx, testSandboxId);
+        });
+
+        const exists = await dialect.transaction(async (tx) => {
+            return dialect.sandboxExists(tx, testSandboxId);
+        });
+        expect(exists).toBe(false);
+    });
+
+    it("does not require sandbox context (no RLS dependency)", async () => {
+        // sandboxExists should work without calling setSandboxContext first
+        // because it queries the sandboxes table directly by ID
+        const exists = await dialect.transaction(async (tx) => {
+            // Intentionally NOT calling setSandboxContext
+            return dialect.sandboxExists(tx, testSandboxId);
+        });
+        expect(typeof exists).toBe("boolean");
+    });
+});
+```
+
+### Phase 1: Success Criteria
+
+#### Phase 1: Automated Verification
+- [x] `pnpm typecheck` fails (method doesn't exist on interface yet — expected RED)
+- [x] Tests in `postgres.sandbox-exists.test.ts` skip (no DATABASE_URL in unit env) — would fail with "sandboxExists is not a function" against real DB
+
+#### Phase 1: Manual Verification
+- [x] Confirm tests are well-structured and cover the three key scenarios: absent, present, deleted
+
+### Phase 1: Discoveries and Notable Information
+- Tests skip rather than fail in unit env because `describe.skipIf(!DB_URL)` gates the entire suite. The RED signal is confirmed via typecheck (4 TS2339 errors) which is the stronger signal.
+- Existing cache tests (408 total) pass cleanly with the added `sandboxExists: vi.fn()` mock field.
+- The advisory-lock test file uses a fake tx pattern (no real DB), while sandbox-exists tests need real Postgres — different test strategies coexist in the same directory.
+
+---
+
+## Phase 2: GREEN — Implement `sandboxExists`
+
+### Phase 2: Overview
+Add `sandboxExists` to the `SqlDialect` interface and implement it in `PostgresDialect`. Make all Phase 1 tests pass.
+
+### Phase 2: Changes Required
+
+#### 1. Add method to SqlDialect interface
+**File**: `src/fs/sql-fs/types.ts`
+**Changes**: Insert after `deleteSandbox` (line 147):
+
+```typescript
+	/**
+	 * Returns true if a sandbox row with the given ID exists in the database.
+	 * Does not require sandbox context (no RLS dependency) — queries sandboxes table directly.
+	 */
+	sandboxExists(tx: Tx, sandboxId: string): Promise<boolean>;
+```
+
+#### 2. Implement in PostgresDialect
+**File**: `src/fs/sql-fs/dialects/postgres.ts`
+**Changes**: Insert after `deleteSandbox` (line 111):
+
+```typescript
+	async sandboxExists(tx: PgTx, sandboxId: string): Promise<boolean> {
+		const rows = await tx<{ exists: boolean }[]>`
+			SELECT EXISTS(SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
+		`;
+		return rows[0]?.exists ?? false;
+	}
+```
+
+#### 3. Update mock dialect in sql-fs.cache.test.ts
+**File**: `src/fs/sql-fs/sql-fs.cache.test.ts`
+**Changes**: Add `sandboxExists: vi.fn()` to the mock dialect at line 64 (after `deleteSandbox: vi.fn()`):
+
+```typescript
+sandboxExists: vi.fn(),
+```
+
+### Phase 2: Success Criteria
+
+#### Phase 2: Automated Verification
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test -- src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts` passes (all 4 tests green)
+- [ ] `pnpm test -- src/fs/sql-fs/sql-fs.cache.test.ts` passes (existing tests still green with updated mock)
+
+#### Phase 2: Manual Verification
+- [ ] Review SQL query uses parameterized `${sandboxId}` (no injection risk)
+- [ ] Confirm method does not require `setSandboxContext` call (no RLS dependency)
+
+### Phase 2: Discoveries and Notable Information
+[Filled during execution]
+
+---
+
+## Phase 3: RED — Tests for `withSessionEntry` and `withSessionOrRehydrate`
+
+### Phase 3: Overview
+Write unit tests that define the expected behavior of the new `withSessionOrRehydrate` method and the refactored `withSessionEntry` helper. These test the SessionManager directly using a mock createFs factory.
+
+### Phase 3: Changes Required
+
+#### 1. Create SessionManager unit test file
+**File**: `src/api/__tests__/session-manager.rehydrate.test.ts` (NEW)
+**Changes**: Write unit tests covering:
+- Warm pool hit (fast path, no PG check)
+- Cold pool miss, sandbox exists in PG → rehydrates via `getOrCreate`
+- Cold pool miss, sandbox absent from PG → throws ENOENT
+- Concurrent rehydration for same sandbox serializes (no duplicate sessions)
+- Destroyed sandbox stays ENOENT (PG row deleted → `sandboxExists` returns false)
+
+```typescript
+/**
+ * Unit tests for SessionManager.withSessionOrRehydrate().
+ *
+ * Tests the three code paths:
+ * 1. Warm hit: sandbox in pool → execute immediately
+ * 2. Cold hit: sandbox in PG but not in pool → rehydrate via getOrCreate
+ * 3. Cold miss: sandbox not in PG → throw ENOENT
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { SessionManager } from "../session-manager.js";
+import type { IFileSystem } from "just-bash";
+
+// Minimal IFileSystem stub — only needs getAllPaths for pathCacheBytes estimation
+function stubFs(): IFileSystem {
+    return {
+        getAllPaths: () => ["/", "/home", "/home/user", "/tmp", "/bin"],
+        // All other methods are unused in these tests
+    } as unknown as IFileSystem;
+}
+
+// Tracks which sandboxes "exist" in our fake Postgres
+let pgSandboxes: Set<string>;
+
+// Spy to track createFs calls
+let createFsSpy: ReturnType<typeof vi.fn>;
+
+function makeSessionManager(): SessionManager {
+    pgSandboxes = new Set();
+    createFsSpy = vi.fn(async (_backend: string, _sandboxId: string) => {
+        return stubFs();
+    });
+    return new SessionManager({
+        backend: "memory",
+        createFs: createFsSpy,
+    });
+}
+
+describe("SessionManager.withSessionOrRehydrate()", () => {
+    let sm: SessionManager;
+
+    beforeEach(() => {
+        sm = makeSessionManager();
+    });
+
+    it("returns result from warm session without PG check", async () => {
+        // Warm the pool
+        await sm.withSession("sb-1", async () => "warmed");
+
+        const result = await sm.withSessionOrRehydrate("sb-1", async (session) => {
+            return `hello from ${session.state}`;
+        });
+        expect(result).toBe("hello from active");
+        // createFs should have been called only once (during warmup), not again
+        expect(createFsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws ENOENT when sandbox does not exist in pool or PG", async () => {
+        await expect(
+            sm.withSessionOrRehydrate("nonexistent", async () => "nope"),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("rehydrates from PG when sandbox exists in DB but not in pool", async () => {
+        // Simulate: sandbox was created on another replica (exists in PG)
+        pgSandboxes.add("sb-cold");
+
+        const result = await sm.withSessionOrRehydrate("sb-cold", async (session) => {
+            return session.state;
+        });
+        expect(result).toBe("active");
+        // createFs called once for the rehydration
+        expect(createFsSpy).toHaveBeenCalledWith("memory", "sb-cold");
+    });
+
+    it("rehydrated session is warm on subsequent calls", async () => {
+        pgSandboxes.add("sb-once");
+
+        // First call: rehydrates
+        await sm.withSessionOrRehydrate("sb-once", async () => "first");
+        // Second call: warm hit
+        await sm.withSessionOrRehydrate("sb-once", async () => "second");
+
+        // createFs called only once (rehydration), not twice
+        expect(createFsSpy).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+**Note**: This test file will need adjustment during Phase 4 implementation because `withSessionOrRehydrate` needs a way to call `sandboxExists` against Postgres. The exact mechanism (injected `sandboxExistsFn` or access through the dialect) will be finalized in Phase 4. The test structure and assertions are the important RED artifacts.
+
+### Phase 3: Success Criteria
+
+#### Phase 3: Automated Verification
+- [ ] `pnpm typecheck` fails (method doesn't exist on SessionManager yet — expected RED)
+- [ ] Tests fail with "withSessionOrRehydrate is not a function" or similar
+
+#### Phase 3: Manual Verification
+- [ ] Confirm tests cover all three code paths (warm, cold-exists, cold-absent)
+- [ ] Confirm no mocking of internals that would make tests brittle
+
+### Phase 3: Discoveries and Notable Information
+[Filled during execution]
+
+---
+
+## Phase 4: GREEN — Implement `withSessionEntry` Refactor + `withSessionOrRehydrate`
+
+### Phase 4: Overview
+This is the core implementation phase. Extract shared logic into `withSessionEntry`, add `withSessionOrRehydrate`, and update the SessionManager constructor to accept a `sandboxExistsFn` for PG existence checks.
+
+### Phase 4: Changes Required
+
+#### 1. Add `sandboxExistsFn` to SessionManager constructor options
+**File**: `src/api/session-manager.ts`
+**Changes**: Extend the constructor options interface (~line 110) to accept an optional existence-check function:
+
+```typescript
+// Add to the SessionManagerOptions interface:
+/**
+ * Checks whether a sandbox exists in the persistent store (Postgres).
+ * Required for withSessionOrRehydrate to distinguish "evicted" from "deleted".
+ * When undefined, withSessionOrRehydrate falls back to withExistingSession behavior.
+ */
+sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
+```
+
+Store it as a private field:
+```typescript
+private readonly sandboxExistsFn?: (sandboxId: string) => Promise<boolean>;
+```
+
+#### 2. Extract `withSessionEntry` helper
+**File**: `src/api/session-manager.ts`
+**Changes**: Add a private method that encapsulates the shared closing-check → ensureFreshCache → mutex → inFlight → fn → publishVersionIfDirty pattern. Insert after `withExecLock` (~line 290):
+
+```typescript
+/**
+ * Shared entry logic for all session wrappers.
+ * Must be called inside the distributed exec lock.
+ *
+ * 1. Checks session isn't closing
+ * 2. Runs cross-replica cache coherence (Phase D)
+ * 3. Acquires local mutex, tracks inFlight
+ * 4. Calls fn(session)
+ * 5. Publishes version if dirty (Phase D/E)
+ */
+private async withSessionEntry<T>(sandboxId: string, session: Session, fn: (session: Session) => Promise<T>): Promise<T> {
+    if (session.state === "closing") {
+        throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+    }
+
+    await this.ensureFreshCache(sandboxId, session);
+
+    return session.mutex.runExclusive(async () => {
+        if (session.state === "closing") {
+            throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+        }
+        session.inFlight++;
+        session.lastUsed = Date.now();
+        try {
+            return await fn(session);
+        } finally {
+            try {
+                await this.publishVersionIfDirty(sandboxId, session);
+            } catch (err) {
+                console.error(
+                    JSON.stringify({
+                        event: "publish_version_finally_error",
+                        sandboxId,
+                        error: (err as Error).message,
+                    }),
+                );
+            }
+            session.inFlight--;
+            session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
+            session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+        }
+    });
+}
+```
+
+#### 3. Refactor `withSession` to use `withSessionEntry`
+**File**: `src/api/session-manager.ts`
+**Changes**: Replace the body of `withSession` (lines 396-444) with delegation to `withSessionEntry`:
+
+```typescript
+async withSession<T>(
+    sandboxId: string,
+    fn: (session: Session) => Promise<T>,
+    runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+    return this.withExecLock(sandboxId, async () => {
+        const session = await this.getOrCreate(sandboxId, runtimeOptions);
+        return this.withSessionEntry(sandboxId, session, fn);
+    });
+}
+```
+
+#### 4. Refactor `withExistingSession` to use `withSessionEntry`
+**File**: `src/api/session-manager.ts`
+**Changes**: Replace the body of `withExistingSession` (lines 455-493) with delegation:
+
+```typescript
+async withExistingSession<T>(sandboxId: string, fn: (session: Session) => Promise<T>): Promise<T> {
+    return this.withExecLock(sandboxId, async () => {
+        const session = this.sessions.get(sandboxId);
+        if (session === undefined) {
+            throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+        }
+        return this.withSessionEntry(sandboxId, session, fn);
+    });
+}
+```
+
+#### 5. Add `withSessionOrRehydrate` method
+**File**: `src/api/session-manager.ts`
+**Changes**: Add new public method after `withExistingSession`:
+
+```typescript
+/**
+ * Like withExistingSession, but falls back to Postgres to check if the sandbox
+ * exists before throwing ENOENT. If the sandbox is in Postgres but not in the
+ * pool (evicted by reaper, or created on another replica), rehydrates it via
+ * getOrCreate — leveraging Phase E snapshot for fast cold-start.
+ *
+ * Fast path: Map.get outside distributed lock (no Redis RTT for warm hits).
+ * Cold path: lock → double-check → PG exists → getOrCreate.
+ *
+ * Requires `sandboxExistsFn` to be set in constructor options.
+ * Falls back to withExistingSession behavior when `sandboxExistsFn` is undefined.
+ */
+async withSessionOrRehydrate<T>(
+    sandboxId: string,
+    fn: (session: Session) => Promise<T>,
+    runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+    // Fast path: warm pool hit — no lock needed
+    const warm = this.sessions.get(sandboxId);
+    if (warm !== undefined && warm.state !== "closing") {
+        return this.withExecLock(sandboxId, async () => {
+            // Re-check under lock (may have been evicted between check and lock acquisition)
+            const session = this.sessions.get(sandboxId);
+            if (session !== undefined && session.state !== "closing") {
+                return this.withSessionEntry(sandboxId, session, fn);
+            }
+            // Fall through to cold path
+            return this.rehydrateAndExec(sandboxId, fn, runtimeOptions);
+        });
+    }
+
+    // Cold path: need to check Postgres
+    return this.withExecLock(sandboxId, async () => {
+        // Double-check under lock
+        const session = this.sessions.get(sandboxId);
+        if (session !== undefined && session.state !== "closing") {
+            return this.withSessionEntry(sandboxId, session, fn);
+        }
+        return this.rehydrateAndExec(sandboxId, fn, runtimeOptions);
+    });
+}
+
+/**
+ * Cold-path helper: checks PG existence, rehydrates via getOrCreate, then executes.
+ * Must be called inside the distributed exec lock.
+ */
+private async rehydrateAndExec<T>(
+    sandboxId: string,
+    fn: (session: Session) => Promise<T>,
+    runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+    if (this.sandboxExistsFn !== undefined) {
+        const exists = await this.sandboxExistsFn(sandboxId);
+        if (!exists) {
+            throw Object.assign(
+                new Error(`ENOENT: sandbox ${sandboxId} not found`),
+                { code: "ENOENT" },
+            );
+        }
+    } else {
+        // No existence check configured — strict pool-only behavior
+        const session = this.sessions.get(sandboxId);
+        if (session === undefined) {
+            throw Object.assign(
+                new Error(`ENOENT: sandbox ${sandboxId} not found`),
+                { code: "ENOENT" },
+            );
+        }
+    }
+    const session = await this.getOrCreate(sandboxId, runtimeOptions);
+    return this.withSessionEntry(sandboxId, session, fn);
+}
+```
+
+#### 6. Wire up `sandboxExistsFn` in server.ts
+**File**: `src/api/server.ts`
+**Changes**: Where `SessionManager` is constructed, pass a `sandboxExistsFn` that uses the Postgres dialect:
+
+```typescript
+// The sandboxExistsFn creates a one-shot dialect connection to check existence.
+// This is acceptable because:
+// 1. It only runs on cold-path (first access per sandbox per replica)
+// 2. The connection is pooled by the postgres driver
+const sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+    const dialect = new PostgresDialect(databaseUrl);
+    await dialect.connect();
+    try {
+        return await dialect.transaction(async (tx) => {
+            return dialect.sandboxExists(tx, sandboxId);
+        });
+    } finally {
+        await dialect.disconnect();
+    }
+};
+
+const sessionManager = new SessionManager({
+    backend,
+    createFs: (b, id) => createSandboxFs(b, id),
+    sandboxExistsFn: backend === "postgres" ? sandboxExistsFn : undefined,
+});
+```
+
+**Important**: Review how the existing `createFs` factory manages connections. If the dialect connection can be shared or pooled, prefer that over creating a new connection per existence check. The implementer should check if `getRedisClient()` / connection pooling patterns apply here.
+
+**Alternative (preferred if feasible)**: If the SessionManager already has access to a dialect instance or connection pool, use that instead of creating a new one. The research shows `createSandboxFs` creates a new `PostgresDialect` per call (line 47 of `index.ts`), so a separate lightweight check function is warranted.
+
+#### 7. Update Phase 3 test file to work with actual implementation
+**File**: `src/api/__tests__/session-manager.rehydrate.test.ts`
+**Changes**: Adjust the test setup to pass `sandboxExistsFn` that checks the `pgSandboxes` Set:
+
+```typescript
+function makeSessionManager(): SessionManager {
+    pgSandboxes = new Set();
+    createFsSpy = vi.fn(async (_backend: string, _sandboxId: string) => {
+        return stubFs();
+    });
+    return new SessionManager({
+        backend: "memory",
+        createFs: createFsSpy,
+        sandboxExistsFn: async (sandboxId: string) => pgSandboxes.has(sandboxId),
+    });
+}
+```
+
+### Phase 4: Success Criteria
+
+#### Phase 4: Automated Verification
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test -- src/api/__tests__/session-manager.rehydrate.test.ts` passes (all tests green)
+- [ ] `pnpm test:unit` passes (no regressions — withSession/withExistingSession still work)
+
+#### Phase 4: Manual Verification
+- [ ] Review `withSessionEntry` captures exact same behavior as original inline code
+- [ ] Review `withSessionOrRehydrate` fast path skips Redis lock on warm hit
+- [ ] Review `rehydrateAndExec` prevents resurrection of deleted sandboxes
+- [ ] Confirm `withExistingSession` is preserved for internal use (reaper, strict tests)
+
+### Phase 4: Discoveries and Notable Information
+[Filled during execution]
+
+---
+
+## Phase 5: GREEN — Rewire Route Call Sites
+
+### Phase 5: Overview
+Replace all 11 `withExistingSession` call sites in HTTP routes and MCP tools with `withSessionOrRehydrate`. This is a mechanical find-and-replace — the method signature is compatible (same `sandboxId` + `fn` args, optional `runtimeOptions`).
+
+### Phase 5: Changes Required
+
+#### 1. Exec routes (2 call sites)
+**File**: `src/api/routes/exec.ts`
+
+**Line 65** — exec-sync:
+```typescript
+// Before:
+const execResult = await sessionManager.withExistingSession<ExecSyncResult>(sandboxId, async (session) => {
+// After:
+const execResult = await sessionManager.withSessionOrRehydrate<ExecSyncResult>(sandboxId, async (session) => {
+```
+
+**Line 148** — exec SSE:
+```typescript
+// Before:
+await sessionManager.withExistingSession(sandboxId, async (session) => {
+// After:
+await sessionManager.withSessionOrRehydrate(sandboxId, async (session) => {
+```
+
+#### 2. File routes (5 call sites)
+**File**: `src/api/routes/files.ts`
+
+Replace `withExistingSession` → `withSessionOrRehydrate` at lines:
+- **Line 105** — GET file (read)
+- **Line 165** — PUT file (write)
+- **Line 192** — DELETE file
+- **Line 291** — mkdir
+- **Line 332** — tree listing
+
+#### 3. Ingest routes (3 call sites)
+**File**: `src/api/routes/ingest.ts`
+
+Replace at lines:
+- **Line 71** — ingest tar.gz
+- **Line 162** — ingest JSON manifest
+- **Line 209** — export tar.gz
+
+#### 4. MCP tools (3 call sites)
+**File**: `src/api/mcp/tools.ts`
+
+Replace at lines:
+- **Line 134** — bash_exec
+- **Line 217** — fs_ingest
+- **Line 263** — fs_export
+
+#### Total: 13 replacements (11 unique call sites + 2 additional found in files.ts at lines 242 and 291)
+
+**Search-and-replace pattern**:
+```
+withExistingSession  →  withSessionOrRehydrate
+```
+
+This is safe because the method signatures are compatible:
+- `withExistingSession<T>(sandboxId, fn)` → `withSessionOrRehydrate<T>(sandboxId, fn)`
+- No call site passes `runtimeOptions` (the third optional param)
+
+### Phase 5: Success Criteria
+
+#### Phase 5: Automated Verification
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test:unit` passes
+- [ ] `grep -r 'withExistingSession' src/api/routes/ src/api/mcp/` returns 0 matches (all rewired)
+- [ ] `grep -r 'withSessionOrRehydrate' src/api/routes/ src/api/mcp/` returns 13 matches
+
+#### Phase 5: Manual Verification
+- [ ] Verify `withExistingSession` still exists in `session-manager.ts` (kept for internal use)
+- [ ] Verify no route accidentally passes `runtimeOptions` (it shouldn't)
+
+### Phase 5: Discoveries and Notable Information
+[Filled during execution]
+
+---
+
+## Phase 6: VERIFY — Full Test Suite Including Integration Tests
+
+### Phase 6: Overview
+Run the full test suite. The 17 previously-failing tests in `concurrency.pg.test.ts` should now pass because the HTTP routes use `withSessionOrRehydrate`, which checks Postgres and rehydrates cold sessions.
+
+### Phase 6: Changes Required
+
+#### 1. Verify concurrency.pg.test.ts setup wires sandboxExistsFn
+**File**: `src/api/__tests__/integration/concurrency.pg.test.ts`
+**Changes**: Check that `makePgEnv()` (line 58) constructs SessionManager with `sandboxExistsFn`. If the server.ts wiring from Phase 4 doesn't apply to test setup, update `makePgEnv`:
+
+```typescript
+function makePgEnv() {
+    const databaseUrl = process.env.DATABASE_URL!;
+    const sandboxExistsFn = async (sandboxId: string): Promise<boolean> => {
+        const dialect = new PostgresDialect(databaseUrl);
+        await dialect.connect();
+        try {
+            return await dialect.transaction(async (tx) => {
+                return dialect.sandboxExists(tx, sandboxId);
+            });
+        } finally {
+            await dialect.disconnect();
+        }
+    };
+
+    const sm = new SessionManager({
+        backend: "postgres",
+        createFs: (backend, sandboxId) => createSandboxFs(backend, sandboxId),
+        sandboxExistsFn,
+    });
+    const app = new Hono<{ Variables: AuthVariables }>();
+    app.use("/v1/*", authMiddleware);
+    app.route("/v1/sandboxes", fileRoutes(sm));
+    return { app, sm };
+}
+```
+
+**Also add the import** at the top of the file:
+```typescript
+import { PostgresDialect } from "../../../fs/sql-fs/dialects/postgres.js";
+```
+
+#### 2. Review test sandbox creation
+The tests in `concurrency.pg.test.ts` call `newId()` to get a UUID, then immediately hit HTTP routes. The routes now call `withSessionOrRehydrate` → `sandboxExistsFn(sandboxId)`. But these sandboxes haven't been created in Postgres yet!
+
+**Key insight**: `createSandboxFs()` (called by `getOrCreate`) both creates the sandbox row in PG AND returns the filesystem. So the flow is:
+1. Route receives request for sandbox `sb-xyz`
+2. `withSessionOrRehydrate` checks pool → miss
+3. `sandboxExistsFn("sb-xyz")` → **false** (never created)
+4. Throws ENOENT
+
+**This means the tests still need to create the sandbox in PG first.** The tests must either:
+- Call `POST /v1/sandboxes` first (which uses `withSession` → `getOrCreate` → creates in PG), OR
+- Call `sm.getOrCreate(sbId)` to warm the pool (which also creates in PG)
+
+**Review the test code**: Check if tests are designed to work with the rehydration path (sandbox exists in PG from another replica) or if they assume fresh sandboxes. If the latter, the tests need a `createSandboxFs` warmup step added.
+
+**Most likely fix**: Add a helper that creates the sandbox in PG without warming the pool:
+
+```typescript
+import { PostgresDialect } from "../../../fs/sql-fs/dialects/postgres.js";
+
+/** Create a sandbox in Postgres without warming the SessionManager pool. */
+async function createSandboxInPg(sandboxId: string): Promise<void> {
+    const dialect = new PostgresDialect(DB_URL!);
+    await dialect.connect();
+    try {
+        await dialect.transaction(async (tx) => {
+            await dialect.createSandbox(tx, sandboxId);
+        });
+    } catch (e) {
+        const sqlErr = e as { code?: string };
+        if (sqlErr.code !== "23505") throw e; // Ignore unique violation
+    } finally {
+        await dialect.disconnect();
+    }
+}
+```
+
+Then in each test, before hitting HTTP routes:
+```typescript
+it(`all ${N} writes return 204`, async () => {
+    const { app } = makePgEnv();
+    const token = await makeToken();
+    const sbId = newId();
+    await createSandboxInPg(sbId);  // ← Add this line
+    // ... existing test code
+});
+```
+
+This simulates the real-world scenario: sandbox was created on Replica A, and Replica B (this test's SessionManager) is cold but should rehydrate.
+
+### Phase 6: Success Criteria
+
+#### Phase 6: Automated Verification
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test:unit` passes (all unit tests green)
+- [ ] `pnpm test:integration` passes (all 17 concurrency.pg tests green)
+- [ ] `pnpm test` passes (full suite)
+
+#### Phase 6: Manual Verification
+- [ ] Confirm each of the 17 tests passes individually (not just the suite)
+- [ ] No new test files left in failing state
+- [ ] `withExistingSession` is no longer called from any route (only from internal SessionManager code)
+
+### Phase 6: Discoveries and Notable Information
+[Filled during execution]
+
+---
+
+## Testing Strategy
+
+### Unit Tests (no DB required)
+- `src/fs/sql-fs/sql-fs.cache.test.ts` — Existing tests pass with updated mock dialect
+- `src/api/__tests__/session-manager.rehydrate.test.ts` — New tests for withSessionOrRehydrate:
+  - Warm hit returns immediately
+  - Cold hit with PG existence → rehydrates
+  - Cold miss → ENOENT
+  - Rehydrated session is warm on subsequent calls
+  - No `sandboxExistsFn` → falls back to strict pool-only
+
+### Integration Tests (requires DATABASE_URL)
+- `src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts` — New tests for dialect method:
+  - Returns false for absent sandbox
+  - Returns true after creation
+  - Returns false after deletion
+  - Works without RLS context
+- `src/api/__tests__/integration/concurrency.pg.test.ts` — Existing 17 tests now pass
+
+### Key Edge Cases
+- Race: concurrent rehydration + destroy for same sandbox (serialized by exec lock)
+- Race: reaper evicts session while rehydration is in progress (double-check under lock)
+- Sandbox created on Replica A, first access on Replica B (the core scenario)
+- Server restart: all sessions evicted, first request rehydrates each
+
+## Performance Considerations
+
+| Scenario | Latency | I/O |
+|----------|---------|-----|
+| Warm hit (common case) | ~0ms | 1 Map.get (no lock) |
+| Cold hit, sandbox exists | ~10ms | Lock acquire + SELECT EXISTS + getOrCreate (Phase E snapshot) |
+| Cold hit, sandbox absent | ~2ms | Lock acquire + SELECT EXISTS |
+
+The ~10ms cold-hit cost is paid once per replica per sandbox, amortized across all subsequent requests until idle eviction. Phase E snapshot reduces the pathCache load from ~10ms CTE to ~5ms Redis read.
+
+## Security Preservation
+
+- **Deleted sandboxes stay deleted**: PG existence check is the gate. DELETE removes the row → `sandboxExists` returns false → ENOENT.
+- **No new attack surface**: Random UUID to any route still gets ENOENT (absent from `sandboxes` table).
+- **Destroy race safe**: Concurrent DELETE and rehydrate serialize on the distributed exec lock.
+- **No ownership change**: Rehydrated sessions use default owner (""), same as `getOrCreate` always has. Auth middleware validates bearer tokens independently.
+
+## References
+
+- Research document: `thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md`
+- GitHub Issue #10: Multi-replica session rehydration gap
+- `src/api/session-manager.ts` — SessionManager (the file being modified)
+- `src/fs/sql-fs/types.ts:141-147` — SqlDialect sandbox lifecycle methods
+- `src/fs/sql-fs/dialects/postgres.ts:106-111` — PostgresDialect.deleteSandbox pattern
+- `src/api/__tests__/integration/concurrency.pg.test.ts` — 17 failing tests (acceptance criterion)
+- `src/fs/sql-fs/sql-fs.cache.test.ts:56-82` — Mock dialect pattern to follow
+- `tasks/IMPLEMENT-multi-replica-redis.md` — Phase A/C/E gap discovery documentation

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -624,19 +624,22 @@ function makeSessionManager(): SessionManager {
 ### Phase 4: Success Criteria
 
 #### Phase 4: Automated Verification
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm lint:fix` passes
-- [ ] `pnpm test -- src/api/__tests__/session-manager.rehydrate.test.ts` passes (all tests green)
-- [ ] `pnpm test:unit` passes (no regressions — withSession/withExistingSession still work)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` passes (auto-fixed 2 files — formatting only)
+- [x] `pnpm test -- src/api/__tests__/session-manager.rehydrate.test.ts` passes (all 6 tests green)
+- [x] `pnpm test:unit` passes (414 tests green, no regressions)
 
 #### Phase 4: Manual Verification
-- [ ] Review `withSessionEntry` captures exact same behavior as original inline code
-- [ ] Review `withSessionOrRehydrate` fast path skips Redis lock on warm hit
-- [ ] Review `rehydrateAndExec` prevents resurrection of deleted sandboxes
-- [ ] Confirm `withExistingSession` is preserved for internal use (reaper, strict tests)
+- [x] Review `withSessionEntry` captures exact same behavior as original inline code
+- [x] Review `withSessionOrRehydrate` fast path skips Redis lock on warm hit
+- [x] Review `rehydrateAndExec` prevents resurrection of deleted sandboxes
+- [x] Confirm `withExistingSession` is preserved for internal use (reaper, strict tests)
 
 ### Phase 4: Discoveries and Notable Information
-[Filled during execution]
+- The original `withSession` set `lastUsed` in `getOrCreate` (line 212) but NOT inside the mutex, while `withExistingSession` set `lastUsed = Date.now()` inside the mutex (line 472/480). The `withSessionEntry` helper puts `lastUsed` inside the mutex, which is correct for both paths — `getOrCreate` also sets it, so the warm path gets a redundant but harmless extra update.
+- The plan's `server.ts` wiring suggested creating a new PostgresDialect per existence check. Instead, implemented a single long-lived dialect with lazy connection (connected on first call), matching the connection-pooled pattern of the `postgres` driver. This avoids the overhead of `connect()/disconnect()` per check.
+- Biome auto-fixed formatting in `session-manager.ts` and the test file — no semantic changes, just whitespace/indent adjustments from the tab-based style.
+- The `withSessionOrRehydrate` fast path (warm pool check outside the lock) is an optimization that avoids the distributed lock RTT for the common case. The cold path always double-checks under the lock to handle the race where the session was evicted between the unlocked check and lock acquisition.
 
 ---
 

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -822,19 +822,24 @@ This simulates the real-world scenario: sandbox was created on Replica A, and Re
 ### Phase 6: Success Criteria
 
 #### Phase 6: Automated Verification
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm lint:fix` passes
-- [ ] `pnpm test:unit` passes (all unit tests green)
-- [ ] `pnpm test:integration` passes (all 17 concurrency.pg tests green)
-- [ ] `pnpm test` passes (full suite)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` passes (no fixes needed)
+- [x] `pnpm test:unit` passes (414 tests green, 4 skipped)
+- [ ] `pnpm test:integration` passes (all 17 concurrency.pg tests green) — requires DATABASE_URL
+- [ ] `pnpm test` passes (full suite) — requires DATABASE_URL
 
 #### Phase 6: Manual Verification
-- [ ] Confirm each of the 17 tests passes individually (not just the suite)
-- [ ] No new test files left in failing state
-- [ ] `withExistingSession` is no longer called from any route (only from internal SessionManager code)
+- [ ] Confirm each of the 17 tests passes individually (not just the suite) — requires DATABASE_URL
+- [x] No new test files left in failing state
+- [x] `withExistingSession` is no longer called from any route (only from internal SessionManager code)
 
 ### Phase 6: Discoveries and Notable Information
-[Filled during execution]
+- Used a lazy-connect `PostgresDialect` in `makePgEnv()` (matching server.ts pattern) rather than the plan's per-call connect/disconnect approach. This avoids connection overhead when `sandboxExistsFn` is called multiple times within a single test.
+- Added `createSandboxInPg()` helper that creates the sandbox row in PG without warming the SessionManager pool — simulates the multi-replica scenario where Replica A created the sandbox and Replica B (this test's SM) has a cold pool.
+- 11 HTTP-route tests needed `createSandboxInPg(sbId)` calls. The 6 `sm.withSession()` tests in Section 6 did NOT need changes because `withSession` → `getOrCreate` creates the sandbox automatically.
+- Section 5 tests (cross-sandbox isolation) create two sandboxes per test — used `Promise.all([createSandboxInPg(sbA), createSandboxInPg(sbB)])` for parallel pre-creation.
+- The `createSandboxFs` factory (index.ts:51-58) already handles `23505` unique violations, so re-creating an already-existing sandbox during `getOrCreate` rehydration is a no-op INSERT that silently succeeds.
+- Integration test verification (DATABASE_URL-dependent) deferred to user — unit tests and typecheck confirm correctness of all non-DB code paths.
 
 ---
 

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -367,15 +367,19 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 ### Phase 3: Success Criteria
 
 #### Phase 3: Automated Verification
-- [ ] `pnpm typecheck` fails (method doesn't exist on SessionManager yet — expected RED)
-- [ ] Tests fail with "withSessionOrRehydrate is not a function" or similar
+- [x] `pnpm typecheck` fails (11 TS errors: `sandboxExistsFn` unknown in options + `withSessionOrRehydrate` not on SessionManager — expected RED)
+- [x] Tests fail with "TypeError: sm.withSessionOrRehydrate is not a function" (all 6 tests)
 
 #### Phase 3: Manual Verification
-- [ ] Confirm tests cover all three code paths (warm, cold-exists, cold-absent)
-- [ ] Confirm no mocking of internals that would make tests brittle
+- [x] Confirm tests cover all three code paths (warm, cold-exists, cold-absent)
+- [x] Confirm no mocking of internals that would make tests brittle
 
 ### Phase 3: Discoveries and Notable Information
-[Filled during execution]
+- Used `InMemoryFs` from just-bash (established pattern in session-manager.test.ts) instead of the plan's manual `stubFs()`. This provides real `getAllPaths()` for `estimatePathCacheBytes` and avoids `as unknown as IFileSystem` casts.
+- Added two extra tests beyond the plan's four: (1) destroyed sandbox stays ENOENT after PG row removal, (2) falls back to pool-only ENOENT when `sandboxExistsFn` is not set. These cover the destroy-race and no-fn-fallback paths from Phase 4's design.
+- The `sandboxExistsFn` constructor option doesn't exist yet (TS2353), confirming the RED signal comes from both the interface gap and the missing method.
+- All 408 existing unit tests pass — no regressions from adding the new test file.
+- The `pnpm test` runner includes the new file automatically (Vitest glob picks up `*.test.ts` in `__tests__/`).
 
 ---
 

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -709,18 +709,20 @@ This is safe because the method signatures are compatible:
 ### Phase 5: Success Criteria
 
 #### Phase 5: Automated Verification
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm lint:fix` passes
-- [ ] `pnpm test:unit` passes
-- [ ] `grep -r 'withExistingSession' src/api/routes/ src/api/mcp/` returns 0 matches (all rewired)
-- [ ] `grep -r 'withSessionOrRehydrate' src/api/routes/ src/api/mcp/` returns 13 matches
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` passes (no fixes needed)
+- [x] `pnpm test:unit` passes (414 tests green, 4 skipped)
+- [x] `grep -r 'withExistingSession' src/api/routes/ src/api/mcp/` returns 0 matches (all rewired)
+- [x] `grep -r 'withSessionOrRehydrate' src/api/routes/ src/api/mcp/` returns 14 matches
 
 #### Phase 5: Manual Verification
-- [ ] Verify `withExistingSession` still exists in `session-manager.ts` (kept for internal use)
-- [ ] Verify no route accidentally passes `runtimeOptions` (it shouldn't)
+- [x] Verify `withExistingSession` still exists in `session-manager.ts` (kept for internal use)
+- [x] Verify no route accidentally passes `runtimeOptions` (it shouldn't)
 
 ### Phase 5: Discoveries and Notable Information
-[Filled during execution]
+- The plan estimated 13 replacements (11 unique + 2 additional). Actual count is 14: exec.ts (2), files.ts (6), ingest.ts (3), tools.ts (3). The plan missed the `writeFiles` route at files.ts:242 in its initial count of "5 call sites" for files.ts.
+- The replacement is fully mechanical — `withSessionOrRehydrate` has the same `(sandboxId, fn)` signature as `withExistingSession`, and no call site passes `runtimeOptions`.
+- Biome required zero formatting fixes, confirming the method name swap is purely lexical with no indentation or line-length impact.
 
 ---
 

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -698,7 +698,7 @@ Replace at lines:
 #### Total: 13 replacements (11 unique call sites + 2 additional found in files.ts at lines 242 and 291)
 
 **Search-and-replace pattern**:
-```
+```text
 withExistingSession  →  withSessionOrRehydrate
 ```
 

--- a/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
+++ b/thoughts/shared/plans/2026-04-24_21-34-03_session-rehydration-gap-tdd.md
@@ -241,17 +241,19 @@ sandboxExists: vi.fn(),
 ### Phase 2: Success Criteria
 
 #### Phase 2: Automated Verification
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm lint:fix` passes
-- [ ] `pnpm test -- src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts` passes (all 4 tests green)
-- [ ] `pnpm test -- src/fs/sql-fs/sql-fs.cache.test.ts` passes (existing tests still green with updated mock)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` passes
+- [x] `pnpm test -- src/fs/sql-fs/dialects/postgres.sandbox-exists.test.ts` passes (all 4 tests skipped — no DATABASE_URL in unit env, as expected)
+- [x] `pnpm test -- src/fs/sql-fs/sql-fs.cache.test.ts` passes (408 tests green with existing mock)
 
 #### Phase 2: Manual Verification
-- [ ] Review SQL query uses parameterized `${sandboxId}` (no injection risk)
-- [ ] Confirm method does not require `setSandboxContext` call (no RLS dependency)
+- [x] Review SQL query uses parameterized `${sandboxId}` (no injection risk)
+- [x] Confirm method does not require `setSandboxContext` call (no RLS dependency)
 
 ### Phase 2: Discoveries and Notable Information
-[Filled during execution]
+- The mock dialect in `sql-fs.cache.test.ts` already had `sandboxExists: vi.fn()` from Phase 1, so no change was needed there.
+- The `postgres` driver tagged template (`tx<{ exists: boolean }[]>`) handles parameterization automatically — `${sandboxId}` is a bind parameter, not string interpolation.
+- `SELECT EXISTS(...)` returns a single row with a boolean column, matching the Postgres driver's automatic type coercion. The `?? false` fallback is defensive only.
 
 ---
 

--- a/thoughts/shared/plans/2026-04-24_22-44-38_multi-tenant-postgres-routing.md
+++ b/thoughts/shared/plans/2026-04-24_22-44-38_multi-tenant-postgres-routing.md
@@ -1,0 +1,1093 @@
+---
+date: 2026-04-24T22:44:38+09:30
+researcher: quangnguyentechno@gmail.com
+git_commit: 6aed558064353fc2ff60489fdf65d9d3e7692fa9
+branch: feat/multi-replica-redis
+repository: virtualFS
+task: "Multi-tenant Postgres routing (one container, N databases)"
+tags: [implementation-plan, multi-tenant, session-manager, auth, redis, postgres]
+status: draft
+last_updated: 2026-04-24
+last_updated_by: quangnguyentechno@gmail.com
+---
+
+# Multi-Tenant Postgres Routing — Implementation Plan
+
+## Overview
+
+Allow a single virtualFS API process to serve N tenants, each mapped to a dedicated Postgres database (all using the default `public` schema). Tenant is resolved from a JWT claim; Postgres dialects are cached per-tenant and lazily constructed on first use. All Redis keys gain a tenant prefix. A startup migration runner applies DDL to every configured tenant database. Backward-compatible with the current single-`DATABASE_URL` deployment.
+
+## Current State Analysis
+
+### How the current pipeline is wired
+
+- `src/api/server.ts:30-54` — constructs a single `SessionManager` from the process-wide `FS_BACKEND` + implicit `DATABASE_URL` (read inside the factory). Redis client and `RedisPathSnapshot` are also single, process-wide singletons.
+- `src/fs/sql-fs/index.ts:25-67` — `createSandboxFs("postgres", sandboxId)` reads `process.env.DATABASE_URL` directly (line 28). Builds one `PostgresDialect` per call, no per-tenant cache.
+- `src/api/session-manager.ts:137` — `sessions: Map<string, Session>` keyed by `sandboxId` only. `createFs` receives only `(backend, sandboxId)`.
+- `src/api/auth.ts:20-49` — `authMiddleware` verifies HS256 JWT and stashes `sub` as `owner` on the Hono context. No tenant claim.
+- `src/api/lib/jwt.ts:29-38` — `signToken({ sub, expiresIn, secret })` signs only `{ sub }`.
+- `src/api/cli/token.ts:12-27` — CLI accepts `--sub` and `--expires` only.
+- `src/api/routes/admin.ts:17-20` — `POST /v1/admin/tokens` validates `{ sub, expiresIn }`.
+- `src/api/distributed-lock.ts:163-165` — `execLockKey(sandboxId)` returns `vfs:lock:${sandboxId}`.
+- `src/api/session-manager.ts:31-33` — `versionKey(sandboxId)` returns `vfs:ver:${sandboxId}`.
+- `src/fs/sql-fs/redis-path-snapshot.ts:65-67` — `RedisPathSnapshot.key(sandboxId)` returns `vfs:snap:${sandboxId}`.
+- `src/fs/sql-fs/redis-blob-cache.ts:33-35` — `RedisBlobCache.key(sha256)` returns `vfs:blob:${hex}` (content-addressable, globally shared today).
+
+### Migration situation
+
+- `src/fs/sql-fs/migrations/postgres/0000_create_tables.sql` — `CREATE TABLE IF NOT EXISTS` for sandboxes/inodes/dirents/blobs (all unqualified → `public` schema).
+- `src/fs/sql-fs/migrations/postgres/0001_rls_and_procs.sql` — `CREATE OR REPLACE FUNCTION fs_resolve(…)` + RLS policies; idempotent.
+- There is **no startup migration runner**. Migrations are applied by `drizzle-kit migrate` (scripted in `package.json`), or ad-hoc by `benchmark.ts:154-166` for benchmarks. The server boots assuming the schema already exists.
+
+### Why this can't serve multiple tenants today
+
+1. One `DATABASE_URL` means one Postgres database. No code path reads a per-tenant URL.
+2. `SessionManager` has no concept of tenant scope — two tenants' sandboxes would collide in the `Map<string, Session>` if UUIDs ever collide (improbable but not impossible).
+3. All four Redis keyspaces (lock, ver, snap, blob) are flat across sandbox IDs. Cross-tenant ID reuse would leak state or lock unrelated work.
+4. The blob cache is intentionally content-shared. For multi-tenant it becomes a confidentiality side-channel unless prefixed.
+
+## Desired End State
+
+A single API process reads a `TENANT_DATABASES` JSON env var mapping `tenantId → postgresConnectionString` and serves requests for any configured tenant based on a `tenant` JWT claim. Each request routes to the correct tenant's Postgres database; Redis keys are fully tenant-partitioned; cross-tenant isolation is enforced at the storage layer.
+
+**Verification that the end state is reached:**
+
+- Two tenants configured (`tenant-a`, `tenant-b`) against two local Postgres databases.
+- Token signed with `tenant=tenant-a` cannot access sandboxes created with a `tenant=tenant-b` token (404).
+- Redis `KEYS vfs:tenant-a:*` and `KEYS vfs:tenant-b:*` show disjoint keyspaces during concurrent activity.
+- Destroying sandbox for tenant-a does not touch tenant-b's database or Redis state.
+- Existing single-`DATABASE_URL` deployments keep working unchanged (implicit tenant `default`).
+
+### Key Discoveries
+
+- `pg_advisory_xact_lock` lives per-database — already gives us free cross-tenant isolation at the DB layer (`src/fs/sql-fs/dialects/postgres.ts:60-66,109`).
+- Every route already funnels through `SessionManager.withSession` / `withExistingSession` / `destroy` (`src/api/routes/sandboxes.ts:48,94`, `src/api/routes/exec.ts:33`, `src/api/routes/files.ts:88`, `src/api/routes/ingest.ts:39`). Single chokepoint for tenant plumbing.
+- `createSandboxFs` is a single-path factory; only the `postgres` branch needs the tenant-aware URL (`src/fs/sql-fs/index.ts:26-67`).
+- Migrations are already idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`) — iterating tenants at boot is safe.
+- Version counter initial fetch already gracefully handles Redis errors (`src/api/session-manager.ts:240-249`). The tenant-prefixed key just changes which key we read.
+
+## What We're NOT Doing
+
+- **Not supporting multiple schemas within one database.** Each tenant gets its own database.
+- **Not supporting per-tenant Redis instances.** One Redis serves all tenants; isolation comes from key prefixes.
+- **Not implementing dynamic tenant onboarding without restart.** `TENANT_DATABASES` is read once at boot; adding a tenant requires a restart.
+- **Not changing the blob cache to allow cross-tenant dedup** (safer default is tenant-partitioned; a later opt-in could enable sharing).
+- **Not removing the existing single-`DATABASE_URL` path.** Deployments that set `DATABASE_URL` without `TENANT_DATABASES` continue working under an implicit tenant id (`default`).
+- **Not changing ownership (`owner`/`sub`) semantics.** `sub` still scopes sandbox access *within* a tenant; tenant scopes access *across* databases.
+- **Not touching MySQL / Azure SQL dialects.** They remain unimplemented (already) — tenant plumbing is Postgres-only in this phase.
+
+## Implementation Approach
+
+Five phases, each independently verifiable against a real local Postgres + Redis:
+
+1. **Tenant config + JWT tenant claim** — plumbing with no behavior change (tenant defaults to `default`).
+2. **Per-tenant Postgres backend routing in SessionManager** — split the single `createFs` into a tenant-aware factory and a per-tenant backend cache; key sessions by `(tenantId, sandboxId)`.
+3. **Tenant-prefixed Redis keys** — update all four key builders (lock, ver, snap, blob).
+4. **Startup migration runner** — iterate configured tenant databases at boot and apply migrations idempotently.
+5. **End-to-end verification** — two-tenant local stack, cross-tenant isolation checks, regression of existing tests.
+
+TDD is applied selectively (not strictly every phase): new pure units (tenant config loader, key builders) get unit tests first; integration behavior is verified against real local Postgres + Redis per phase.
+
+---
+
+## Phase 1: Tenant config loader + JWT tenant claim
+
+### Phase 1: Overview
+
+Add `tenant` as a first-class claim on issued JWTs. Add a `TenantConfig` loader that parses `TENANT_DATABASES` (JSON) with backward-compatible fallback to `DATABASE_URL` as tenant `default`. Auth middleware resolves the tenant on every request. Nothing else changes behavior yet — SessionManager still uses a single backend.
+
+### Phase 1: Changes Required
+
+#### 1.1 Tenant config loader (new)
+
+**File**: `src/api/tenants.ts` (new)
+
+```ts
+/**
+ * Tenant configuration loader.
+ *
+ * Sources of truth, in priority order:
+ *   1. TENANT_DATABASES — JSON blob mapping tenantId → postgres connection string.
+ *   2. DATABASE_URL (legacy single-tenant) — registered under tenant id "default".
+ *
+ * Exactly one must be set. TENANT_DATABASES takes precedence when both exist.
+ */
+export interface TenantConfig {
+  readonly tenantIds: readonly string[];
+  hasTenant(tenantId: string): boolean;
+  getConnectionString(tenantId: string): string; // throws on unknown tenant
+}
+
+export const DEFAULT_TENANT_ID = "default";
+
+export function loadTenantConfig(env: NodeJS.ProcessEnv = process.env): TenantConfig {
+  const raw = env.TENANT_DATABASES;
+  if (raw !== undefined && raw.length > 0) {
+    const parsed = parseTenantJson(raw);
+    return fromMap(parsed);
+  }
+  const legacy = env.DATABASE_URL;
+  if (legacy !== undefined && legacy.length > 0) {
+    return fromMap(new Map([[DEFAULT_TENANT_ID, legacy]]));
+  }
+  throw new Error(
+    "Tenant configuration missing: set TENANT_DATABASES (JSON) or DATABASE_URL (single-tenant legacy).",
+  );
+}
+
+function parseTenantJson(raw: string): Map<string, string> {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`TENANT_DATABASES is not valid JSON: ${(e as Error).message}`);
+  }
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    throw new Error("TENANT_DATABASES must be a JSON object of { tenantId: connectionString }.");
+  }
+  const m = new Map<string, string>();
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (typeof v !== "string" || v.length === 0) {
+      throw new Error(`TENANT_DATABASES[${k}] must be a non-empty connection string.`);
+    }
+    if (!/^[A-Za-z0-9_.-]+$/.test(k)) {
+      throw new Error(`TENANT_DATABASES tenant id "${k}" contains invalid characters; allowed: A-Z a-z 0-9 _ . -`);
+    }
+    m.set(k, v);
+  }
+  if (m.size === 0) throw new Error("TENANT_DATABASES is empty.");
+  return m;
+}
+
+function fromMap(m: Map<string, string>): TenantConfig {
+  const ids = Object.freeze([...m.keys()]);
+  return {
+    tenantIds: ids,
+    hasTenant: (id) => m.has(id),
+    getConnectionString: (id) => {
+      const v = m.get(id);
+      if (v === undefined) throw new Error(`Unknown tenant: ${id}`);
+      return v;
+    },
+  };
+}
+```
+
+Tenant id charset restriction (`A-Za-z0-9_.-`) guarantees the id is safe to embed verbatim in Redis keys without ambiguity or injection concerns.
+
+#### 1.2 JWT payload + signing
+
+**File**: `src/api/lib/jwt.ts`
+
+```ts
+// Add optional `tenant` to SignTokenOptions and TokenPayload; include in signed body.
+export interface SignTokenOptions {
+  sub: string;
+  tenant?: string;         // NEW
+  expiresIn?: string;
+  secret: string;
+}
+
+export interface TokenPayload {
+  sub: string;
+  tenant?: string;         // NEW
+  iat?: number;
+  exp?: number;
+}
+
+export async function signToken({ sub, tenant, expiresIn, secret }: SignTokenOptions): Promise<string> {
+  const key = new TextEncoder().encode(secret);
+  const body: Record<string, unknown> = { sub };
+  if (tenant !== undefined) body.tenant = tenant;
+  const jwt = new SignJWT(body).setProtectedHeader({ alg: "HS256" }).setIssuedAt();
+  if (expiresIn && expiresIn !== "never") jwt.setExpirationTime(expiresIn);
+  return jwt.sign(key);
+}
+```
+
+#### 1.3 Token CLI
+
+**File**: `src/api/cli/token.ts`
+
+```ts
+// Accept --tenant <id>. Default to DEFAULT_TENANT_ID when omitted so legacy scripts still work.
+// In parseArgs(): recognize --tenant alongside --sub and --expires.
+// Pass tenant through signToken().
+```
+
+#### 1.4 Admin token endpoint
+
+**File**: `src/api/routes/admin.ts`
+
+```ts
+const tokenBodySchema = z.object({
+  sub: z.string().min(1, "sub is required"),
+  tenant: z.string().regex(/^[A-Za-z0-9_.-]+$/).optional(), // NEW
+  expiresIn: z.enum(["30d", "1y", "24h", "never"]).optional(),
+});
+// Forward tenant to signToken() and echo it in the 201 response.
+```
+
+#### 1.5 Auth middleware — resolve tenant
+
+**File**: `src/api/auth.ts`
+
+```ts
+import { DEFAULT_TENANT_ID, loadTenantConfig, type TenantConfig } from "./tenants.js";
+
+export type AuthVariables = {
+  owner: string;
+  tenant: string;          // NEW
+};
+
+// Construct a module-scoped TenantConfig once; constructing middleware reads from it.
+export function createAuthMiddleware(tenantConfig: TenantConfig) {
+  return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
+    // ...existing bearer-token parse + jwtVerify...
+
+    const sub = payload.sub;
+    if (!sub) return c.json({ error: "invalid_token", code: "AUTH_INVALID" }, UNAUTHORIZED);
+
+    // Tenant resolution: claim → else DEFAULT_TENANT_ID (for legacy tokens in single-tenant deployments)
+    const claim = typeof (payload as { tenant?: unknown }).tenant === "string"
+      ? (payload as { tenant: string }).tenant
+      : DEFAULT_TENANT_ID;
+
+    if (!tenantConfig.hasTenant(claim)) {
+      return c.json({ error: "unknown_tenant", code: "AUTH_UNKNOWN_TENANT" }, UNAUTHORIZED);
+    }
+
+    c.set("owner", sub);
+    c.set("tenant", claim);
+    await next();
+  });
+}
+
+// Keep `authMiddleware` export for tests that still construct it statically:
+// build it lazily on first import using loadTenantConfig().
+```
+
+#### 1.6 Server wiring
+
+**File**: `src/api/server.ts`
+
+```ts
+import { loadTenantConfig } from "./tenants.js";
+
+const tenantConfig = loadTenantConfig();
+app.use("/v1/*", createAuthMiddleware(tenantConfig));
+app.use("/mcp", createAuthMiddleware(tenantConfig));
+// NOTE: SessionManager is still single-backend at this phase; we pass tenantConfig
+// in Phase 2. This phase's server change compiles but does not yet route per-tenant.
+```
+
+### Phase 1: Success Criteria
+
+#### Phase 1: Automated Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test:unit` passes (existing tests)
+- [ ] New unit tests for `loadTenantConfig`: valid JSON, invalid JSON (400-ish error path at parse), missing both env vars (throws), `DATABASE_URL` fallback, invalid charset rejection, empty object rejection
+- [ ] New unit test for `signToken`: tenant claim round-trips through `jwtVerify`
+- [ ] Auth middleware test: token with unknown tenant claim → 401 `AUTH_UNKNOWN_TENANT`; token missing claim in a deployment with only `default` → passes
+
+#### Phase 1: Manual Verification
+
+1. **Create a local JSON tenant config and boot the server (implicit default still works):**
+
+   ```bash
+   # Single-tenant legacy path
+   unset TENANT_DATABASES
+   DATABASE_URL=postgres://postgres:test@localhost:5432/vfs_default \
+   AUTH_SECRET=s1 \
+   REDIS_URL=redis://localhost:6379 \
+   FS_BACKEND=postgres \
+     pnpm dev
+   ```
+
+2. **Mint a token without `--tenant`, verify it lands as `default`:**
+
+   ```bash
+   TOKEN=$(AUTH_SECRET=s1 pnpm token:create -- --sub user-1 --expires 24h)
+   curl -sI http://localhost:8080/v1/sandboxes \
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{}' \
+     -X POST
+   # Expect: HTTP/1.1 201 (Phase 2 delivers full functional parity; here we just
+   #         want auth to accept the token)
+   ```
+
+3. **Mint a token with a bogus tenant, expect 401:**
+
+   ```bash
+   BAD_TOKEN=$(AUTH_SECRET=s1 pnpm token:create -- --sub user-1 --tenant ghost --expires 24h)
+   curl -s -X POST http://localhost:8080/v1/sandboxes \
+     -H "Authorization: Bearer $BAD_TOKEN" -H "Content-Type: application/json" -d '{}'
+   # Expect: {"error":"unknown_tenant","code":"AUTH_UNKNOWN_TENANT"}
+   ```
+
+### Phase 1: Discoveries and Notable Information
+
+[Filled by the implementing agent during Phase 1 execution.]
+
+---
+
+## Phase 2: Per-tenant Postgres backend routing
+
+### Phase 2: Overview
+
+Split `createSandboxFs` / `destroySandbox` so they take a tenant-specific connection string. `SessionManager` holds a `Map<tenantId, PerTenantBackend>` with lazy-constructed `PostgresDialect`s. Session map is keyed by `${tenantId}:${sandboxId}`. All `withSession` / `withExistingSession` / `destroy` / `getSession` callers pass tenant. Redis keys **not yet** prefixed — Phase 3.
+
+### Phase 2: Changes Required
+
+#### 2.1 Tenant-aware factory
+
+**File**: `src/fs/sql-fs/index.ts`
+
+```ts
+// New signatures — additive, non-breaking. Old signatures remain for tests/benchmark
+// that construct dialects directly.
+
+export interface PostgresBackendOptions {
+  readonly connectionString: string;
+  readonly blobCache?: RedisBlobCache;
+  readonly pathSnapshot?: RedisPathSnapshot;
+  readonly redis?: Redis;
+}
+
+/** New: construct a PostgresDialect with an explicit connection string. */
+export async function createPostgresSandboxFs(
+  opts: PostgresBackendOptions,
+  sandboxId: string,
+): Promise<IFileSystem> {
+  const dialect = new PostgresDialect(opts.connectionString, opts.blobCache);
+  await dialect.connect();
+  try {
+    await dialect.transaction(async (tx) => { await dialect.createSandbox(tx, sandboxId); });
+  } catch (e) {
+    const sqlErr = e as { code?: string };
+    if (sqlErr.code !== "23505") throw e;
+  }
+  const fs = new SqlFs({
+    dialect,
+    sandboxId,
+    redis: opts.redis,
+    pathSnapshot: opts.pathSnapshot,
+  });
+  await fs.ready();
+  return fs;
+}
+
+export async function destroyPostgresSandbox(connectionString: string, sandboxId: string): Promise<void> {
+  const dialect = new PostgresDialect(connectionString);
+  await dialect.connect();
+  try {
+    await dialect.transaction(async (tx) => { await dialect.deleteSandbox(tx, sandboxId); });
+  } finally {
+    await dialect.disconnect();
+  }
+}
+
+// Keep existing createSandboxFs(backend, sandboxId) as a thin adapter that
+// reads DATABASE_URL from env — single-tenant callers (tests, benchmarks)
+// are unaffected.
+```
+
+Each tenant's dialect should **not** share a pool across tenants. Pool-per-tenant is explicit here (new `PostgresDialect` per tenant's first `withSession`). Pool lifetime = process lifetime.
+
+#### 2.2 SessionManager — backend map + composite keys
+
+**File**: `src/api/session-manager.ts`
+
+```ts
+import type { TenantConfig } from "./tenants.js";
+
+interface PerTenantBackend {
+  readonly connectionString: string;
+  dialect: PostgresDialect | undefined; // lazily created on first getOrCreate for this tenant
+  readonly blobCache: RedisBlobCache | undefined;
+}
+
+export interface SessionManagerOptions {
+  // existing fields...
+  readonly tenantConfig: TenantConfig;                     // NEW — required
+  readonly blobCacheFactory?: () => RedisBlobCache | undefined; // NEW — one-per-tenant if Redis enabled
+}
+
+// sessions Map: key shape "{tenantId}:{sandboxId}"
+private readonly sessions: Map<string, Session> = new Map();
+private readonly pending: Map<string, Promise<Session>> = new Map();
+private readonly backends: Map<string, PerTenantBackend> = new Map();
+
+private sessionKey(tenantId: string, sandboxId: string): string {
+  return `${tenantId}:${sandboxId}`;
+}
+
+private getOrInitBackend(tenantId: string): PerTenantBackend {
+  const existing = this.backends.get(tenantId);
+  if (existing !== undefined) return existing;
+  const connectionString = this.tenantConfig.getConnectionString(tenantId); // throws on unknown
+  const blobCache = this.blobCacheFactory?.();
+  const backend: PerTenantBackend = { connectionString, dialect: undefined, blobCache };
+  this.backends.set(tenantId, backend);
+  return backend;
+}
+```
+
+All public methods gain a `tenantId` parameter:
+
+```ts
+async withSession<T>(
+  tenantId: string,
+  sandboxId: string,
+  fn: (session: Session) => Promise<T>,
+  runtimeOptions?: RuntimeOptions,
+): Promise<T> { /* ... */ }
+
+async withExistingSession<T>(tenantId: string, sandboxId: string, fn): Promise<T> { /* ... */ }
+async destroy(tenantId: string, sandboxId: string): Promise<boolean> { /* ... */ }
+getSession(tenantId: string, sandboxId: string): Session | undefined { /* ... */ }
+```
+
+Inside `getOrCreate`, construct the fs via `createPostgresSandboxFs` using the tenant's backend:
+
+```ts
+const backend = this.getOrInitBackend(tenantId);
+const fs = await createPostgresSandboxFs(
+  { connectionString: backend.connectionString, blobCache: backend.blobCache, redis: this.redis, pathSnapshot: this.pathSnapshot },
+  sandboxId,
+);
+```
+
+Single-flight `pending` map, `reaper`, and all Redis-coordination (`ensureFreshCache`, `publishVersionIfDirty`, `withExecLock`, `deleteVersionKey`) switch to the composite key — they take `(tenantId, sandboxId)` and build the Redis key via Phase 3's helpers.
+
+#### 2.3 Route handlers — pass tenant through
+
+Every `sessionManager.xxx(sandboxId, ...)` call becomes `sessionManager.xxx(c.get("tenant"), sandboxId, ...)`. Call sites (all existing):
+
+- `src/api/routes/sandboxes.ts:48,67,87,94` (create/get/destroy)
+- `src/api/routes/files.ts` — every `withExistingSession` / `withSession` call
+- `src/api/routes/exec.ts:26,37+` — `checkOwnership` + every exec path
+- `src/api/routes/ingest.ts:39+` — every ingest/export path
+- `src/api/mcp/server.ts:80` — MCP handler must extract `tenant` from the Hono context and pass it into the MCP handler signature
+
+For MCP: `handleMcpRequest(req, sessionManager, owner, tenant)` — update the signature and thread tenant through tool call wrappers.
+
+#### 2.4 Server wiring
+
+**File**: `src/api/server.ts`
+
+```ts
+const sessionManager = new SessionManager({
+  tenantConfig,
+  redis: redisClient,
+  execLockOptions,
+  pathSnapshot,
+  blobCacheFactory: () => redisClient
+    ? new RedisBlobCache(redisClient, {
+        ttlMs: parseNonNegativeInt("REDIS_BLOB_CACHE_TTL_MS", 24 * 60 * 60 * 1000),
+        maxBytes: parseNonNegativeInt("REDIS_BLOB_MAX_BYTES", 8 * 1024 * 1024),
+      })
+    : undefined,
+});
+```
+
+`backend: "postgres"` is implicit now — tenant-aware paths only support Postgres. The `backend` option is removed from `SessionManagerOptions` (InMemoryFs is only used in tests, which construct backends directly via `createFs` override).
+
+### Phase 2: Success Criteria
+
+#### Phase 2: Automated Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test:unit` passes — update existing session-manager tests to pass tenant id; add tests asserting a separate `PostgresDialect` is constructed per tenant and reused across subsequent `getOrCreate` calls for the same tenant
+- [ ] New test: `sessions` map distinguishes same `sandboxId` across different tenants (no collision)
+- [ ] New test: `destroy(tenantA, sid)` leaves a session for `(tenantB, sid)` intact
+
+#### Phase 2: Manual Verification
+
+1. **Create two Postgres databases locally:**
+
+   ```bash
+   docker run -d --name vfs-pg -e POSTGRES_PASSWORD=test -p 5432:5432 postgres:16
+   sleep 3
+   PGPASSWORD=test psql -h localhost -U postgres -c "CREATE DATABASE vfs_tenant_a;"
+   PGPASSWORD=test psql -h localhost -U postgres -c "CREATE DATABASE vfs_tenant_b;"
+   ```
+
+2. **Apply migrations manually for each (Phase 4 automates this):**
+
+   ```bash
+   for db in vfs_tenant_a vfs_tenant_b; do
+     PGPASSWORD=test psql -h localhost -U postgres -d $db \
+       -f src/fs/sql-fs/migrations/postgres/0000_create_tables.sql
+     PGPASSWORD=test psql -h localhost -U postgres -d $db \
+       -f src/fs/sql-fs/migrations/postgres/0001_rls_and_procs.sql
+   done
+   ```
+
+3. **Boot the server with a tenant map:**
+
+   ```bash
+   docker run -d --name vfs-redis -p 6379:6379 redis:7
+
+   TENANT_DATABASES='{
+     "tenant-a":"postgres://postgres:test@localhost:5432/vfs_tenant_a",
+     "tenant-b":"postgres://postgres:test@localhost:5432/vfs_tenant_b"
+   }' \
+   REDIS_URL=redis://localhost:6379 \
+   AUTH_SECRET=s1 \
+   FS_BACKEND=postgres \
+     pnpm dev
+   ```
+
+4. **Mint per-tenant tokens:**
+
+   ```bash
+   TOK_A=$(AUTH_SECRET=s1 pnpm token:create -- --sub alice --tenant tenant-a --expires 24h)
+   TOK_B=$(AUTH_SECRET=s1 pnpm token:create -- --sub bob   --tenant tenant-b --expires 24h)
+   ```
+
+5. **Create a sandbox per tenant, write a distinguishing file:**
+
+   ```bash
+   SB_A=$(curl -s -X POST http://localhost:8080/v1/sandboxes \
+     -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" -d '{}' | jq -r '.id')
+   SB_B=$(curl -s -X POST http://localhost:8080/v1/sandboxes \
+     -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" -d '{}' | jq -r '.id')
+
+   curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_A/exec-sync" \
+     -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" \
+     -d '{"script":"echo A-secret > /home/user/who.txt"}' | jq
+
+   curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_B/exec-sync" \
+     -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" \
+     -d '{"script":"echo B-secret > /home/user/who.txt"}' | jq
+   ```
+
+6. **Cross-tenant isolation: tenant-a cannot read tenant-b's sandbox:**
+
+   ```bash
+   # 404 because SB_B does not exist in tenant-a's database/session pool
+   curl -s -o /dev/null -w '%{http_code}\n' \
+     "http://localhost:8080/v1/sandboxes/$SB_B/files/home/user/who.txt" \
+     -H "Authorization: Bearer $TOK_A"
+   # Expect: 404
+   ```
+
+7. **Direct DB inspection proves physical isolation:**
+
+   ```bash
+   PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_a \
+     -c "SELECT id, owner FROM sandboxes;"
+   # Expect: exactly one row, owner=alice, id=$SB_A
+
+   PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b \
+     -c "SELECT id, owner FROM sandboxes;"
+   # Expect: exactly one row, owner=bob, id=$SB_B
+   ```
+
+### Phase 2: Discoveries and Notable Information
+
+[Filled by the implementing agent during Phase 2 execution.]
+
+---
+
+## Phase 3: Tenant-prefixed Redis keys
+
+### Phase 3: Overview
+
+All four Redis keyspaces gain a tenant segment: `vfs:{tenant}:lock:{sandboxId}`, `vfs:{tenant}:ver:{sandboxId}`, `vfs:{tenant}:snap:{sandboxId}`, `vfs:{tenant}:blob:{sha256hex}`. Starting prefixed gives hard isolation by default — a later opt-in flag could re-enable cross-tenant blob dedup if measured benefit exceeds the side-channel risk.
+
+Because this changes key layout, any residual keys in Redis from the previous deployment become unreachable. Phase 3 ships with a `redis-cli FLUSHDB` step in the rollout notes (safe — Redis is a cache, not a source of truth).
+
+### Phase 3: Changes Required
+
+#### 3.1 Key builders accept tenant
+
+**File**: `src/api/distributed-lock.ts:163-165`
+
+```ts
+export function execLockKey(tenantId: string, sandboxId: string): string {
+  return `vfs:${tenantId}:lock:${sandboxId}`;
+}
+```
+
+**File**: `src/api/session-manager.ts:31-33`
+
+```ts
+function versionKey(tenantId: string, sandboxId: string): string {
+  return `vfs:${tenantId}:ver:${sandboxId}`;
+}
+```
+
+**File**: `src/fs/sql-fs/redis-path-snapshot.ts:65-67`
+
+```ts
+static key(tenantId: string, sandboxId: string): string {
+  return `vfs:${tenantId}:snap:${sandboxId}`;
+}
+
+// Propagate through write/read/delete signatures:
+async write(tenantId: string, sandboxId: string, version: number, pathCache: Map<string, PathCacheEntry>): Promise<void>
+async read(tenantId: string, sandboxId: string): Promise<...>
+async delete(tenantId: string, sandboxId: string): Promise<void>
+```
+
+**File**: `src/fs/sql-fs/redis-blob-cache.ts:33-35`
+
+```ts
+// Blob cache becomes per-tenant. Constructed per-tenant in Phase 2's blobCacheFactory —
+// the instance already knows its tenant, so the public `get`/`set` API doesn't change.
+export class RedisBlobCache {
+  readonly #tenantId: string;
+  constructor(client: Redis, tenantId: string, opts: RedisBlobCacheOptions = {}) {
+    this.#tenantId = tenantId;
+    // ...existing fields
+  }
+  #key(sha256: Uint8Array): string {
+    return `vfs:${this.#tenantId}:blob:${Buffer.from(sha256).toString("hex")}`;
+  }
+  // get/set use this.#key(sha) instead of the static key().
+}
+```
+
+The `blobCacheFactory` introduced in Phase 2 closes over the tenant id when constructing each per-tenant instance:
+
+```ts
+// In SessionManager.getOrInitBackend:
+const blobCache = this.redis ? new RedisBlobCache(this.redis, tenantId, blobOpts) : undefined;
+```
+
+(Update `SessionManagerOptions.blobCacheFactory` to `(tenantId: string) => RedisBlobCache | undefined`.)
+
+#### 3.2 All call sites thread tenant through
+
+- `src/api/session-manager.ts` — `ensureFreshCache`, `publishVersionIfDirty`, `deleteVersionKey`, `destroy`, `withExecLock` all take tenant and build the appropriate key.
+- `src/api/session-manager.version-counter.test.ts` + `session-manager.exec-lock.test.ts` + `session-manager.rehydrate.test.ts` — update to pass tenant.
+- `src/fs/sql-fs/redis-path-snapshot.test.ts` — update to pass tenant; add a cross-tenant isolation test (same sandboxId, two tenants, no key collision).
+- `src/fs/sql-fs/redis-blob-cache.test.ts` — add test that two caches with the same Redis client but different tenant ids do not see each other's blobs.
+
+### Phase 3: Success Criteria
+
+#### Phase 3: Automated Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test` passes (all existing Redis-touching tests updated)
+- [ ] New tests: same sandbox id in two tenants produces disjoint keys in all four keyspaces
+- [ ] Integration test `src/fs/sql-fs/integration/redis-blob-cache.integration.test.ts` extended: two tenants writing the same bytes produce two distinct keys (hex-dumped)
+
+#### Phase 3: Manual Verification
+
+1. **With Phase 2's two-tenant stack running, trigger activity on both:**
+
+   ```bash
+   for i in 1 2 3; do
+     curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_A/exec-sync" \
+       -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" \
+       -d '{"script":"echo hello'$i' > /home/user/f'$i'.txt"}' > /dev/null
+     curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_B/exec-sync" \
+       -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" \
+       -d '{"script":"echo world'$i' > /home/user/f'$i'.txt"}' > /dev/null
+   done
+   ```
+
+2. **Inspect Redis keyspace — keys must be disjoint:**
+
+   ```bash
+   docker exec vfs-redis redis-cli --scan --pattern 'vfs:tenant-a:*' | sort
+   docker exec vfs-redis redis-cli --scan --pattern 'vfs:tenant-b:*' | sort
+   # Expect: both non-empty; no overlap; no keys of the old shape `vfs:lock:*` / `vfs:ver:*`
+   docker exec vfs-redis redis-cli --scan --pattern 'vfs:lock:*'
+   # Expect: empty (no un-prefixed residue being written)
+   ```
+
+3. **Confirm version counter is per-tenant:**
+
+   ```bash
+   docker exec vfs-redis redis-cli GET "vfs:tenant-a:ver:$SB_A"
+   docker exec vfs-redis redis-cli GET "vfs:tenant-b:ver:$SB_B"
+   # Expect: two independent counters, each > 0 after the writes above
+   ```
+
+4. **Blob cache partitioning test — same content, same sha, different keys:**
+
+   ```bash
+   curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_A/exec-sync" \
+     -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" \
+     -d '{"script":"printf shared > /home/user/common.txt"}' > /dev/null
+   curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_B/exec-sync" \
+     -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" \
+     -d '{"script":"printf shared > /home/user/common.txt"}' > /dev/null
+
+   # sha256("shared") = 1b61f7fde28bf36b9eacf93bebee74c11d0d00c01bc46ac2057e...
+   docker exec vfs-redis redis-cli --scan --pattern 'vfs:*:blob:1b61f7fde28bf36b*'
+   # Expect: exactly TWO keys, one per tenant (same sha hex suffix, different tenant segment)
+   ```
+
+### Phase 3: Discoveries and Notable Information
+
+[Filled by the implementing agent during Phase 3 execution.]
+
+---
+
+## Phase 4: Startup migration runner
+
+### Phase 4: Overview
+
+On server boot, iterate every configured tenant's connection string and apply the two Postgres migrations idempotently. Fail-closed: if any tenant fails to migrate, the process exits before binding the HTTP port. This replaces manual `psql -f` or `drizzle-kit migrate` for multi-tenant deployments.
+
+### Phase 4: Changes Required
+
+#### 4.1 Migration runner
+
+**File**: `src/api/migrations.ts` (new)
+
+```ts
+/**
+ * Startup migration runner.
+ *
+ * Applies every .sql file under src/fs/sql-fs/migrations/postgres/ (lexicographic
+ * order) to each configured tenant database. Migrations are idempotent
+ * (CREATE TABLE IF NOT EXISTS / CREATE OR REPLACE FUNCTION), so rerunning on a
+ * migrated database is a no-op.
+ *
+ * Fails closed: the first tenant error aborts the boot with a clear log line.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import type { TenantConfig } from "./tenants.js";
+
+function migrationFiles(): readonly string[] {
+  const dir = fileURLToPath(new URL("../fs/sql-fs/migrations/postgres/", import.meta.url));
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".sql"))
+    .sort()
+    .map((name) => `${dir}${name}`);
+}
+
+export async function runMigrations(tenantConfig: TenantConfig): Promise<void> {
+  const files = migrationFiles();
+  for (const tenantId of tenantConfig.tenantIds) {
+    const url = tenantConfig.getConnectionString(tenantId);
+    // Prefer DATABASE_DIRECT_URL-style direct connection when available —
+    // but we only have the pooled URL per tenant; transactions + DDL work
+    // through pgbouncer transaction mode as long as we avoid SET SESSION.
+    const sql = postgres(url, { prepare: false, max: 1 });
+    try {
+      for (const path of files) {
+        const body = readFileSync(path, "utf8");
+        console.log(JSON.stringify({ event: "migration_start", tenantId, file: path.split("/").pop() }));
+        await sql.begin(async (tx) => { await tx.unsafe(body); });
+        console.log(JSON.stringify({ event: "migration_ok", tenantId, file: path.split("/").pop() }));
+      }
+    } catch (err) {
+      console.error(JSON.stringify({
+        event: "migration_failed",
+        tenantId,
+        error: (err as Error).message,
+      }));
+      await sql.end({ timeout: 5 });
+      throw new Error(`Migration failed for tenant "${tenantId}": ${(err as Error).message}`);
+    }
+    await sql.end({ timeout: 5 });
+  }
+}
+```
+
+#### 4.2 Boot integration
+
+**File**: `src/api/server.ts`
+
+```ts
+// After tenantConfig is loaded but before `serve(...)` is called:
+if (isMain) {
+  await runMigrations(tenantConfig);
+  const port = Number(process.env.PORT ?? "8080");
+  serve({ fetch: app.fetch, port }, () => {
+    console.log(JSON.stringify({ event: "server_start", port, tenantCount: tenantConfig.tenantIds.length }));
+  });
+}
+```
+
+Gate migrations behind an env var in case operators want to run them out-of-band:
+
+```ts
+if (process.env.SKIP_STARTUP_MIGRATIONS !== "true") {
+  await runMigrations(tenantConfig);
+}
+```
+
+### Phase 4: Success Criteria
+
+#### Phase 4: Automated Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] New integration test `src/api/__tests__/integration/migrations.integration.test.ts`: fresh empty Postgres database → `runMigrations` succeeds → tables exist → second call is a no-op
+- [ ] Existing `src/fs/sql-fs/integration/*` tests pass (they already migrate their own databases)
+
+#### Phase 4: Manual Verification
+
+1. **Drop one tenant database and reboot with startup migrations enabled:**
+
+   ```bash
+   PGPASSWORD=test psql -h localhost -U postgres -c "DROP DATABASE vfs_tenant_b;"
+   PGPASSWORD=test psql -h localhost -U postgres -c "CREATE DATABASE vfs_tenant_b;"
+   # (tables are gone)
+
+   TENANT_DATABASES='{"tenant-a":"postgres://postgres:test@localhost:5432/vfs_tenant_a","tenant-b":"postgres://postgres:test@localhost:5432/vfs_tenant_b"}' \
+   REDIS_URL=redis://localhost:6379 \
+   AUTH_SECRET=s1 \
+   FS_BACKEND=postgres \
+     pnpm dev
+
+   # Expect log lines in order:
+   #   {"event":"migration_start","tenantId":"tenant-a","file":"0000_create_tables.sql"}
+   #   {"event":"migration_ok","tenantId":"tenant-a","file":"0000_create_tables.sql"}
+   #   {"event":"migration_start","tenantId":"tenant-a","file":"0001_rls_and_procs.sql"}
+   #   {"event":"migration_ok","tenantId":"tenant-a","file":"0001_rls_and_procs.sql"}
+   #   (same for tenant-b)
+   #   {"event":"server_start","port":8080,"tenantCount":2}
+   ```
+
+2. **Verify tables exist in tenant-b:**
+
+   ```bash
+   PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b \
+     -c "\dt"
+   # Expect: sandboxes, inodes, dirents, blobs
+   PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b \
+     -c "\df fs_resolve"
+   # Expect: fs_resolve function listed
+   ```
+
+3. **Break a tenant's URL, verify fail-closed:**
+
+   ```bash
+   TENANT_DATABASES='{"tenant-a":"postgres://postgres:test@localhost:5432/vfs_tenant_a","tenant-b":"postgres://postgres:WRONG@localhost:5432/vfs_tenant_b"}' \
+   REDIS_URL=redis://localhost:6379 AUTH_SECRET=s1 FS_BACKEND=postgres \
+     pnpm dev
+   # Expect: process exits with "Migration failed for tenant \"tenant-b\": ..." and NO server_start event
+   curl -sI http://localhost:8080/healthz
+   # Expect: connection refused (server never bound)
+   ```
+
+### Phase 4: Discoveries and Notable Information
+
+[Filled by the implementing agent during Phase 4 execution.]
+
+---
+
+## Phase 5: End-to-end verification + regression safety
+
+### Phase 5: Overview
+
+Full two-tenant stack walk-through from `docker-compose up` through create → exec → ingest → export → destroy on both tenants concurrently, plus the full test suite and a documented rollout note for operators.
+
+### Phase 5: Changes Required
+
+#### 5.1 `docker-compose.local.yml` (new, repo root)
+
+```yaml
+services:
+  pg:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: test
+    ports: ["5432:5432"]
+    volumes: ["./scripts/initdb:/docker-entrypoint-initdb.d:ro"]
+
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+```
+
+**File**: `scripts/initdb/00-create-tenant-dbs.sql` (new)
+
+```sql
+CREATE DATABASE vfs_tenant_a;
+CREATE DATABASE vfs_tenant_b;
+```
+
+(Startup migrations from Phase 4 handle table DDL; `initdb` only creates the databases.)
+
+#### 5.2 `docs/MULTI_TENANT.md` (new)
+
+Short operator-facing note covering:
+- `TENANT_DATABASES` JSON shape
+- JWT `tenant` claim + token CLI `--tenant` flag
+- Per-tenant Redis key prefixes
+- Startup migration behavior and `SKIP_STARTUP_MIGRATIONS` escape hatch
+- Backward compatibility: `DATABASE_URL` alone still works (tenant id `default`)
+
+#### 5.3 Regression — existing single-tenant tests
+
+All existing integration tests under `src/fs/sql-fs/integration/` construct dialects directly and do not go through `SessionManager` or auth — they continue working unchanged. API-level tests that use `SessionManager` must be updated in Phase 2 to pass `tenant-id`. Confirm here that the whole suite is green.
+
+### Phase 5: Success Criteria
+
+#### Phase 5: Automated Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint:fix` passes
+- [ ] `pnpm test` passes (entire suite, including integration)
+- [ ] `pnpm test:comparison` passes (just-bash semantics unaffected)
+- [ ] `pnpm knip` passes (no unused exports introduced)
+
+#### Phase 5: Manual Verification
+
+**Full walkthrough against a fresh local stack:**
+
+```bash
+# 0. Start stack
+docker compose -f docker-compose.local.yml up -d
+sleep 3
+
+# 1. Boot API (startup migrations run automatically)
+TENANT_DATABASES='{"tenant-a":"postgres://postgres:test@localhost:5432/vfs_tenant_a","tenant-b":"postgres://postgres:test@localhost:5432/vfs_tenant_b"}' \
+REDIS_URL=redis://localhost:6379 \
+AUTH_SECRET=s1 \
+FS_BACKEND=postgres \
+  pnpm dev &
+sleep 2
+
+# 2. Mint per-tenant tokens
+TOK_A=$(AUTH_SECRET=s1 pnpm token:create -- --sub alice --tenant tenant-a --expires 24h)
+TOK_B=$(AUTH_SECRET=s1 pnpm token:create -- --sub bob   --tenant tenant-b --expires 24h)
+
+# 3. Create sandboxes concurrently
+SB_A=$(curl -s -X POST http://localhost:8080/v1/sandboxes -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" -d '{}' | jq -r '.id')
+SB_B=$(curl -s -X POST http://localhost:8080/v1/sandboxes -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" -d '{}' | jq -r '.id')
+echo "tenant-a sandbox: $SB_A"
+echo "tenant-b sandbox: $SB_B"
+
+# 4. Concurrent writes — guarantees distinct DBs, distinct Redis lock keys
+(curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_A/exec-sync" \
+   -H "Authorization: Bearer $TOK_A" -H "Content-Type: application/json" \
+   -d '{"script":"for i in {1..50}; do echo line-$i >> /home/user/log.txt; done && wc -l /home/user/log.txt"}' | jq) &
+(curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB_B/exec-sync" \
+   -H "Authorization: Bearer $TOK_B" -H "Content-Type: application/json" \
+   -d '{"script":"for i in {1..50}; do echo line-$i >> /home/user/log.txt; done && wc -l /home/user/log.txt"}' | jq) &
+wait
+# Expect: both return exitCode=0 and stdout "50 /home/user/log.txt"
+
+# 5. Cross-tenant 404 check
+curl -s -o /dev/null -w 'cross-tenant read: %{http_code}\n' \
+  "http://localhost:8080/v1/sandboxes/$SB_B/files/home/user/log.txt" \
+  -H "Authorization: Bearer $TOK_A"
+# Expect: 404
+
+# 6. Unknown tenant in token → 401
+BAD=$(AUTH_SECRET=s1 pnpm token:create -- --sub eve --tenant tenant-ghost --expires 24h)
+curl -s -X POST http://localhost:8080/v1/sandboxes \
+  -H "Authorization: Bearer $BAD" -H "Content-Type: application/json" -d '{}'
+# Expect: {"error":"unknown_tenant","code":"AUTH_UNKNOWN_TENANT"}
+
+# 7. Physical DB isolation
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_a -c "SELECT id FROM sandboxes;" | grep $SB_A
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b -c "SELECT id FROM sandboxes;" | grep $SB_B
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_a -c "SELECT id FROM sandboxes;" | grep $SB_B && echo "LEAK" || echo "isolated"
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b -c "SELECT id FROM sandboxes;" | grep $SB_A && echo "LEAK" || echo "isolated"
+# Expect: both "isolated"
+
+# 8. Redis keyspace partition
+docker exec $(docker ps --format '{{.Names}}' | grep redis) redis-cli --scan --pattern 'vfs:tenant-a:*' | wc -l
+docker exec $(docker ps --format '{{.Names}}' | grep redis) redis-cli --scan --pattern 'vfs:tenant-b:*' | wc -l
+docker exec $(docker ps --format '{{.Names}}' | grep redis) redis-cli --scan --pattern 'vfs:lock:*'  | wc -l
+# Expect: first two > 0; last (un-prefixed) = 0
+
+# 9. Destroy both, verify ownership still enforced
+curl -s -o /dev/null -w 'destroy wrong tenant: %{http_code}\n' \
+  -X DELETE "http://localhost:8080/v1/sandboxes/$SB_B" -H "Authorization: Bearer $TOK_A"
+# Expect: 404  (not visible in tenant-a's world)
+
+curl -s -o /dev/null -w 'destroy A: %{http_code}\n' -X DELETE "http://localhost:8080/v1/sandboxes/$SB_A" -H "Authorization: Bearer $TOK_A"
+curl -s -o /dev/null -w 'destroy B: %{http_code}\n' -X DELETE "http://localhost:8080/v1/sandboxes/$SB_B" -H "Authorization: Bearer $TOK_B"
+# Expect: both 204
+
+# 10. Post-destroy DB state
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_a -c "SELECT COUNT(*) FROM sandboxes;"
+PGPASSWORD=test psql -h localhost -U postgres -d vfs_tenant_b -c "SELECT COUNT(*) FROM sandboxes;"
+# Expect: 0 in both
+```
+
+**Legacy single-tenant compatibility check:**
+
+```bash
+# Kill the multi-tenant server, reboot in legacy mode
+unset TENANT_DATABASES
+DATABASE_URL=postgres://postgres:test@localhost:5432/vfs_tenant_a \
+REDIS_URL=redis://localhost:6379 \
+AUTH_SECRET=s1 \
+FS_BACKEND=postgres \
+  pnpm dev &
+sleep 2
+
+# Token with no tenant claim should work and resolve to `default`
+TOK=$(AUTH_SECRET=s1 pnpm token:create -- --sub legacy-user --expires 24h)
+SB=$(curl -s -X POST http://localhost:8080/v1/sandboxes \
+  -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" -d '{}' | jq -r '.id')
+curl -s -X POST "http://localhost:8080/v1/sandboxes/$SB/exec-sync" \
+  -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+  -d '{"script":"echo legacy-ok"}' | jq
+# Expect: exitCode=0, stdout "legacy-ok\n"
+
+# Redis keys use "default" prefix
+docker exec $(docker ps --format '{{.Names}}' | grep redis) redis-cli --scan --pattern 'vfs:default:*' | head
+# Expect: non-empty
+```
+
+### Phase 5: Discoveries and Notable Information
+
+[Filled by the implementing agent during Phase 5 execution.]
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **`src/api/tenants.test.ts` (new)** — all branches of `loadTenantConfig`: valid JSON, invalid JSON, missing both env vars, legacy fallback, invalid charset, empty object, duplicate key handling (JSON.parse collapses; document behavior).
+- **`src/api/lib/jwt.test.ts` (augment existing)** — `tenant` claim round-trips; missing claim still parses.
+- **`src/api/__tests__/auth.test.ts` (augment)** — unknown tenant → 401; missing claim + single-tenant `default` config → accepted; missing claim + multi-tenant config → 401 (unknown tenant `default`).
+- **`src/api/__tests__/session-manager.test.ts` (augment)** — `(tenant, sandbox)` composite key behavior; per-tenant backend cache lifecycle; destroy one tenant's sandbox leaves the other's session intact.
+- **`src/fs/sql-fs/redis-path-snapshot.test.ts` (augment)** — same sandbox id across tenants produces disjoint keys.
+- **`src/fs/sql-fs/redis-blob-cache.test.ts` (augment)** — same content, different tenants → distinct Redis keys.
+
+### Integration Tests
+
+- **`src/api/__tests__/integration/migrations.integration.test.ts` (new)** — fresh empty database, `runMigrations(config)` creates tables and fs_resolve; second run is a no-op.
+- **`src/api/__tests__/integration/multi-tenant.integration.test.ts` (new)** — two real Postgres databases; cross-tenant isolation (read, exec, destroy); concurrent activity does not cross-contaminate; verify `pg_advisory_xact_lock` is per-database (two `withSession` calls with the same sandbox id in different tenants do not serialize).
+
+### Manual Testing Steps
+
+Covered phase by phase above. Phase 5 consolidates them into a single walkthrough script.
+
+## Performance Considerations
+
+- **Connection pool count.** N tenants × default `max` pool size. For 10 tenants on Neon with pool size 10 that's 100 connections from this process; Neon pooler handles this. Bare Postgres `max_connections` is typically 100 — at >5 tenants consider per-tenant pool size caps via a dedicated env var. Out of scope for this plan; note as future work.
+- **Per-tenant `PostgresDialect` construction.** Lazy, once per tenant per process lifetime. Amortized to zero.
+- **Redis memory.** Blob cache no longer dedups across tenants; expect N× memory for identical content. If this becomes material, add an opt-in `REDIS_BLOB_CACHE_SHARED=true` that drops the tenant prefix on the blob namespace only (future work; not in this plan).
+- **Startup time.** Startup migrations add roughly 50–200 ms per tenant against a warm Postgres. Cold-start latency under autoscale becomes N × single-tenant baseline; acceptable for single-digit tenant counts. For larger fleets, migration-at-first-use becomes preferable; out of scope.
+
+## Migration Notes
+
+- **Existing deployments** with `DATABASE_URL` set and `TENANT_DATABASES` unset continue to work unchanged. Tenant id resolves to `default` automatically. Issued JWTs without a `tenant` claim are accepted in this mode.
+- **Moving from single- to multi-tenant:**
+  1. Create the new tenant database(s) in Postgres.
+  2. Set `TENANT_DATABASES` with the existing database re-registered under its original identifier (e.g., `"default"` to preserve already-minted tokens, or a new id with fresh tokens minted).
+  3. Flush Redis (`redis-cli FLUSHDB`) to evict un-prefixed keys from the previous deployment — the running app never reads them again, so this is purely hygiene.
+  4. Mint new per-tenant tokens via CLI or admin endpoint; old tokens stop working only if their claimed tenant is no longer configured.
+- **Adding a tenant after deploy** requires a restart to re-read `TENANT_DATABASES` and run startup migrations. Dynamic onboarding is out of scope.
+
+## References
+
+- Architecture doc: `tasks/arch-redis-caching-and-locking.md`
+- Implementation plan (through Phase 5): `tasks/IMPLEMENT.md`
+- Existing session-manager version counter: `src/api/session-manager.ts:302-379`
+- Existing distributed lock: `src/api/distributed-lock.ts`
+- Existing migrations: `src/fs/sql-fs/migrations/postgres/`

--- a/thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md
+++ b/thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md
@@ -1,0 +1,422 @@
+---
+date: 2026-04-24T21:16:55+09:30
+researcher: QuangNguyen2609
+git_commit: 571a99d9897e858797bf80ed52969503f9c16378
+branch: feat/multi-replica-redis
+repository: virtualFS
+topic: "GitHub Issue #10: Multi-replica session rehydration gap — cold replicas return ENOENT for existing sandboxes"
+tags: [research, codebase, session-manager, multi-replica, redis, rehydration, withExistingSession]
+status: complete
+last_updated: 2026-04-24
+last_updated_by: QuangNguyen2609
+---
+
+# Research: GitHub Issue #10 — Session Rehydration Gap
+
+**Date**: 2026-04-24 21:16:55 ACST
+**Researcher**: QuangNguyen2609
+**Git Commit**: 571a99d9897e858797bf80ed52969503f9c16378
+**Branch**: feat/multi-replica-redis
+**Repository**: virtualFS
+
+## Research Question
+
+Fully comprehend the context, code patterns, and architecture surrounding GitHub Issue #10: "Multi-replica: session rehydration gap — cold replicas return ENOENT for existing sandboxes". Understand how the current SessionManager works, what the proposed fix entails, which files need changes, and how existing infrastructure (Redis phases A-E) supports the solution.
+
+## Summary
+
+Issue #10 identifies a **pre-existing architectural limitation** in the virtualFS API where non-create HTTP routes throw ENOENT for sandboxes that exist in Postgres but aren't in the local in-memory session pool. This manifests in multi-replica deployments (LB routes request to a replica that never saw the sandbox) and after server restarts (pool is empty). The fix requires a new `withSessionOrRehydrate` wrapper on `SessionManager` that checks Postgres before throwing ENOENT, plus a `sandboxExists` method on `SqlDialect`. Phase E's Redis path snapshot makes rehydration cheap (~5ms for 1k paths).
+
+---
+
+## Detailed Findings
+
+### 1. The Problem: `withExistingSession` Pool-Only Lookup
+
+**File**: `src/api/session-manager.ts:454-494`
+
+The `SessionManager` maintains a process-local `Map<string, Session>` (line 137). Two entry wrappers exist:
+
+- **`withSession`** (line 391): Create-if-missing via `getOrCreate`. Used only by `POST /v1/sandboxes`.
+- **`withExistingSession`** (line 454): Strict pool lookup — throws ENOENT if `sessions.get(sandboxId) === undefined`. Used by all other routes.
+
+The ENOENT throw happens at **lines 456-459**:
+```typescript
+const session = this.sessions.get(sandboxId);
+if (session === undefined) {
+    throw Object.assign(
+        new Error(`ENOENT: sandbox ${sandboxId} not found`),
+        { code: "ENOENT" },
+    );
+}
+```
+
+**Why it was designed this way** (commit `6311437`, US-061):
+1. One chokepoint for creation (rate-limiting, quota, auth)
+2. Deletion must be final (auto-create would resurrect deleted sandboxes)
+3. REST idiomatics: POST creates, other verbs act
+
+All three reasons were correct for single-replica. Multi-replica exposes the trade-off: a cold replica cannot distinguish "sandbox was deleted" from "sandbox exists on another replica" without a PG lookup.
+
+---
+
+### 2. SessionManager Architecture
+
+**File**: `src/api/session-manager.ts`
+
+#### Session Type (lines 75-97)
+```typescript
+interface Session {
+    readonly fs: IFileSystem;           // SqlFs or InMemoryFs
+    readonly bash: Bash;                // just-bash instance
+    readonly runtimeOptions: RuntimeOptions;
+    lastUsed: number;                   // For idle eviction
+    inFlight: number;                   // Concurrent operation count
+    readonly mutex: Mutex;              // Local async-mutex
+    state: "active" | "closing";
+    owner: string;
+    createdAt: string;
+    pathCacheBytes: number;
+    overBudget: boolean;
+    destroyPromise?: Promise<void>;
+    lastSeenVersion: number;            // Phase D coherence
+}
+```
+
+#### Key Private Fields (lines 137-148)
+- `sessions: Map<string, Session>` — the process-local pool
+- `pending: Map<string, Promise<Session>>` — single-flight deduplication for `getOrCreate`
+- `redis: Redis | undefined` — Redis client (undefined = single-replica mode)
+- `pathSnapshot: RedisPathSnapshot | undefined` — Phase E snapshot writer
+
+#### Method Map
+
+| Method | Lines | Purpose |
+|--------|-------|---------|
+| `getOrCreate` | 209-274 | Fetch/create session; single-flight dedup via `pending` map |
+| `withExecLock` | 287-290 | Distributed Redis lock wrapper (no-op if no Redis) |
+| `ensureFreshCache` | 302-333 | Phase D: reload if version counter mismatch |
+| `publishVersionIfDirty` | 341-379 | Phase D/E: INCR version + write snapshot |
+| `withSession` | 391-445 | Create-if-missing, exec with locks |
+| `withExistingSession` | 454-494 | Pool-only lookup, throws ENOENT |
+| `destroy` | 505-542 | Mark closing, cleanup PG + Redis keys |
+| `runReaper` | 579-589 | Idle/over-budget eviction (no DB cleanup) |
+
+#### Locking Hierarchy
+1. **Distributed lock** (`withExecLock` → Redis `SET NX PX`): Cross-replica serialization
+2. **Coherence check** (`ensureFreshCache`): Inside distributed lock, outside local mutex
+3. **Local mutex** (`session.mutex.runExclusive`): Same-sandbox serialization on this replica
+
+#### getOrCreate Single-Flight (lines 209-274)
+- Check `sessions` map → return if warm
+- Check `pending` map → return same promise if in-flight
+- Create IIFE, store in `pending` before awaiting
+- Inside: `createFs()` → `new Bash()` → read Redis version → build Session → store in `sessions`
+- Finally: delete from `pending`
+
+#### Idle Reaper (lines 579-589)
+- Evicts sessions from pool when idle > `idleMs` or over memory budget
+- Does NOT call `destroySandboxFn` — sandbox remains in Postgres
+- This is key: evicted sandboxes need rehydration on next access
+
+---
+
+### 3. SqlDialect Interface and Postgres Dialect
+
+**File**: `src/fs/sql-fs/types.ts`
+
+The `SqlDialect<Tx>` interface has ~20 methods across categories:
+- **Connection**: `connect()`, `disconnect()`
+- **Transactions**: `transaction<T>(fn)`
+- **Sandbox context**: `setSandboxContext(tx, sandboxId)`, `setSandboxContextWithLock(tx, sandboxId)`
+- **Sandbox lifecycle**: `createSandbox(tx, sandboxId)`, `deleteSandbox(tx, sandboxId)`
+- **Inode CRUD**: `createInode`, `getInode`, `updateInode`, `deleteInode`
+- **Hardlinks**: `incrementNlink`, `decrementNlink`
+- **Dirents**: `insertDirent`, `upsertDirent`, `deleteDirent`, `listDirents`, `moveDirent`
+- **Blobs**: `upsertBlob`, `getBlob`, `gcOrphanBlobs`
+- **Bulk/tree**: `loadAllPaths`, `loadSubtreeInodes`, `bulkIngest`
+- **Path resolution**: `resolvePath`
+
+**No existing `sandboxExists` method.** The issue proposes adding one.
+
+**File**: `src/fs/sql-fs/dialects/postgres.ts`
+
+Key patterns:
+- **Tagged template SQL** via `postgres` library: `await tx\`SELECT ...\``
+- **RLS context**: `SET LOCAL app.sandbox_id` via `set_config(..., true)` (transaction-scoped)
+- **Advisory locks**: `pg_advisory_xact_lock(hashtextextended(sandboxId, 0))` (transaction-scoped, pgbouncer-safe)
+- **loadAllPaths** (lines 338-393): Recursive CTE starting from root inode, building full path tree
+
+---
+
+### 4. All withExistingSession Call Sites (11 total)
+
+#### HTTP Routes (8 call sites):
+
+| File | Route | Line | HTTP Method |
+|------|-------|------|-------------|
+| `src/api/routes/exec.ts` | `/exec-sync` | 65 | POST |
+| `src/api/routes/exec.ts` | `/exec` (SSE) | 148 | POST |
+| `src/api/routes/files.ts` | `/files/*` (read) | 105 | GET |
+| `src/api/routes/files.ts` | `/files/*` (write) | 165 | PUT |
+| `src/api/routes/files.ts` | `/files/*` (delete) | 192 | DELETE |
+| `src/api/routes/files.ts` | `/tree` | 332 | GET |
+| `src/api/routes/ingest.ts` | `/ingest` | 71 | POST |
+| `src/api/routes/ingest.ts` | `/ingest-files` | 162 | POST |
+| `src/api/routes/ingest.ts` | `/export` | 209 | GET |
+
+#### MCP Tools (3 call sites):
+
+| File | Tool | Line |
+|------|------|------|
+| `src/api/mcp/tools.ts` | `bash_exec` | 134 |
+| `src/api/mcp/tools.ts` | `fs_ingest` | 217 |
+| `src/api/mcp/tools.ts` | `fs_export` | 263 |
+
+#### Contrasting withSession usage (1 site):
+- `src/api/routes/sandboxes.ts:48` — `POST /v1/sandboxes` — the only create endpoint
+
+**No call site passes `runtimeOptions`** (withExistingSession doesn't accept them). The new `withSessionOrRehydrate` should accept optional `runtimeOptions` for the rehydration path.
+
+---
+
+### 5. SqlFs Initialization & Phase E Snapshot
+
+**File**: `src/fs/sql-fs/sql-fs.ts`
+
+#### ready() (lines 324-328)
+Calls `#loadFreshPathCache()` to populate the in-memory pathCache.
+
+#### #loadFreshPathCache() (lines 275-318)
+Decision tree:
+1. If Redis + pathSnapshot configured:
+   - Read `vfs:ver:{sandboxId}` for current version
+   - Read `vfs:snap:{sandboxId}` for snapshot
+   - **Strict version equality**: snapshot.version === currentVersion → return snapshot entries (~5ms)
+   - Miss/mismatch → fall through to CTE
+2. Fallback: `dialect.loadAllPaths(tx)` recursive CTE (~10-11ms for 1k paths)
+
+#### reload() (lines 342-359)
+Single-flighted via `#pendingReload`. Drops pathCache + contentCache, repopulates from DB or snapshot. Used by Phase D coherence on version mismatch.
+
+**File**: `src/fs/sql-fs/index.ts`
+
+#### createSandboxFs() (lines 25-76)
+1. Validate `DATABASE_URL`
+2. Get Redis client (lazy singleton)
+3. Create RedisBlobCache if Redis available
+4. Create RedisPathSnapshot if `REDIS_PATH_SNAPSHOT_ENABLED=true`
+5. Create PostgresDialect, connect
+6. Execute `createSandbox()` (idempotent on unique violation 23505)
+7. Instantiate SqlFs
+8. Call `fs.ready()` (Phase E snapshot check happens here)
+
+---
+
+### 6. Multi-Replica Redis Plan: Three Independent Gap Discoveries
+
+**File**: `tasks/IMPLEMENT-multi-replica-redis.md`
+
+All three phases that involved testing independently discovered and documented this gap:
+
+**Phase A Discovery (line 647):**
+> "Session rehydration gap (surfaced during manual E2E verification): HTTP routes use `withExistingSession`, which requires the sandbox to be in the `SessionManager` in-memory pool. After a server restart the pool is empty..."
+
+**Phase C Discovery (line 1093):**
+> "HTTP `withExistingSession` routes still hit the 'session rehydration gap' (Phase A discovery): a cold replica cannot service routes for a sandbox that was created on another replica..."
+
+**Phase E Discovery (line 1635):**
+> "Session rehydration over HTTP... Would require a `withSessionOrRehydrate` wrapper that falls back to `getOrCreate` when the pool is cold. Not in Phase E's scope — filed as future work..."
+
+| Phase | What It Does | Helps Rehydration? |
+|-------|-------------|-------------------|
+| A: Blob cache | Redis read-through for blobs | No (requires warm session) |
+| B: PG advisory lock | DB-level write serialization | No (requires warm session) |
+| C: Redis exec lock | Cross-replica exec serialization | No (requires warm session) |
+| D: Version counter | Cache coherence on handoff | No (requires warm session) |
+| E: Path snapshot | Fast cold-start pathCache | **Yes — but only inside `getOrCreate`/`ready()`, which `withExistingSession` never calls** |
+
+Phase E is the key enabler: it makes `getOrCreate` cheap for rehydration (~5ms vs ~10-11ms for CTE).
+
+---
+
+### 7. Failing Tests: concurrency.pg.test.ts
+
+**File**: `src/api/__tests__/integration/concurrency.pg.test.ts`
+
+**17 test cases, all failing with ENOENT.** The root cause: tests generate fresh sandbox IDs and immediately hit HTTP routes that call `withExistingSession`, without ever warming the session pool.
+
+**Contrast with passing tests** (`concurrency.test.ts`):
+```typescript
+// PASSING: explicit warmup
+await sm.getOrCreate(sbId);
+// then HTTP requests...
+
+// FAILING: no warmup
+const sbId = newId();
+// immediately HTTP requests → ENOENT
+```
+
+Test structure (6 describe blocks):
+1. N concurrent PUTs to same path (2 tests)
+2. N concurrent PUTs to distinct paths (1 test)
+3. Write-delete-read cache invalidation (2 tests)
+4. ContentCache consistency (2 tests)
+5. Cross-sandbox isolation (2 tests)
+6. Ordering scenarios S1-S4 (8 tests)
+
+**Once `withSessionOrRehydrate` replaces `withExistingSession` on routes**, these tests should pass because the wrapper will check Postgres and rehydrate on pool miss.
+
+---
+
+### 8. Proposed Fix Design
+
+#### New method: `withSessionOrRehydrate` (SessionManager)
+
+```typescript
+async withSessionOrRehydrate<T>(
+    sandboxId: string,
+    fn: (session: Session) => Promise<T>,
+    runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+    // Fast path: warm hit
+    const warm = this.sessions.get(sandboxId);
+    if (warm !== undefined) {
+        return this.withSessionEntry(sandboxId, warm, fn);
+    }
+
+    return this.withExecLock(sandboxId, async () => {
+        // Double-check under lock
+        let session = this.sessions.get(sandboxId);
+        if (session === undefined) {
+            const exists = await this.sandboxExistsInPG(sandboxId);
+            if (!exists) {
+                throw Object.assign(
+                    new Error(`ENOENT: sandbox ${sandboxId} not found`),
+                    { code: "ENOENT" },
+                );
+            }
+            session = await this.getOrCreate(sandboxId, runtimeOptions);
+        }
+        return this.withSessionEntry(sandboxId, session, fn);
+    });
+}
+```
+
+Key design decisions:
+- **Fast path**: `Map.get` only (identical to today's warm hit)
+- **Double-checked lookup**: Under distributed lock to avoid races
+- **PG existence gate**: Prevents auto-creation of non-existent sandboxes
+- **Rehydration via `getOrCreate`**: Reuses Phase E snapshot path
+
+#### `withSessionEntry` refactor
+
+Extract the shared `ensureFreshCache → mutex.runExclusive → publishVersionIfDirty` block from `withSession` and `withExistingSession` into a shared helper, eliminating 60+ lines of duplication.
+
+#### New SqlDialect method: `sandboxExists`
+
+```typescript
+// types.ts
+sandboxExists(tx: Tx, sandboxId: string): Promise<boolean>;
+
+// postgres.ts
+async sandboxExists(tx: PgTx, sandboxId: string): Promise<boolean> {
+    const rows = await tx<{ exists: boolean }[]>`
+        SELECT EXISTS (SELECT 1 FROM sandboxes WHERE id = ${sandboxId}) AS exists
+    `;
+    return rows[0]?.exists ?? false;
+}
+```
+
+#### Route rewiring
+
+Replace `withExistingSession` with `withSessionOrRehydrate` in:
+- `src/api/routes/exec.ts` (2 call sites)
+- `src/api/routes/files.ts` (4 call sites)
+- `src/api/routes/ingest.ts` (3 call sites)
+- `src/api/mcp/tools.ts` (3 call sites)
+
+`withExistingSession` stays for internal callers (idle reaper, strict tests).
+
+---
+
+### 9. Cost Analysis
+
+| Scenario | Latency | I/O |
+|----------|---------|-----|
+| Warm hit (common) | ~0ms | 1 Map.get |
+| Cold hit, sandbox exists (first LB handoff) | ~10ms | Lock acquire + SELECT EXISTS + getOrCreate (snapshot) |
+| Cold hit, sandbox absent | ~2ms | Lock acquire + SELECT EXISTS |
+
+The ~10ms cold-hit cost is paid once per replica per sandbox, amortized across all subsequent requests until idle eviction.
+
+---
+
+### 10. Security Preservation
+
+- **Deleted sandboxes stay deleted**: PG existence check is the gate. `DELETE` removes the row; subsequent `withSessionOrRehydrate` sees `exists = false` → ENOENT.
+- **No new attack surface**: Random UUID to `/exec-sync` still gets ENOENT (absent from `sandboxes` table).
+- **Destroy race safe**: Concurrent DELETE and rehydrate serialize on `vfs:lock:{id}`.
+
+---
+
+## Code References
+
+- `src/api/session-manager.ts:137` — `sessions: Map<string, Session>` (the process-local pool)
+- `src/api/session-manager.ts:209-274` — `getOrCreate` (single-flight session creation)
+- `src/api/session-manager.ts:287-290` — `withExecLock` (distributed Redis lock wrapper)
+- `src/api/session-manager.ts:302-333` — `ensureFreshCache` (Phase D coherence)
+- `src/api/session-manager.ts:341-379` — `publishVersionIfDirty` (Phase D/E version + snapshot)
+- `src/api/session-manager.ts:391-445` — `withSession` (create-if-missing wrapper)
+- `src/api/session-manager.ts:454-494` — `withExistingSession` (strict pool lookup — the ENOENT source)
+- `src/api/session-manager.ts:505-542` — `destroy` (lifecycle teardown)
+- `src/api/session-manager.ts:579-589` — `runReaper` (idle eviction — no DB cleanup)
+- `src/fs/sql-fs/types.ts:93-281` — `SqlDialect<Tx>` interface (all ~20 methods)
+- `src/fs/sql-fs/dialects/postgres.ts:54-66` — RLS/SET LOCAL pattern
+- `src/fs/sql-fs/dialects/postgres.ts:338-393` — `loadAllPaths` recursive CTE
+- `src/fs/sql-fs/sql-fs.ts:275-318` — `#loadFreshPathCache` (Phase E snapshot decision)
+- `src/fs/sql-fs/sql-fs.ts:324-328` — `ready()` (initialization entry point)
+- `src/fs/sql-fs/sql-fs.ts:342-359` — `reload()` (cache refresh for coherence)
+- `src/fs/sql-fs/index.ts:25-76` — `createSandboxFs` factory
+- `src/fs/sql-fs/redis-path-snapshot.ts:69-127` — Phase E snapshot read/write/delete
+- `src/api/routes/exec.ts:65,148` — withExistingSession call sites (exec)
+- `src/api/routes/files.ts:105,165,192,332` — withExistingSession call sites (files)
+- `src/api/routes/ingest.ts:71,162,209` — withExistingSession call sites (ingest/export)
+- `src/api/mcp/tools.ts:134,217,263` — withExistingSession call sites (MCP)
+- `src/api/routes/sandboxes.ts:48` — withSession call site (create — the only auto-creator)
+- `src/api/distributed-lock.ts:98-161` — Redis distributed lock implementation
+- `src/api/__tests__/integration/concurrency.pg.test.ts` — 17 failing tests (ENOENT from pool miss)
+
+## Architecture Insights
+
+### Locking Hierarchy (3 layers)
+1. **Lock 1**: `session.mutex` (in-replica, free microtask wait)
+2. **Lock 2**: Redis exec lock `vfs:lock:{id}` (cross-replica, heartbeat renewal)
+3. **Lock 3**: `pg_advisory_xact_lock` (transaction-tied, last-line backstop)
+
+### Cache Coherence Protocol (Phase D)
+- Each session tracks `lastSeenVersion`
+- On exec entry: read `vfs:ver:{id}` → if mismatch, `reload()` pathCache
+- On exec exit: if dirty, `INCR vfs:ver:{id}` + write Phase E snapshot
+
+### Snapshot Optimization (Phase E)
+- `vfs:snap:{id}` stores msgpack-encoded pathCache with embedded version
+- Strict version-equality check prevents stale snapshot use
+- Load test: 75% reduction in recursive-CTE calls for 3-replica setup
+
+### Key Invariant: Eviction vs Destroy
+- **Reaper eviction** drops the session from pool but leaves sandbox in Postgres (rehydratable)
+- **Destroy** removes from both pool AND Postgres (permanent deletion)
+- `withSessionOrRehydrate` bridges the gap: evicted sandboxes can be rehydrated, destroyed ones stay ENOENT
+
+## Open Questions
+
+1. **Should `withSessionOrRehydrate` acquire the distributed lock before or after the PG existence check?** The issue proposes: fast-path Map.get (no lock), then lock → double-check → PG check → getOrCreate. This avoids a Redis round-trip on warm hits.
+
+2. **Runtime options on rehydrate**: When rehydrating, should the wrapper accept `runtimeOptions`? The issue says yes (passthrough to `getOrCreate`), but no current call site passes them. The "first caller wins" contract means rehydrated sessions start with defaults.
+
+3. **Ownership verification on rehydrate**: The current design doesn't re-verify ownership (the `owner` field is set at creation time). Is this safe, or should rehydration also validate the bearer token against the sandbox owner?
+
+4. **MySQL/Azure SQL dialects**: `sandboxExists` is trivial for both but deferred. V1 targets Postgres only.
+
+5. **Metrics**: Should `vfs.session.rehydrate_total` and `vfs.session.rehydrate_duration_ms` be added in the main PR or as a follow-up?

--- a/thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md
+++ b/thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md
@@ -149,9 +149,9 @@ Key patterns:
 
 ---
 
-### 4. All withExistingSession Call Sites (11 total)
+### 4. All withExistingSession Call Sites (12 total)
 
-#### HTTP Routes (8 call sites):
+#### HTTP Routes (9 call sites):
 
 | File | Route | Line | HTTP Method |
 |------|-------|------|-------------|
@@ -420,3 +420,4 @@ The ~10ms cold-hit cost is paid once per replica per sandbox, amortized across a
 4. **MySQL/Azure SQL dialects**: `sandboxExists` is trivial for both but deferred. V1 targets Postgres only.
 
 5. **Metrics**: Should `vfs.session.rehydrate_total` and `vfs.session.rehydrate_duration_ms` be added in the main PR or as a follow-up?
+


### PR DESCRIPTION
## Summary

This PR merges the `feat/multi-replica-redis` branch: Redis-backed coherence (version counter, path snapshots, exec locks, rehydration), sandbox runtime metadata in Postgres, and related API/test updates.

It also **adds the implementation plan** for the next major initiative: **multi-tenant Postgres routing** (one process, N databases, tenant JWT claim, prefixed Redis keys, startup migrations).

## Plan outline (5 phases)

1. Tenant config loader + `tenant` JWT claim (legacy `DATABASE_URL` → implicit `default`).
2. Per-tenant Postgres routing in `SessionManager` (composite session keys, lazy dialects).
3. Tenant-prefixed Redis keys (lock, ver, snap, blob).
4. Startup migration runner over all configured tenant DBs.
5. E2E verification, docs, single-tenant regression.

## Test plan

- [ ] `pnpm typecheck && pnpm lint:fix && pnpm test:unit`
- [ ] Integration tests where `DATABASE_URL` / Redis are available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandboxes now persist owner and runtime flags so inactive replicas can restore (rehydrate) sessions.

* **Improvements**
  * Ownership checks unified; forbidden responses standardized across routes.
  * Server shutdown now closes metadata connectors; HTTP concurrency assertions relaxed to allow benign race outcomes.

* **Tests**
  * Expanded unit and integration tests for rehydration, cross-replica authorization, concurrency, and DB-backed sandbox metadata.

* **Documentation**
  * Added rehydration and multi-tenant design/rollout plans and a DB migration for runtime flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->