### PR TITLE
perf(api): replace per-file writeFile loop with bulkIngest in /ingest-files

### DIFF
--- a/commands/virtualfs-api.md
+++ b/commands/virtualfs-api.md
@@ -52,6 +52,7 @@ All reference material lives under `skills/virtualfs-api/` in this project:
 
 - **Working examples** → `skills/virtualfs-api/examples/`
   - `quickstart.sh` — create sandbox, write file, exec, delete
+  - `ingest-files.sh` — upload a local folder via the `ingest-files` JSON manifest
   - `ingest-explore.sh` — load a codebase and grep/cat via bash_exec
   - `sse-stream.sh` — SSE streaming execution
 
@@ -63,8 +64,10 @@ response shapes, and known gotchas from the live API.
 ## Core rules
 
 1. Always use parameterised shell variables (`$BASE_URL`, `$TOKEN`, `$SB`) in examples.
-2. Prefer `ingest-files` (base64 JSON) over `ingest` (tar.gz) for loading files — the tar
-   route extracts via bash and hits the ACA 240s gateway timeout for >20 files.
+2. Use `ingest-files` (base64 JSON) for loading a local folder. It is the only supported
+   ingest route — the tar.gz `/ingest` route was removed. Server-side it now uses a single
+   bulk multi-row INSERT (~5 round-trips total regardless of file count) so 100+ files
+   typically complete in <1s.
 3. Remind the user that `writeFiles` takes plain-text absolute paths; `ingest-files` takes
    base64 relative paths under a `basePath`.
 4. Sandbox filesystem survives session eviction (Postgres is durable). Shell state (env vars,

--- a/skills/virtualfs-api/SKILLS.md
+++ b/skills/virtualfs-api/SKILLS.md
@@ -13,6 +13,7 @@ Claude Code, curl, or Node.js.
 | **Error codes** | `ref/errors.md` | HTTP → FS code table + debugging patterns |
 | **Bash capabilities** | `ref/bash.md` | What just-bash supports / doesn't |
 | **Quickstart** | `examples/quickstart.sh` | Full lifecycle in one script |
+| **Folder upload** | `examples/ingest-files.sh` | Upload a local directory via the `ingest-files` JSON manifest |
 | **Codebase exploration** | `examples/ingest-explore.sh` | Load source files + grep/cat via bash |
 | **SSE streaming** | `examples/sse-stream.sh` | Real-time script output |
 
@@ -53,9 +54,11 @@ Sub-commands:
 
 ## Key facts to remember
 
-1. **`ingest-files` vs `ingest`**: use `ingest-files` (base64 JSON) for source files.
-   The tar.gz route runs `tar` inside just-bash — 3 Postgres round-trips per file,
-   sequentially. At ~300 ms/file on Neon (AUS-East), >20 files hits the ACA 240s timeout.
+1. **`ingest-files` is the only ingest route**. The tar.gz `/ingest` route was removed
+   (it shelled out to `tar -xzf` inside just-bash, costing 3 Postgres round-trips per
+   file and reliably tripping the ACA 240 s gateway timeout). `ingest-files` now uses
+   a single bulk multi-row INSERT — ~5 DB round-trips total regardless of file count,
+   so 100+ files typically complete in well under a second.
 
 2. **`writeFiles` vs `ingest-files`**:
    - `writeFiles` → plain text, **absolute** paths, no `basePath`

--- a/skills/virtualfs-api/examples/ingest-explore.sh
+++ b/skills/virtualfs-api/examples/ingest-explore.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 BASE_URL="${BASE_URL:?BASE_URL env var required (e.g. https://your-app.azurecontainerapps.io)}"
 TOKEN="${TOKEN:?TOKEN env var required}"
 SRC_DIR="${SRC_DIR:?SRC_DIR env var required — path to local source directory}"
-MAX_FILES="${MAX_FILES:-25}"    # keep under ACA 240s timeout (~2s/file on Neon)
+MAX_FILES="${MAX_FILES:-200}"   # bulkIngest commits in ~5 round-trips regardless of count; cap is just to keep the demo bounded
 SANDBOX_BASE_PATH="/home/user/src"
 
 SB=""
@@ -83,7 +83,7 @@ echo "Payload size: $(echo -n "$PAYLOAD" | wc -c | tr -d ' ') bytes"
 echo ""
 
 # ── 3. Ingest ─────────────────────────────────────────────────────────────────
-echo "--- Ingesting files (this takes ~2s/file on Neon) ---"
+echo "--- Ingesting files (bulk multi-row INSERT — typically <1s) ---"
 INGEST_RESULT=$(echo "$PAYLOAD" | curl -fsS -X POST "$BASE_URL/v1/sandboxes/$SB/ingest-files" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \

--- a/skills/virtualfs-api/examples/ingest-files.sh
+++ b/skills/virtualfs-api/examples/ingest-files.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# VirtualFS API — Upload a local folder via the JSON `ingest-files` route
+#
+# Walks SRC_DIR recursively, base64-encodes every file, posts one JSON manifest
+# to /v1/sandboxes/$SB/ingest-files. The server commits the whole batch with a
+# single bulk multi-row INSERT, so 100+ files typically complete in <1s.
+#
+# Stop-gap until the `pnpm push` CLI helper lands (see issue #16).
+#
+# Usage:
+#   BASE_URL=... TOKEN=... SB=<sandbox-id> SRC_DIR=./src bash ingest-files.sh
+#   BASE_URL=... TOKEN=... SB=<sandbox-id> SRC_DIR=./src BASE_PATH=/home/user/src bash ingest-files.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:?BASE_URL env var required}"
+TOKEN="${TOKEN:?TOKEN env var required}"
+SB="${SB:?SB (sandbox id) env var required}"
+SRC_DIR="${SRC_DIR:?SRC_DIR env var required — path to local directory to upload}"
+BASE_PATH="${BASE_PATH:-/home/user/src}"
+
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "SRC_DIR does not exist or is not a directory: $SRC_DIR" >&2
+  exit 1
+fi
+
+echo "Uploading $SRC_DIR → sandbox $SB at $BASE_PATH"
+
+# Build the JSON manifest with Node (recursive, base64, binary-safe)
+node -e '
+  const fs = require("fs"), path = require("path");
+  const dir = process.argv[1], base = process.argv[2];
+  const out = {};
+  (function walk(d) {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else out[path.relative(dir, p)] = fs.readFileSync(p).toString("base64");
+    }
+  })(dir);
+  process.stdout.write(JSON.stringify({ basePath: base, files: out }));
+' "$SRC_DIR" "$BASE_PATH" \
+| curl -fsS -X POST "$BASE_URL/v1/sandboxes/$SB/ingest-files" \
+       -H "Authorization: Bearer $TOKEN" \
+       -H "Content-Type: application/json" \
+       --data-binary @- \
+       -w '\nstatus=%{http_code} time=%{time_total}s\n'

--- a/skills/virtualfs-api/examples/ingest-files.sh
+++ b/skills/virtualfs-api/examples/ingest-files.sh
@@ -26,16 +26,21 @@ fi
 
 echo "Uploading $SRC_DIR → sandbox $SB at $BASE_PATH"
 
-# Build the JSON manifest with Node (recursive, base64, binary-safe)
+# Build the JSON manifest with Node (recursive, base64, binary-safe).
+# - skips symlinks so readFileSync cannot escape the selected tree
+# - uses Object.create(null) so filenames like "__proto__" are preserved
+# - normalizes keys to POSIX separators so the manifest is portable across OSes
 node -e '
   const fs = require("fs"), path = require("path");
   const dir = process.argv[1], base = process.argv[2];
-  const out = {};
+  const out = Object.create(null);
   (function walk(d) {
     for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      if (e.isSymbolicLink()) continue;
       const p = path.join(d, e.name);
-      if (e.isDirectory()) walk(p);
-      else out[path.relative(dir, p)] = fs.readFileSync(p).toString("base64");
+      if (e.isDirectory()) { walk(p); continue; }
+      const rel = path.relative(dir, p).split(path.sep).join("/");
+      out[rel] = fs.readFileSync(p).toString("base64");
     }
   })(dir);
   process.stdout.write(JSON.stringify({ basePath: base, files: out }));

--- a/skills/virtualfs-api/ref/endpoints.md
+++ b/skills/virtualfs-api/ref/endpoints.md
@@ -270,25 +270,32 @@ Client disconnect cancels the script via `AbortController`.
 
 ## Ingest / Export
 
-### POST /v1/sandboxes/:id/ingest-files — JSON manifest upload (PREFERRED)
+### POST /v1/sandboxes/:id/ingest-files — JSON manifest upload
 
-Takes **base64-encoded** content and **relative** paths under a `basePath`.
+The only ingest route. Takes **base64-encoded** content and **relative** paths under
+a `basePath`. Walks the manifest with the dialect's bulk multi-row INSERT, so the
+whole batch costs ~5 DB round-trips regardless of file count.
 
 ```bash
-# Build payload from local files
+# Build payload from local files (recursive)
 node -e "
 const fs = require('fs'), path = require('path');
-const srcDir = './src';
-const files = {};
-for (const f of fs.readdirSync(srcDir)) {
-  files[f] = fs.readFileSync(path.join(srcDir, f)).toString('base64');
-}
-process.stdout.write(JSON.stringify({ basePath: '/home/user/src', files }));
-" | curl -s -X POST "$BASE_URL/v1/sandboxes/$SB/ingest-files" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  --data-binary @- | jq
-# → {"status":"ok","fileCount":12}
+const root = process.argv[1], base = process.argv[2];
+const out = {};
+(function walk(d) {
+  for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    const p = path.join(d, e.name);
+    if (e.isDirectory()) walk(p);
+    else out[path.relative(root, p)] = fs.readFileSync(p).toString('base64');
+  }
+})(root);
+process.stdout.write(JSON.stringify({ basePath: base, files: out }));
+" ./src /home/user/src \
+| curl -s -X POST "$BASE_URL/v1/sandboxes/$SB/ingest-files" \
+       -H "Authorization: Bearer $TOKEN" \
+       -H "Content-Type: application/json" \
+       --data-binary @- | jq
+# → {"status":"ok","fileCount":37}
 ```
 
 Request body:
@@ -303,23 +310,9 @@ Request body:
 }
 ```
 
-**Performance:** ~2 s/file (3 Postgres round-trips per file: blob upsert, inode upsert, dirent
-insert). Keep batches ≤ 25 files per request to stay under ACA's 240 s stream timeout.
-For larger codebases, split into multiple calls by directory.
-
-### POST /v1/sandboxes/:id/ingest — tar.gz upload
-
-```bash
-tar czf /tmp/project.tar.gz -C /path/to/project .
-curl -s -X POST "$BASE_URL/v1/sandboxes/$SB/ingest" \
-  -H "Authorization: Bearer $TOKEN" \
-  -F "archive=@/tmp/project.tar.gz" \
-  -F "basePath=/home/user/project" | jq
-# → {"status":"ok","basePath":"/home/user/project"}
-```
-
-**Warning:** extraction runs `tar -xzf` inside just-bash. Each file costs ~3 DB round-trips
-sequentially. For >20 files the ACA 240 s stream timeout will be hit. Use `ingest-files` instead.
+**Performance:** ~150 files / ~1 MB JSON typically completes in <100 ms server-side.
+The previous "≤25 files per batch" rule no longer applies — the dialect now uses a
+single bulk INSERT. Practical caps are HTTP body size and the 240 s ACA gateway window.
 
 ### GET /v1/sandboxes/:id/export — Download as tar.gz
 

--- a/skills/virtualfs-api/ref/endpoints.md
+++ b/skills/virtualfs-api/ref/endpoints.md
@@ -277,16 +277,20 @@ a `basePath`. Walks the manifest with the dialect's bulk multi-row INSERT, so th
 whole batch costs ~5 DB round-trips regardless of file count.
 
 ```bash
-# Build payload from local files (recursive)
+# Build payload from local files (recursive). Skips symlinks, uses a
+# null-prototype object so keys like "__proto__" survive, normalizes manifest
+# keys to POSIX separators so the payload works the same on Windows hosts.
 node -e "
 const fs = require('fs'), path = require('path');
 const root = process.argv[1], base = process.argv[2];
-const out = {};
+const out = Object.create(null);
 (function walk(d) {
   for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    if (e.isSymbolicLink()) continue;
     const p = path.join(d, e.name);
-    if (e.isDirectory()) walk(p);
-    else out[path.relative(root, p)] = fs.readFileSync(p).toString('base64');
+    if (e.isDirectory()) { walk(p); continue; }
+    const rel = path.relative(root, p).split(path.sep).join('/');
+    out[rel] = fs.readFileSync(p).toString('base64');
   }
 })(root);
 process.stdout.write(JSON.stringify({ basePath: base, files: out }));

--- a/skills/virtualfs-api/ref/errors.md
+++ b/skills/virtualfs-api/ref/errors.md
@@ -58,11 +58,13 @@ falls back to a full Postgres reload. In practice this is transparent — just r
 
 ### 504 / "stream timeout" on ingest
 
-The ACA gateway has a 240 s stream timeout. You hit this when:
-- Using `POST /ingest` (tar.gz) with >20 files
+The ACA gateway has a 240 s stream timeout. With the bulk-INSERT `/ingest-files`
+path this is rare — the dialect commits the whole batch in ~5 round-trips. You can
+still hit it when:
+- The HTTP request body itself is huge and slow to upload
 - Network to Neon (Postgres) is degraded
 
-Fix: switch to `POST /ingest-files` with batches of ≤25 files.
+Fix: split very large uploads into a couple of calls by directory; check Neon health.
 
 ### Token looks right but gets AUTH_INVALID
 

--- a/src/api/__tests__/ingest.test.ts
+++ b/src/api/__tests__/ingest.test.ts
@@ -229,6 +229,37 @@ describe("POST /v1/sandboxes/:id/ingest-files", () => {
 		expect(res.status).toBe(401);
 	});
 
+	it("returns sanitized 500 when fs backend lacks bulkIngest (no raw ENOTSUP leak)", async () => {
+		// Bare InMemoryFs — no bulkIngest shim attached. Simulates a misconfigured
+		// backend where the route's defensive guard fires.
+		const sessionManager = new SessionManager({ createFs: async () => new InMemoryFs() });
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		await sessionManager.getOrCreate("default", SANDBOX_ID);
+
+		// Suppress the expected structured error log so the test output stays clean.
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				basePath: "/home/user/project",
+				files: { "a.txt": Buffer.from("hello").toString("base64") },
+			}),
+		});
+
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "Internal server error", code: "INTERNAL_ERROR" });
+		// Verify we logged the diagnostic so this can be detected in production.
+		expect(errorSpy).toHaveBeenCalled();
+		const logged = errorSpy.mock.calls[0]?.[0];
+		expect(typeof logged).toBe("string");
+		expect(logged as string).toContain("ingest_files_backend_unsupported");
+		errorSpy.mockRestore();
+	});
+
 	it("returns 403 when ingest-files hits a cold replica owned by another caller", async () => {
 		const meta = new Map<string, SandboxMeta>();
 		const ownerManager = new SessionManager({

--- a/src/api/__tests__/ingest.test.ts
+++ b/src/api/__tests__/ingest.test.ts
@@ -33,8 +33,7 @@ async function makeToken(sub = "agent-1"): Promise<string> {
  * we make (file readable, fileCount returned).
  */
 function withBulkIngest(fs: IFileSystem): IFileSystem & Pick<ICoherentFs, "bulkIngest"> {
-	const wrapped = fs as IFileSystem & Pick<ICoherentFs, "bulkIngest">;
-	wrapped.bulkIngest = async (files: BulkIngestFile[]) => {
+	const bulkIngest = async (files: BulkIngestFile[]): Promise<void> => {
 		for (const f of files) {
 			const lastSlash = f.path.lastIndexOf("/");
 			const parentDir = lastSlash > 0 ? f.path.slice(0, lastSlash) : "/";
@@ -49,7 +48,7 @@ function withBulkIngest(fs: IFileSystem): IFileSystem & Pick<ICoherentFs, "bulkI
 			await fs.writeFile(f.path, f.content);
 		}
 	};
-	return wrapped;
+	return Object.assign(fs, { bulkIngest }) satisfies IFileSystem & Pick<ICoherentFs, "bulkIngest">;
 }
 
 function makeTestEnv(): { sessionManager: SessionManager; fs: IFileSystem } {
@@ -173,6 +172,33 @@ describe("POST /v1/sandboxes/:id/ingest-files", () => {
 		expect(res.status).toBe(400);
 		const body = (await res.json()) as { code: string };
 		expect(body.code).toBe("INVALID_INPUT");
+	});
+
+	it("returns 400 listing offending keys when any file value is not valid base64", async () => {
+		const { sessionManager } = makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		await sessionManager.getOrCreate("default", SANDBOX_ID);
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				basePath: "/home/user/project",
+				files: {
+					"good.txt": Buffer.from("hello").toString("base64"),
+					"bad.txt": "not*valid*base64!!!",
+					"truncated.txt": "abc", // length not divisible by 4
+				},
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { code: string; details: string[] };
+		expect(body.code).toBe("INVALID_INPUT");
+		expect(body.details.some((d) => d.includes("invalid base64"))).toBe(true);
+		expect(body.details.some((d) => d.includes("bad.txt"))).toBe(true);
+		expect(body.details.some((d) => d.includes("truncated.txt"))).toBe(true);
 	});
 
 	it("returns 404 for non-existent sandbox", async () => {

--- a/src/api/__tests__/ingest.test.ts
+++ b/src/api/__tests__/ingest.test.ts
@@ -1,20 +1,20 @@
 /**
  * Unit tests for ingest routes.
- * US-071: POST /v1/sandboxes/:id/ingest — tar.gz upload
  * US-072: POST /v1/sandboxes/:id/ingest-files — JSON manifest upload
  * US-073: GET /v1/sandboxes/:id/export — tar.gz download
  */
 
 import { execSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Hono } from "hono";
 import { SignJWT } from "jose";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { SandboxMeta } from "../../fs/sql-fs/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
+import type { BulkIngestFile, SandboxMeta } from "../../fs/sql-fs/types.js";
 import { type AuthVariables, authMiddleware } from "../auth.js";
 import { ingestRoutes } from "../routes/ingest.js";
 import { SessionManager } from "../session-manager.js";
@@ -26,8 +26,34 @@ async function makeToken(sub = "agent-1"): Promise<string> {
 	return new SignJWT({ sub }).setProtectedHeader({ alg: "HS256" }).sign(secretBytes);
 }
 
+/**
+ * Wraps `InMemoryFs` with a `bulkIngest` shim that the route layer expects on
+ * an `ICoherentFs`. The implementation just walks the file list with mkdir+writeFile
+ * — fast enough for unit tests, and behaviourally equivalent for the assertions
+ * we make (file readable, fileCount returned).
+ */
+function withBulkIngest(fs: IFileSystem): IFileSystem & Pick<ICoherentFs, "bulkIngest"> {
+	const wrapped = fs as IFileSystem & Pick<ICoherentFs, "bulkIngest">;
+	wrapped.bulkIngest = async (files: BulkIngestFile[]) => {
+		for (const f of files) {
+			const lastSlash = f.path.lastIndexOf("/");
+			const parentDir = lastSlash > 0 ? f.path.slice(0, lastSlash) : "/";
+			if (parentDir !== "/") {
+				try {
+					await fs.mkdir(parentDir, { recursive: true });
+				} catch (e) {
+					const code = (e as Error & { code?: string }).code;
+					if (code !== "EEXIST") throw e;
+				}
+			}
+			await fs.writeFile(f.path, f.content);
+		}
+	};
+	return wrapped;
+}
+
 function makeTestEnv(): { sessionManager: SessionManager; fs: IFileSystem } {
-	const fs = new InMemoryFs();
+	const fs = withBulkIngest(new InMemoryFs());
 	const sessionManager = new SessionManager({
 		createFs: async () => fs,
 	});
@@ -41,183 +67,7 @@ function makeTestApp(sessionManager: SessionManager) {
 	return app;
 }
 
-/**
- * Creates a tar.gz archive on the host filesystem containing the given files,
- * and returns its contents as a Uint8Array.
- */
-function createTarGz(files: Record<string, string>): Uint8Array {
-	const tmpDir = path.join(os.tmpdir(), `ingest-test-${Date.now()}`);
-	mkdirSync(tmpDir, { recursive: true });
-	try {
-		for (const [name, content] of Object.entries(files)) {
-			writeFileSync(path.join(tmpDir, name), content, "utf-8");
-		}
-		const archivePath = path.join(tmpDir, "_archive.tar.gz");
-		const fileNames = Object.keys(files).join(" ");
-		execSync(`tar czf '${archivePath}' -C '${tmpDir}' ${fileNames}`);
-		const buf = readFileSync(archivePath);
-		return new Uint8Array(buf);
-	} finally {
-		rmSync(tmpDir, { recursive: true, force: true });
-	}
-}
-
 const SANDBOX_ID = "test-sandbox-ingest-abc";
-
-describe("POST /v1/sandboxes/:id/ingest", () => {
-	beforeEach(() => {
-		process.env.AUTH_SECRET = AUTH_SECRET;
-	});
-
-	afterEach(() => {
-		process.env.AUTH_SECRET = "";
-	});
-
-	it("ingest tar.gz of 3 files — files are readable in sandbox at basePath", async () => {
-		const { sessionManager } = makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-		await sessionManager.getOrCreate("default", SANDBOX_ID);
-
-		const files = {
-			"hello.txt": "hello world",
-			"foo.js": "console.log('foo');",
-			"bar.md": "# Bar\nSome content",
-		};
-		const archiveBytes = createTarGz(files);
-
-		const formData = new FormData();
-		formData.append("archive", new File([archiveBytes], "archive.tar.gz", { type: "application/gzip" }));
-		formData.append("basePath", "/home/user/project");
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest`, {
-			method: "POST",
-			headers: { Authorization: `Bearer ${token}` },
-			body: formData,
-		});
-
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { status: string; basePath: string };
-		expect(body.status).toBe("ok");
-		expect(body.basePath).toBe("/home/user/project");
-
-		// Verify files are readable in the sandbox
-		const session = await sessionManager.getOrCreate("default", SANDBOX_ID);
-		for (const [name, expectedContent] of Object.entries(files)) {
-			const content = await session.fs.readFile(`/home/user/project/${name}`);
-			expect(content).toBe(expectedContent);
-		}
-	});
-
-	it("uses default basePath /home/user/project when not specified", async () => {
-		const { sessionManager } = makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-		await sessionManager.getOrCreate("default", SANDBOX_ID);
-
-		const archiveBytes = createTarGz({ "readme.txt": "hello" });
-		const formData = new FormData();
-		formData.append("archive", new File([archiveBytes], "archive.tar.gz", { type: "application/gzip" }));
-		// No basePath field
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest`, {
-			method: "POST",
-			headers: { Authorization: `Bearer ${token}` },
-			body: formData,
-		});
-
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { status: string; basePath: string };
-		expect(body.basePath).toBe("/home/user/project");
-	});
-
-	it("missing archive field returns 400", async () => {
-		const { sessionManager } = makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-
-		const formData = new FormData();
-		formData.append("basePath", "/home/user/project");
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest`, {
-			method: "POST",
-			headers: { Authorization: `Bearer ${token}` },
-			body: formData,
-		});
-
-		expect(res.status).toBe(400);
-		const body = (await res.json()) as { code: string };
-		expect(body.code).toBe("INVALID_INPUT");
-	});
-
-	it("unauthenticated request returns 401", async () => {
-		const { sessionManager } = makeTestEnv();
-		const app = makeTestApp(sessionManager);
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest`, {
-			method: "POST",
-		});
-
-		expect(res.status).toBe(401);
-	});
-
-	it("returns 404 for non-existent sandbox", async () => {
-		const { sessionManager } = makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-
-		const archiveBytes = createTarGz({ "a.txt": "hello" });
-		const formData = new FormData();
-		formData.append("archive", new File([archiveBytes], "archive.tar.gz", { type: "application/gzip" }));
-
-		const res = await app.request("/v1/sandboxes/00000000-0000-0000-0000-000000000000/ingest", {
-			method: "POST",
-			headers: { Authorization: `Bearer ${token}` },
-			body: formData,
-		});
-
-		expect(res.status).toBe(404);
-	});
-
-	it("returns 403 when ingest-files hits a cold replica owned by another caller", async () => {
-		const meta = new Map<string, SandboxMeta>();
-		const ownerManager = new SessionManager({
-			createFs: async () => new InMemoryFs(),
-			getSandboxMetaFn: async (_tenantId, sandboxId) => meta.get(sandboxId) ?? null,
-			persistSandboxMetaFn: async (_tenantId, sandboxId, sandboxMeta) => {
-				meta.set(sandboxId, sandboxMeta);
-			},
-		});
-		await ownerManager.withSession("default", SANDBOX_ID, async (session) => {
-			session.owner = "agent-1";
-			await ownerManager.persistSandboxMeta("default", SANDBOX_ID, {
-				owner: "agent-1",
-				python: false,
-				javascript: false,
-			});
-		});
-
-		const coldReplica = new SessionManager({
-			createFs: async () => new InMemoryFs(),
-			getSandboxMetaFn: async (_tenantId, sandboxId) => meta.get(sandboxId) ?? null,
-		});
-		const app = makeTestApp(coldReplica);
-		const token = await makeToken("agent-2");
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
-			method: "POST",
-			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-			body: JSON.stringify({
-				basePath: "/home/user/project",
-				files: { "blocked.txt": Buffer.from("denied").toString("base64") },
-			}),
-		});
-
-		expect(res.status).toBe(403);
-		const body = (await res.json()) as { error: string; code: string };
-		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
-	});
-});
 
 describe("POST /v1/sandboxes/:id/ingest-files", () => {
 	beforeEach(() => {
@@ -255,6 +105,42 @@ describe("POST /v1/sandboxes/:id/ingest-files", () => {
 		expect(await session.fs.readFile("/home/user/project/hello.txt")).toBe("hello world");
 		expect(await session.fs.readFile("/home/user/project/foo.js")).toBe("console.log('foo');");
 		expect(await session.fs.readFile("/home/user/project/sub/bar.md")).toBe("# Bar\nSome content");
+	});
+
+	it("invokes bulkIngest exactly once with decoded BulkIngestFile[] (no per-file loop regression)", async () => {
+		const fs = withBulkIngest(new InMemoryFs());
+		const spy = vi.spyOn(fs, "bulkIngest");
+		const sessionManager = new SessionManager({ createFs: async () => fs });
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		await sessionManager.getOrCreate("default", SANDBOX_ID);
+
+		const files: Record<string, string> = {
+			"a.txt": Buffer.from("alpha").toString("base64"),
+			"sub/b.txt": Buffer.from("bravo").toString("base64"),
+		};
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ basePath: "/home/user/project", files }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(spy).toHaveBeenCalledOnce();
+
+		const arg = spy.mock.calls[0]?.[0] as BulkIngestFile[];
+		expect(arg).toHaveLength(2);
+
+		const a = arg.find((f) => f.path === "/home/user/project/a.txt");
+		expect(a).toBeDefined();
+		expect(new TextDecoder().decode(a!.content)).toBe("alpha");
+		expect(a!.mode).toBe(0o644);
+
+		const b = arg.find((f) => f.path === "/home/user/project/sub/b.txt");
+		expect(b).toBeDefined();
+		expect(new TextDecoder().decode(b!.content)).toBe("bravo");
+		expect(b!.mode).toBe(0o644);
 	});
 
 	it("missing basePath returns 400 validation error", async () => {
@@ -304,6 +190,56 @@ describe("POST /v1/sandboxes/:id/ingest-files", () => {
 		});
 
 		expect(res.status).toBe(404);
+	});
+
+	it("unauthenticated request returns 401", async () => {
+		const { sessionManager } = makeTestEnv();
+		const app = makeTestApp(sessionManager);
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+		});
+
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 403 when ingest-files hits a cold replica owned by another caller", async () => {
+		const meta = new Map<string, SandboxMeta>();
+		const ownerManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+			getSandboxMetaFn: async (_tenantId, sandboxId) => meta.get(sandboxId) ?? null,
+			persistSandboxMetaFn: async (_tenantId, sandboxId, sandboxMeta) => {
+				meta.set(sandboxId, sandboxMeta);
+			},
+		});
+		await ownerManager.withSession("default", SANDBOX_ID, async (session) => {
+			session.owner = "agent-1";
+			await ownerManager.persistSandboxMeta("default", SANDBOX_ID, {
+				owner: "agent-1",
+				python: false,
+				javascript: false,
+			});
+		});
+
+		const coldReplica = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+			getSandboxMetaFn: async (_tenantId, sandboxId) => meta.get(sandboxId) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const token = await makeToken("agent-2");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/ingest-files`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				basePath: "/home/user/project",
+				files: { "blocked.txt": Buffer.from("denied").toString("base64") },
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body).toEqual({ error: "forbidden", code: "FORBIDDEN" });
 	});
 });
 

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -491,6 +491,80 @@ describe("MCP tool — fs_ingest", () => {
 
 		await client.close();
 	});
+
+	it("rejects malformed manifest entries before any DB work and reports both bad paths and bad base64", async () => {
+		const sessionManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const createContent = createResult.content as Array<{ type: string; text?: string }>;
+		const created = JSON.parse(createContent[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: {
+				id: created.id,
+				basePath: "/home/user/proj",
+				files: {
+					"": b64("empty key"),
+					"dir/": b64("trailing slash"),
+					"good.txt": "%%%not-base64%%%",
+				},
+			},
+		});
+
+		const content = res.content as Array<{ type: string; text?: string }>;
+		const parsed = JSON.parse(content[0]?.text ?? "") as { ok: boolean; error: string };
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toMatch(/invalid paths/);
+		expect(parsed.error).toMatch(/invalid base64/);
+
+		await client.close();
+	});
+
+	it("returns a sanitized internal error (no backend wiring) when the FS lacks bulkIngest", async () => {
+		// Use a plain InMemoryFs WITHOUT the bulkIngest shim so the runtime guard
+		// fires and synthesizes an ENOTSUP error. The raw "bulkIngest not supported
+		// by this fs backend" message must NOT leak to the MCP client.
+		const sessionManager = new SessionManager({
+			createFs: async () => new InMemoryFs(),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const createContent = createResult.content as Array<{ type: string; text?: string }>;
+		const created = JSON.parse(createContent[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: {
+				id: created.id,
+				basePath: "/home/user/proj",
+				files: { "a.txt": b64("hello") },
+			},
+		});
+
+		const content = res.content as Array<{ type: string; text?: string }>;
+		const parsed = JSON.parse(content[0]?.text ?? "") as { ok: boolean; error: string };
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toBe("internal error");
+		expect(parsed.error).not.toContain("bulkIngest");
+		expect(parsed.error).not.toContain("backend");
+
+		await client.close();
+	});
 });
 
 describe("MCP tool — fs_export", () => {

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -12,12 +12,41 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
 import { describe, expect, it } from "vitest";
-import type { SandboxMeta } from "../../fs/sql-fs/types.js";
+import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
+import type { BulkIngestFile, SandboxMeta } from "../../fs/sql-fs/types.js";
 import { createMcpServer } from "../mcp/server.js";
 import { registerTools } from "../mcp/tools.js";
 import { SessionManager } from "../session-manager.js";
 import type { Session } from "../session-manager.js";
+
+/**
+ * Wraps `InMemoryFs` with a `bulkIngest` shim so MCP fs_ingest tests (which
+ * cast to ICoherentFs) work without standing up Postgres. Behaves like the
+ * real bulkIngest for the assertions we make: files become readable.
+ */
+function withBulkIngest(fs: IFileSystem): IFileSystem & Pick<ICoherentFs, "bulkIngest"> {
+	const wrapped = fs as IFileSystem & Pick<ICoherentFs, "bulkIngest">;
+	wrapped.bulkIngest = async (files: BulkIngestFile[]) => {
+		for (const f of files) {
+			const lastSlash = f.path.lastIndexOf("/");
+			const parentDir = lastSlash > 0 ? f.path.slice(0, lastSlash) : "/";
+			if (parentDir !== "/") {
+				try {
+					await fs.mkdir(parentDir, { recursive: true });
+				} catch (e) {
+					const code = (e as Error & { code?: string }).code;
+					if (code !== "EEXIST") throw e;
+				}
+			}
+			await fs.writeFile(f.path, f.content);
+		}
+	};
+	return wrapped;
+}
+
+const b64 = (s: string): string => Buffer.from(s, "utf-8").toString("base64");
 
 describe("MCP server", () => {
 	it("initializes without error", () => {
@@ -407,7 +436,7 @@ describe("MCP tool — bash_exec", () => {
 describe("MCP tool — fs_ingest", () => {
 	it("ingests 3 files and verifies they are readable via bash_exec cat", async () => {
 		const sessionManager = new SessionManager({
-			createFs: async () => new InMemoryFs(),
+			createFs: async () => withBulkIngest(new InMemoryFs()),
 		});
 
 		const server = createMcpServer();
@@ -424,16 +453,16 @@ describe("MCP tool — fs_ingest", () => {
 		const createContent = createResult.content as Array<{ type: string; text?: string }>;
 		const created = JSON.parse(createContent[0]?.text ?? "") as { id: string };
 
-		// Ingest 3 files
+		// Ingest 3 files (values are base64-encoded — see fs_ingest tool description)
 		const ingestResult = await client.callTool({
 			name: "fs_ingest",
 			arguments: {
 				id: created.id,
 				basePath: "/home/user/project",
 				files: {
-					"a.txt": "hello from a",
-					"subdir/b.txt": "hello from b",
-					"subdir/c.txt": "hello from c",
+					"a.txt": b64("hello from a"),
+					"subdir/b.txt": b64("hello from b"),
+					"subdir/c.txt": b64("hello from c"),
 				},
 			},
 		});
@@ -467,7 +496,7 @@ describe("MCP tool — fs_ingest", () => {
 describe("MCP tool — fs_export", () => {
 	it("exports files written to sandbox as a JSON map", async () => {
 		const sessionManager = new SessionManager({
-			createFs: async () => new InMemoryFs(),
+			createFs: async () => withBulkIngest(new InMemoryFs()),
 		});
 
 		const server = createMcpServer();
@@ -479,7 +508,7 @@ describe("MCP tool — fs_export", () => {
 		await server.connect(serverTransport);
 		await client.connect(clientTransport);
 
-		// Create a sandbox and ingest files
+		// Create a sandbox and ingest files (base64 per fs_ingest contract)
 		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
 		const createContent = createResult.content as Array<{ type: string; text?: string }>;
 		const created = JSON.parse(createContent[0]?.text ?? "") as { id: string };
@@ -490,9 +519,9 @@ describe("MCP tool — fs_export", () => {
 				id: created.id,
 				basePath: "/home/user/proj",
 				files: {
-					"a.txt": "content of a",
-					"sub/b.txt": "content of b",
-					"sub/c.txt": "content of c",
+					"a.txt": b64("content of a"),
+					"sub/b.txt": b64("content of b"),
+					"sub/c.txt": b64("content of c"),
 				},
 			},
 		});

--- a/src/api/__tests__/mcp.test.ts
+++ b/src/api/__tests__/mcp.test.ts
@@ -522,9 +522,49 @@ describe("MCP tool — fs_ingest", () => {
 
 		const content = res.content as Array<{ type: string; text?: string }>;
 		const parsed = JSON.parse(content[0]?.text ?? "") as { ok: boolean; error: string };
-		expect(parsed.ok).toBe(false);
-		expect(parsed.error).toMatch(/invalid paths/);
-		expect(parsed.error).toMatch(/invalid base64/);
+		// Deterministic full payload: empty key + "dir/" → invalid paths,
+		// "good.txt"/"%%%not-base64%%%" → invalid base64. Asserting the entire
+		// shape catches accidental delimiter/format changes that substring
+		// matches would silently miss.
+		expect(parsed).toEqual({
+			ok: false,
+			error: "invalid paths: , dir/; invalid base64: good.txt",
+		});
+
+		await client.close();
+	});
+
+	it.each([
+		["tmp", "no leading slash"],
+		["./proj", "relative path"],
+		["/home/user/../etc", ".. segment escapes basePath"],
+		["/home/user;rm -rf /", "shell metachar"],
+	])("rejects unsafe basePath %p (%s) before any DB work", async (basePath) => {
+		// The HTTP route validates basePath via isValidBasePath; the MCP tool
+		// shares the same helper. Without this guard, /home/user/../etc would
+		// silently normalize to /home/etc inside SqlFs.bulkIngest — diverging
+		// the two ingest contracts. This test pins both surfaces to one rule.
+		const sessionManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const createContent = createResult.content as Array<{ type: string; text?: string }>;
+		const created = JSON.parse(createContent[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: { id: created.id, basePath, files: { "a.txt": b64("hello") } },
+		});
+		const content = res.content as Array<{ type: string; text?: string }>;
+		const parsed = JSON.parse(content[0]?.text ?? "") as { ok: boolean; error: string };
+		expect(parsed).toEqual({ ok: false, error: "basePath must be a safe absolute path" });
 
 		await client.close();
 	});

--- a/src/api/ingest-validation.test.ts
+++ b/src/api/ingest-validation.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the shared manifest-path / base64 validators.
+ * Both the HTTP `/ingest-files` route and the MCP `fs_ingest` tool depend on
+ * these — drift between them is the bug class we're guarding against here.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isValidBase64, isValidRelativePath } from "./ingest-validation.js";
+
+describe("isValidRelativePath", () => {
+	it.each([
+		["src/index.ts", true],
+		["a.txt", true],
+		["deeply/nested/dir/file.md", true],
+	])("accepts well-formed relative paths: %s", (p, expected) => {
+		expect(isValidRelativePath(p)).toBe(expected);
+	});
+
+	it.each([
+		["", "empty string would join to basePath itself"],
+		["dir/", "trailing slash would normalize to basePath/dir and silently collide"],
+		["a//b", "empty segments collapse on normalization and obscure the user's intent"],
+		["/abs", "absolute paths bypass basePath"],
+		["..", "parent traversal escapes the sandbox"],
+		["a/../b", "embedded `..` escapes basePath after normalization"],
+		[".", "current-dir segment normalizes away to basePath"],
+		["a/./b", "embedded `.` segment normalizes to a/b — ambiguous"],
+		["bad\0path", "null bytes are a known injection vector"],
+	])("rejects malformed relative path %p — %s", (p) => {
+		expect(isValidRelativePath(p)).toBe(false);
+	});
+});
+
+describe("isValidBase64", () => {
+	it.each([
+		["", true],
+		["YQ==", true],
+		["YWI=", true],
+		["YWJj", true],
+		["YWJjZA==", true],
+	])("accepts strict RFC 4648 strings: %s", (s, expected) => {
+		expect(isValidBase64(s)).toBe(expected);
+	});
+
+	it.each([
+		["abc", "length not divisible by 4"],
+		["abcde", "length not divisible by 4"],
+		["%%%not-base64%%%", "non-alphabet chars"],
+		["YWJj YWJj", "whitespace is not allowed in strict base64"],
+		["YWJj\n", "newline is not allowed"],
+		["===", "padding-only is malformed"],
+	])("rejects malformed base64 %p — %s", (s) => {
+		expect(isValidBase64(s)).toBe(false);
+	});
+});

--- a/src/api/ingest-validation.test.ts
+++ b/src/api/ingest-validation.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { isValidBase64, isValidRelativePath } from "./ingest-validation.js";
+import { isValidBase64, isValidBasePath, isValidRelativePath } from "./ingest-validation.js";
 
 describe("isValidRelativePath", () => {
 	it.each([
@@ -49,7 +49,33 @@ describe("isValidBase64", () => {
 		["YWJj YWJj", "whitespace is not allowed in strict base64"],
 		["YWJj\n", "newline is not allowed"],
 		["===", "padding-only is malformed"],
+		["AZ==", "non-canonical: non-zero pad bits — decodes to 0x01 like AQ==, but doesn't round-trip"],
+		["ab==", "non-canonical: pad bits set — decodes to 0x69 but re-encodes to aQ=="],
+		["YQ", "missing required padding"],
+		["YQ=", "wrong padding length for 1-byte payload"],
 	])("rejects malformed base64 %p — %s", (s) => {
 		expect(isValidBase64(s)).toBe(false);
+	});
+});
+
+describe("isValidBasePath", () => {
+	it.each(["/home/user", "/home/user/proj", "/tmp/work", "/a", "/home/user-1/proj_v2/src.dir"])(
+		"accepts safe absolute path %p",
+		(p) => {
+			expect(isValidBasePath(p)).toBe(true);
+		},
+	);
+
+	it.each([
+		["", "empty string"],
+		["home/user", "missing leading slash"],
+		["./proj", "relative path"],
+		["/home/user/../etc", ".. segment escapes basePath"],
+		["/home/user;rm -rf", "shell metachar"],
+		["/home/user $HOME", "shell expansion / spaces"],
+		["/home/user\0", "null byte"],
+		["/home/user\nproj", "newline"],
+	])("rejects unsafe basePath %p — %s", (p) => {
+		expect(isValidBasePath(p)).toBe(false);
 	});
 });

--- a/src/api/ingest-validation.ts
+++ b/src/api/ingest-validation.ts
@@ -32,13 +32,31 @@ export function isValidRelativePath(p: string): boolean {
 }
 
 /**
- * Strict RFC 4648 base64 check (no whitespace, length divisible by 4 once
- * padded). `Buffer.from(_, "base64")` silently drops invalid chars and
- * accepts ragged lengths, so we screen here to reject corrupt manifests
- * before bytes hit the database.
+ * Strict canonical RFC 4648 base64 check.
+ *
+ * Two-step:
+ *   1. Structural regex: 0+ groups of 4 alphabet chars, optionally followed
+ *      by a final group of either 2 chars + `==` or 3 chars + `=`. This
+ *      rejects whitespace, ragged lengths, and bare padding.
+ *   2. Canonical round-trip: `Buffer.from(s, "base64")` silently tolerates
+ *      non-zero pad bits (e.g. `AZ==` decodes to the same bytes as `AQ==`),
+ *      so reject any input that doesn't re-encode to itself. Without this
+ *      check a tampered manifest could pass validation while persisting
+ *      bytes whose checksum no longer matches the value the caller sent.
  */
-const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+const BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 export function isValidBase64(s: string): boolean {
-	if (s.length % 4 !== 0) return false;
-	return BASE64_RE.test(s);
+	if (!BASE64_RE.test(s)) return false;
+	return Buffer.from(s, "base64").toString("base64") === s;
+}
+
+/**
+ * Strict absolute-path check for the `basePath` parameter in both the HTTP
+ * `/ingest-files` route and the MCP `fs_ingest` tool. Rejects shell-unsafe
+ * characters and any `..` segment so the two surfaces share one contract.
+ */
+export function isValidBasePath(p: string): boolean {
+	if (!/^\/[a-zA-Z0-9_\-./]*$/.test(p)) return false;
+	if (p.includes("..")) return false;
+	return true;
 }

--- a/src/api/ingest-validation.ts
+++ b/src/api/ingest-validation.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared input validators for the manifest-based ingest paths
+ * (HTTP `POST /v1/sandboxes/:id/ingest-files` and MCP `fs_ingest`).
+ *
+ * Both surfaces accept the same `{ basePath, files: { relPath: base64 } }`
+ * shape and need the same checks. Keeping them here avoids drift between
+ * the two entry points.
+ */
+
+/**
+ * Strict relative-path check for manifest keys. Rejects paths that would
+ * normalize to (or under) the basePath itself, paths with empty segments,
+ * `.`/`..` segments, leading slashes, and embedded null bytes.
+ *
+ * `SqlFs.bulkIngest` runs every path through `validatePath` again before
+ * touching SQL, but `""`, `"dir/"`, `"a//b"`, `"./x"` would all *normalize*
+ * to something the user didn't intend (the basePath itself, an unrelated
+ * sibling, etc.) — so we reject them up-front and surface a clear
+ * `INVALID_INPUT` rather than a confusing `EEXIST` after dedup.
+ */
+export function isValidRelativePath(p: string): boolean {
+	if (p.length === 0) return false;
+	if (p.includes("\0")) return false;
+	if (p.startsWith("/")) return false;
+	if (p.endsWith("/")) return false;
+	const segments = p.split("/");
+	for (const seg of segments) {
+		if (seg.length === 0) return false;
+		if (seg === "." || seg === "..") return false;
+	}
+	return true;
+}
+
+/**
+ * Strict RFC 4648 base64 check (no whitespace, length divisible by 4 once
+ * padded). `Buffer.from(_, "base64")` silently drops invalid chars and
+ * accepts ragged lengths, so we screen here to reject corrupt manifests
+ * before bytes hit the database.
+ */
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+export function isValidBase64(s: string): boolean {
+	if (s.length % 4 !== 0) return false;
+	return BASE64_RE.test(s);
+}

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -12,24 +12,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
+import { isValidBase64, isValidRelativePath } from "../ingest-validation.js";
 import { withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 300_000;
-
-/**
- * Validates that a relative path is safe (no traversal, no absolute paths, no null bytes).
- */
-function isValidRelativePath(p: string): boolean {
-	if (p.includes("\0")) return false;
-	if (p.startsWith("/")) return false;
-	const segments = p.split("/");
-	for (const seg of segments) {
-		if (seg === "..") return false;
-	}
-	return true;
-}
 
 export function registerTools(server: McpServer, sessionManager: SessionManager, owner: string, tenant: string): void {
 	server.tool(
@@ -217,25 +205,35 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 		async (args) => {
 			const basePath = args.basePath ?? "/home/user";
 
-			// Validate all relative paths before any DB work
-			for (const relativePath of Object.keys(args.files)) {
-				if (!isValidRelativePath(relativePath)) {
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: JSON.stringify({ ok: false, error: `invalid path: ${relativePath}` }),
-							},
-						],
-					};
+			// Validate paths and base64 in one pass before any DB work.
+			// `Buffer.from(_, "base64")` silently decodes garbage to corrupt bytes,
+			// so we reject malformed values up front rather than persist them.
+			const bulkFiles: BulkIngestFile[] = [];
+			const invalidPaths: string[] = [];
+			const invalidBase64: string[] = [];
+			for (const [rel, b64] of Object.entries(args.files)) {
+				if (!isValidRelativePath(rel)) {
+					invalidPaths.push(rel);
+					continue;
 				}
+				if (!isValidBase64(b64)) {
+					invalidBase64.push(rel);
+					continue;
+				}
+				bulkFiles.push({
+					path: `${basePath}/${rel}`,
+					content: new Uint8Array(Buffer.from(b64, "base64")),
+					mode: 0o644,
+				});
 			}
-
-			const bulkFiles: BulkIngestFile[] = Object.entries(args.files).map(([rel, b64]) => ({
-				path: `${basePath}/${rel}`.replace(/\/+/g, "/"),
-				content: new Uint8Array(Buffer.from(b64, "base64")),
-				mode: 0o644,
-			}));
+			if (invalidPaths.length > 0 || invalidBase64.length > 0) {
+				const parts: string[] = [];
+				if (invalidPaths.length > 0) parts.push(`invalid paths: ${invalidPaths.join(", ")}`);
+				if (invalidBase64.length > 0) parts.push(`invalid base64: ${invalidBase64.join(", ")}`);
+				return {
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: parts.join("; ") }) }],
+				};
+			}
 
 			try {
 				await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) => {
@@ -247,9 +245,7 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				});
 
 				return {
-					content: [
-						{ type: "text" as const, text: JSON.stringify({ ok: true, count: Object.keys(args.files).length }) },
-					],
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: true, count: bulkFiles.length }) }],
 				};
 			} catch (err) {
 				const code = (err as Error & { code?: string }).code;
@@ -258,7 +254,28 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "forbidden" }) }],
 					};
 				}
-				const message = code === "ENOENT" ? "sandbox not found" : err instanceof Error ? err.message : String(err);
+				if (code === "ENOENT") {
+					return {
+						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "sandbox not found" }) }],
+					};
+				}
+				// `ENOTSUP` here means the FS backend has no `bulkIngest` — only reachable
+				// from a misconfigured replica. Don't echo the internal "bulkIngest not
+				// supported by this fs backend" message back to the MCP client; log and
+				// return a generic internal error, mirroring the HTTP route.
+				if (code === "ENOTSUP") {
+					console.error(
+						JSON.stringify({
+							event: "fs_ingest_backend_unsupported",
+							sandboxId: args.id,
+							tenant,
+						}),
+					);
+					return {
+						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "internal error" }) }],
+					};
+				}
+				const message = err instanceof Error ? err.message : String(err);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
 				};

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -10,6 +10,8 @@
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
+import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import { withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
@@ -182,16 +184,40 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 
 	server.tool(
 		"fs_ingest",
-		"Upload files into sandbox (use before bash_exec to seed project files)",
+		[
+			"Upload one or more files into a sandbox in a single bulk database insert.",
+			"Use this before `bash_exec` to seed project files. This is the only ingest path",
+			"(the previous tar.gz route was removed). Internally the server commits the entire",
+			"batch with one multi-row INSERT — uploading 100+ files typically completes in",
+			"under a second.",
+			"",
+			"INPUT PREPARATION (important):",
+			"• Each value in `files` MUST be the file's bytes encoded as base64 — not raw text.",
+			'  For text files: `Buffer.from(textContent, "utf-8").toString("base64")`.',
+			"  For binary files: read the bytes and base64-encode them.",
+			"• Each key in `files` MUST be a relative path — no leading `/`, no `..` segments,",
+			"  no null bytes. The server joins it onto `basePath` to form the absolute path.",
+			"• `basePath` is the absolute root inside the sandbox (default `/home/user`).",
+			"  Missing parent directories under `basePath` are created automatically.",
+			"",
+			"Returns `{ ok: true, count: N }` on success. On failure returns `{ ok: false, error }`.",
+		].join("\n"),
 		{
-			id: z.string(),
-			basePath: z.string().optional(),
-			files: z.record(z.string(), z.string()),
+			id: z.string().describe("Sandbox id returned by sandbox_create."),
+			basePath: z
+				.string()
+				.optional()
+				.describe("Absolute root path inside the sandbox to anchor relative file keys. Default: /home/user"),
+			files: z
+				.record(z.string(), z.string())
+				.describe(
+					"Map of relativePath → base64-encoded file bytes. Keys are relative paths under basePath; values must be base64 (use Buffer.from(content).toString('base64')).",
+				),
 		},
 		async (args) => {
 			const basePath = args.basePath ?? "/home/user";
 
-			// Validate all relative paths before writing any files
+			// Validate all relative paths before any DB work
 			for (const relativePath of Object.keys(args.files)) {
 				if (!isValidRelativePath(relativePath)) {
 					return {
@@ -205,17 +231,19 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				}
 			}
 
+			const bulkFiles: BulkIngestFile[] = Object.entries(args.files).map(([rel, b64]) => ({
+				path: `${basePath}/${rel}`.replace(/\/+/g, "/"),
+				content: new Uint8Array(Buffer.from(b64, "base64")),
+				mode: 0o644,
+			}));
+
 			try {
 				await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) => {
-					for (const [relativePath, content] of Object.entries(args.files)) {
-						const absPath = `${basePath}/${relativePath}`;
-						const lastSlash = absPath.lastIndexOf("/");
-						const parentDir = absPath.slice(0, lastSlash);
-						if (parentDir) {
-							await session.fs.mkdir(parentDir, { recursive: true });
-						}
-						await session.fs.writeFile(absPath, content);
+					const fs = session.fs as ICoherentFs;
+					if (typeof fs.bulkIngest !== "function") {
+						throw Object.assign(new Error("bulkIngest not supported by this fs backend"), { code: "ENOTSUP" });
 					}
+					await fs.bulkIngest(bulkFiles);
 				});
 
 				return {

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -12,7 +12,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
-import { isValidBase64, isValidRelativePath } from "../ingest-validation.js";
+import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
 import { withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
@@ -204,6 +204,21 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 		},
 		async (args) => {
 			const basePath = args.basePath ?? "/home/user";
+
+			// Reuse the same basePath guard the HTTP /ingest-files route uses
+			// so the two ingest surfaces share one contract. Inputs like
+			// "tmp", "./proj", "/home/user/../tmp" must not silently normalize
+			// to a different destination than the caller supplied.
+			if (!isValidBasePath(basePath)) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({ ok: false, error: "basePath must be a safe absolute path" }),
+						},
+					],
+				};
+			}
 
 			// Validate paths and base64 in one pass before any DB work.
 			// `Buffer.from(_, "base64")` silently decodes garbage to corrupt bytes,

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -10,32 +10,13 @@ import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import type { AuthVariables } from "../auth.js";
+import { isValidBase64, isValidRelativePath } from "../ingest-validation.js";
 import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 // Validates that a basePath is a safe absolute path (no shell metacharacters)
 function isValidBasePath(p: string): boolean {
 	return /^\/[a-zA-Z0-9_\-./]*$/.test(p) && !p.includes("..");
-}
-
-// Validates that a relative path is safe (no traversal, no absolute paths, no null bytes)
-function isValidRelativePath(p: string): boolean {
-	if (p.includes("\0")) return false;
-	if (p.startsWith("/")) return false;
-	const segments = p.split("/");
-	for (const seg of segments) {
-		if (seg === "..") return false;
-	}
-	return true;
-}
-
-// Strict base64 (RFC 4648) — no whitespace, length divisible by 4 once padded.
-// Buffer.from(_, "base64") silently drops invalid chars and accepts ragged
-// lengths, so we screen here to reject corrupt manifests up front.
-const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
-function isValidBase64(s: string): boolean {
-	if (s.length % 4 !== 0) return false;
-	return BASE64_RE.test(s);
 }
 
 export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -118,6 +118,21 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			if (code === "ENOENT") {
 				return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
 			}
+			// Defensive: in production every replica wires SqlFs (which has bulkIngest),
+			// so this branch is only reachable from a misconfigured backend. Translate
+			// to a sanitized 500 here rather than letting the raw ENOTSUP code leak
+			// through the global handler — `ENOTSUP` isn't part of the public error
+			// vocabulary and would surprise clients.
+			if (code === "ENOTSUP") {
+				console.error(
+					JSON.stringify({
+						event: "ingest_files_backend_unsupported",
+						sandboxId,
+						tenant,
+					}),
+				);
+				return c.json({ error: "Internal server error", code: "INTERNAL_ERROR" }, 500 as ContentfulStatusCode);
+			}
 			throw e;
 		}
 

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -1,6 +1,5 @@
 /**
  * Ingest/Export routes.
- * US-071: POST /v1/sandboxes/:id/ingest — tar.gz upload
  * US-072: POST /v1/sandboxes/:id/ingest-files — JSON manifest upload
  * US-073: GET /v1/sandboxes/:id/export — tar.gz download
  */
@@ -8,6 +7,8 @@
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
+import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
+import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import type { AuthVariables } from "../auth.js";
 import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
@@ -30,70 +31,6 @@ function isValidRelativePath(p: string): boolean {
 
 export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
-
-	// POST /v1/sandboxes/:id/ingest — upload tar.gz and extract into sandbox
-	router.post("/:id/ingest", async (c) => {
-		const sandboxId = c.req.param("id");
-		const tenant = c.get("tenant");
-		const body = await c.req.parseBody();
-		const archiveField = body.archive;
-		const basePathField = body.basePath;
-		const basePath =
-			typeof basePathField === "string" && basePathField.length > 0 ? basePathField : "/home/user/project";
-
-		if (!(archiveField instanceof File)) {
-			return c.json(
-				{ error: "validation_error", code: "INVALID_INPUT", details: ["archive field is required and must be a file"] },
-				400 as ContentfulStatusCode,
-			);
-		}
-
-		if (!isValidBasePath(basePath)) {
-			return c.json(
-				{ error: "validation_error", code: "INVALID_INPUT", details: ["basePath must be a safe absolute path"] },
-				400 as ContentfulStatusCode,
-			);
-		}
-
-		const archiveBuffer = new Uint8Array(await archiveField.arrayBuffer());
-
-		try {
-			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
-				// Ensure /tmp exists before writing archive
-				try {
-					await session.fs.mkdir("/tmp", { recursive: true });
-				} catch (e) {
-					const code = (e as Error & { code?: string }).code;
-					if (code !== "EEXIST") throw e;
-				}
-
-				// Write archive to sandbox FS at /tmp/_ingest.tar.gz
-				await session.fs.writeFile("/tmp/_ingest.tar.gz", archiveBuffer);
-
-				// Extract via bash (just-bash requires dash-prefixed flags: -xzf not xzf)
-				const extractResult = await sessionManager.execWithRuntimeThrottle(
-					session,
-					`mkdir -p '${basePath}' && cd '${basePath}' && tar -xzf /tmp/_ingest.tar.gz && rm /tmp/_ingest.tar.gz`,
-				);
-				if (extractResult.exitCode !== 0) {
-					throw Object.assign(new Error(`tar extraction failed: ${extractResult.stderr || "unknown error"}`), {
-						code: "EINVAL",
-					});
-				}
-			});
-		} catch (e) {
-			const code = (e as Error & { code?: string }).code;
-			if (isForbiddenError(e)) {
-				return forbiddenResponse();
-			}
-			if (code === "ENOENT") {
-				return c.json({ error: "not_found", code: "ENOENT" }, 404 as ContentfulStatusCode);
-			}
-			throw e;
-		}
-
-		return c.json({ status: "ok", basePath });
-	});
 
 	// POST /v1/sandboxes/:id/ingest-files — JSON manifest upload
 	const ingestFilesBodySchema = z.object({
@@ -149,25 +86,19 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 		const fileCount = Object.keys(files).length;
 
+		const bulkFiles: BulkIngestFile[] = Object.entries(files).map(([rel, b64]) => ({
+			path: `${basePath}/${rel}`.replace(/\/+/g, "/"),
+			content: new Uint8Array(Buffer.from(b64, "base64")),
+			mode: 0o644,
+		}));
+
 		try {
 			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
-				for (const [relativePath, base64Content] of Object.entries(files)) {
-					const absPath = `${basePath}/${relativePath}`.replace(/\/+/g, "/");
-					const lastSlash = absPath.lastIndexOf("/");
-					const parentDir = lastSlash > 0 ? absPath.slice(0, lastSlash) : "/";
-
-					if (parentDir !== "/") {
-						try {
-							await session.fs.mkdir(parentDir, { recursive: true });
-						} catch (e) {
-							const code = (e as Error & { code?: string }).code;
-							if (code !== "EEXIST") throw e;
-						}
-					}
-
-					const decoded = Buffer.from(base64Content, "base64");
-					await session.fs.writeFile(absPath, new Uint8Array(decoded));
+				const fs = session.fs as ICoherentFs;
+				if (typeof fs.bulkIngest !== "function") {
+					throw Object.assign(new Error("bulkIngest not supported by this fs backend"), { code: "ENOTSUP" });
 				}
+				await fs.bulkIngest(bulkFiles);
 			});
 		} catch (e) {
 			const code = (e as Error & { code?: string }).code;

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -66,12 +66,18 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			);
 		}
 
-		// Validate all relative paths before writing any files
+		const bulkFiles: BulkIngestFile[] = [];
 		const invalidPaths: string[] = [];
-		for (const relativePath of Object.keys(files)) {
-			if (!isValidRelativePath(relativePath)) {
-				invalidPaths.push(relativePath);
+		for (const [rel, b64] of Object.entries(files)) {
+			if (!isValidRelativePath(rel)) {
+				invalidPaths.push(rel);
+				continue;
 			}
+			bulkFiles.push({
+				path: `${basePath}/${rel}`,
+				content: Buffer.from(b64, "base64"),
+				mode: 0o644,
+			});
 		}
 		if (invalidPaths.length > 0) {
 			return c.json(
@@ -84,13 +90,7 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 			);
 		}
 
-		const fileCount = Object.keys(files).length;
-
-		const bulkFiles: BulkIngestFile[] = Object.entries(files).map(([rel, b64]) => ({
-			path: `${basePath}/${rel}`.replace(/\/+/g, "/"),
-			content: new Uint8Array(Buffer.from(b64, "base64")),
-			mode: 0o644,
-		}));
+		const fileCount = bulkFiles.length;
 
 		try {
 			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -10,14 +10,9 @@ import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import type { AuthVariables } from "../auth.js";
-import { isValidBase64, isValidRelativePath } from "../ingest-validation.js";
+import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
 import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
-
-// Validates that a basePath is a safe absolute path (no shell metacharacters)
-function isValidBasePath(p: string): boolean {
-	return /^\/[a-zA-Z0-9_\-./]*$/.test(p) && !p.includes("..");
-}
 
 export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -29,6 +29,15 @@ function isValidRelativePath(p: string): boolean {
 	return true;
 }
 
+// Strict base64 (RFC 4648) — no whitespace, length divisible by 4 once padded.
+// Buffer.from(_, "base64") silently drops invalid chars and accepts ragged
+// lengths, so we screen here to reject corrupt manifests up front.
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+function isValidBase64(s: string): boolean {
+	if (s.length % 4 !== 0) return false;
+	return BASE64_RE.test(s);
+}
+
 export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
@@ -68,9 +77,14 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 		const bulkFiles: BulkIngestFile[] = [];
 		const invalidPaths: string[] = [];
+		const invalidBase64: string[] = [];
 		for (const [rel, b64] of Object.entries(files)) {
 			if (!isValidRelativePath(rel)) {
 				invalidPaths.push(rel);
+				continue;
+			}
+			if (!isValidBase64(b64)) {
+				invalidBase64.push(rel);
 				continue;
 			}
 			bulkFiles.push({
@@ -79,15 +93,11 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 				mode: 0o644,
 			});
 		}
-		if (invalidPaths.length > 0) {
-			return c.json(
-				{
-					error: "validation_error",
-					code: "INVALID_INPUT",
-					details: [`invalid paths: ${invalidPaths.join(", ")}`],
-				},
-				400 as ContentfulStatusCode,
-			);
+		if (invalidPaths.length > 0 || invalidBase64.length > 0) {
+			const details: string[] = [];
+			if (invalidPaths.length > 0) details.push(`invalid paths: ${invalidPaths.join(", ")}`);
+			if (invalidBase64.length > 0) details.push(`invalid base64: ${invalidBase64.join(", ")}`);
+			return c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode);
 		}
 
 		const fileCount = bulkFiles.length;

--- a/src/fs/sql-fs/integration/postgres.test.ts
+++ b/src/fs/sql-fs/integration/postgres.test.ts
@@ -24,6 +24,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PostgresDialect } from "../dialects/postgres.js";
+import { SqlFs } from "../sql-fs.js";
 import type { BulkIngestFile } from "../types.js";
 
 describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — connection and sandbox context", () => {
@@ -1302,5 +1303,59 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — resolvePath (fs_
 				return dialect.resolvePath(tx, "/nonexistent/path", true);
 			}),
 		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+});
+
+describe.skipIf(!process.env.DATABASE_URL)("SqlFs.bulkIngest — end-to-end through cache-coherence wrapper", () => {
+	const dialect = new PostgresDialect(process.env.DATABASE_URL!);
+	const sandboxId = `test-sqlfs-bulk-${Date.now()}`;
+
+	beforeAll(async () => {
+		await dialect.connect();
+		await dialect.transaction(async (tx) => {
+			await dialect.createSandbox(tx, sandboxId);
+		});
+	});
+
+	afterAll(async () => {
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.deleteSandbox(tx, sandboxId);
+			});
+		} finally {
+			await dialect.disconnect();
+		}
+	});
+
+	it("ingests ~50 files across nested dirs and every file is readable via SqlFs", async () => {
+		const fs = new SqlFs({ dialect, sandboxId });
+		await fs.ready();
+
+		const dirs = ["alpha", "alpha/x", "beta", "beta/y", "gamma"];
+		const files: BulkIngestFile[] = [];
+		for (const dir of dirs) {
+			for (let i = 0; i < 10; i++) {
+				files.push({
+					path: `/home/user/${dir}/file${i}.txt`,
+					content: new TextEncoder().encode(`content-${dir}-${i}`),
+					mode: 0o644,
+				});
+			}
+		}
+
+		await fs.bulkIngest(files);
+
+		// pathCache must contain every ingested path (driven by reload())
+		for (const f of files) {
+			const stat = await fs.stat(f.path);
+			expect(stat.isFile).toBe(true);
+			expect(stat.size).toBe(f.content.byteLength);
+		}
+
+		// readFile pulls each blob from the DB on first access
+		for (const f of files) {
+			const text = await fs.readFile(f.path);
+			expect(text).toBe(new TextDecoder().decode(f.content));
+		}
 	});
 });

--- a/src/fs/sql-fs/integration/postgres.test.ts
+++ b/src/fs/sql-fs/integration/postgres.test.ts
@@ -24,7 +24,6 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PostgresDialect } from "../dialects/postgres.js";
-import { SqlFs } from "../sql-fs.js";
 import type { BulkIngestFile } from "../types.js";
 
 describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — connection and sandbox context", () => {
@@ -1303,59 +1302,5 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — resolvePath (fs_
 				return dialect.resolvePath(tx, "/nonexistent/path", true);
 			}),
 		).rejects.toMatchObject({ code: "ENOENT" });
-	});
-});
-
-describe.skipIf(!process.env.DATABASE_URL)("SqlFs.bulkIngest — end-to-end through cache-coherence wrapper", () => {
-	const dialect = new PostgresDialect(process.env.DATABASE_URL!);
-	const sandboxId = `test-sqlfs-bulk-${Date.now()}`;
-
-	beforeAll(async () => {
-		await dialect.connect();
-		await dialect.transaction(async (tx) => {
-			await dialect.createSandbox(tx, sandboxId);
-		});
-	});
-
-	afterAll(async () => {
-		try {
-			await dialect.transaction(async (tx) => {
-				await dialect.deleteSandbox(tx, sandboxId);
-			});
-		} finally {
-			await dialect.disconnect();
-		}
-	});
-
-	it("ingests ~50 files across nested dirs and every file is readable via SqlFs", async () => {
-		const fs = new SqlFs({ dialect, sandboxId });
-		await fs.ready();
-
-		const dirs = ["alpha", "alpha/x", "beta", "beta/y", "gamma"];
-		const files: BulkIngestFile[] = [];
-		for (const dir of dirs) {
-			for (let i = 0; i < 10; i++) {
-				files.push({
-					path: `/home/user/${dir}/file${i}.txt`,
-					content: new TextEncoder().encode(`content-${dir}-${i}`),
-					mode: 0o644,
-				});
-			}
-		}
-
-		await fs.bulkIngest(files);
-
-		// pathCache must contain every ingested path (driven by reload())
-		for (const f of files) {
-			const stat = await fs.stat(f.path);
-			expect(stat.isFile).toBe(true);
-			expect(stat.size).toBe(f.content.byteLength);
-		}
-
-		// readFile pulls each blob from the DB on first access
-		for (const f of files) {
-			const text = await fs.readFile(f.path);
-			expect(text).toBe(new TextDecoder().decode(f.content));
-		}
 	});
 });

--- a/src/fs/sql-fs/integration/sql-fs.bulkingest.test.ts
+++ b/src/fs/sql-fs/integration/sql-fs.bulkingest.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration test for `SqlFs.bulkIngest` — exercises the cache-coherence
+ * wrapper end-to-end against a real Postgres. The dialect-level bulkIngest
+ * primitive is covered separately in `postgres.test.ts`; this suite verifies
+ * the SqlFs layer (advisory lock + reload + dirty flag).
+ *
+ * Skipped when DATABASE_URL is not set so CI without a DB still passes.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PostgresDialect } from "../dialects/postgres.js";
+import { SqlFs } from "../sql-fs.js";
+import type { BulkIngestFile } from "../types.js";
+
+describe.skipIf(!process.env.DATABASE_URL)("SqlFs.bulkIngest — end-to-end through cache-coherence wrapper", () => {
+	const dialect = new PostgresDialect(process.env.DATABASE_URL!);
+	const sandboxId = `test-sqlfs-bulk-${Date.now()}`;
+
+	beforeAll(async () => {
+		await dialect.connect();
+		await dialect.transaction(async (tx) => {
+			await dialect.createSandbox(tx, sandboxId);
+		});
+	});
+
+	afterAll(async () => {
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.deleteSandbox(tx, sandboxId);
+			});
+		} finally {
+			await dialect.disconnect();
+		}
+	});
+
+	it("ingests ~50 files across nested dirs and every file is readable via SqlFs", async () => {
+		const fs = new SqlFs({ dialect, sandboxId });
+		await fs.ready();
+
+		const dirs = ["alpha", "alpha/x", "beta", "beta/y", "gamma"];
+		const files: BulkIngestFile[] = [];
+		for (const dir of dirs) {
+			for (let i = 0; i < 10; i++) {
+				files.push({
+					path: `/home/user/${dir}/file${i}.txt`,
+					content: new TextEncoder().encode(`content-${dir}-${i}`),
+					mode: 0o644,
+				});
+			}
+		}
+
+		await fs.bulkIngest(files);
+
+		// pathCache must contain every ingested path (driven by reload())
+		for (const f of files) {
+			const stat = await fs.stat(f.path);
+			expect(stat.isFile).toBe(true);
+			expect(stat.size).toBe(f.content.byteLength);
+		}
+
+		// readFile pulls each blob from the DB on first access
+		for (const f of files) {
+			const text = await fs.readFile(f.path);
+			expect(text).toBe(new TextDecoder().decode(f.content));
+		}
+	});
+});

--- a/src/fs/sql-fs/sql-fs.bulkingest.test.ts
+++ b/src/fs/sql-fs/sql-fs.bulkingest.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the SqlFs.bulkIngest cache-coherence wrapper.
+ *
+ * The wrapper is what differentiates the public API method from the dialect
+ * primitive: it must run inside `#withTx` (acquires advisory lock + RLS),
+ * mark the FS dirty so multi-replica version bookkeeping fires, and refresh
+ * `pathCache` via `reload()` so subsequent reads see the new entries.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "./sql-fs.js";
+import type { BulkIngestFile, PathCacheEntry, SqlDialect } from "./types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+function dirEntry(path: string, inodeId: bigint): { path: string } & PathCacheEntry {
+	return { path, inodeId, kind: 2, mode: 0o755, size: 0, mtime: now, contentSha256: null, symlinkTarget: null };
+}
+
+function fileEntry(path: string, inodeId: bigint, size: number): { path: string } & PathCacheEntry {
+	const sha = new Uint8Array(32).fill(0xcd);
+	return { path, inodeId, kind: 1, mode: 0o644, size, mtime: now, contentSha256: sha, symlinkTarget: null };
+}
+
+function makeDialect(): {
+	dialect: SqlDialect<unknown>;
+	bulkIngestMock: ReturnType<typeof vi.fn>;
+	loadAllPathsMock: ReturnType<typeof vi.fn>;
+	transactionMock: ReturnType<typeof vi.fn>;
+	setSandboxContextWithLockMock: ReturnType<typeof vi.fn>;
+} {
+	const transactionMock = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({}));
+	const bulkIngestMock = vi.fn();
+	const loadAllPathsMock = vi.fn(async () => [] as Array<{ path: string } & PathCacheEntry>);
+	const setSandboxContextWithLockMock = vi.fn();
+	const dialect: SqlDialect<unknown> = {
+		connect: vi.fn(),
+		disconnect: vi.fn(),
+		transaction: transactionMock,
+		setSandboxContext: vi.fn(),
+		setSandboxContextWithLock: setSandboxContextWithLockMock,
+		loadAllPaths: loadAllPathsMock,
+		createSandbox: vi.fn(),
+		deleteSandbox: vi.fn(),
+		sandboxExists: vi.fn(),
+		getSandboxMeta: vi.fn(),
+		updateSandboxMeta: vi.fn(),
+		createInode: vi.fn(),
+		getInode: vi.fn(),
+		updateInode: vi.fn(),
+		deleteInode: vi.fn(),
+		incrementNlink: vi.fn(),
+		decrementNlink: vi.fn(),
+		insertDirent: vi.fn(),
+		upsertDirent: vi.fn(),
+		deleteDirent: vi.fn(),
+		listDirents: vi.fn(),
+		moveDirent: vi.fn(),
+		upsertBlob: vi.fn(),
+		getBlob: vi.fn(),
+		gcOrphanBlobs: vi.fn(),
+		loadSubtreeInodes: vi.fn(),
+		bulkIngest: bulkIngestMock,
+		resolvePath: vi.fn(),
+	} as unknown as SqlDialect<unknown>;
+	return { dialect, bulkIngestMock, loadAllPathsMock, transactionMock, setSandboxContextWithLockMock };
+}
+
+describe("SqlFs.bulkIngest", () => {
+	let dialect: SqlDialect<unknown>;
+	let bulkIngestMock: ReturnType<typeof vi.fn>;
+	let loadAllPathsMock: ReturnType<typeof vi.fn>;
+	let transactionMock: ReturnType<typeof vi.fn>;
+	let setSandboxContextWithLockMock: ReturnType<typeof vi.fn>;
+	let fs: SqlFs;
+
+	beforeEach(async () => {
+		const m = makeDialect();
+		dialect = m.dialect;
+		bulkIngestMock = m.bulkIngestMock;
+		loadAllPathsMock = m.loadAllPathsMock;
+		transactionMock = m.transactionMock;
+		setSandboxContextWithLockMock = m.setSandboxContextWithLockMock;
+
+		// Initial pathCache: just /
+		loadAllPathsMock.mockResolvedValueOnce([dirEntry("/", 1n)]);
+		fs = new SqlFs({ dialect, sandboxId: "s1" });
+		await fs.ready();
+	});
+
+	it("is a no-op for an empty file list — no transaction, no reload, no dirty flip", async () => {
+		const txCallsBefore = transactionMock.mock.calls.length;
+		const loadCallsBefore = loadAllPathsMock.mock.calls.length;
+
+		await fs.bulkIngest([]);
+
+		expect(bulkIngestMock).not.toHaveBeenCalled();
+		expect(transactionMock.mock.calls.length).toBe(txCallsBefore);
+		expect(loadAllPathsMock.mock.calls.length).toBe(loadCallsBefore);
+		expect(fs.wasDirty()).toBe(false);
+	});
+
+	it("opens one write tx (with advisory lock), invokes dialect.bulkIngest, sets dirty, then reloads", async () => {
+		const lockCallsBefore = setSandboxContextWithLockMock.mock.calls.length;
+		const loadCallsBefore = loadAllPathsMock.mock.calls.length;
+
+		const files: BulkIngestFile[] = [{ path: "/a.txt", content: new TextEncoder().encode("a"), mode: 0o644 }];
+
+		// Reload after bulkIngest will call loadAllPaths once more.
+		loadAllPathsMock.mockResolvedValueOnce([dirEntry("/", 1n), fileEntry("/a.txt", 2n, 1)]);
+
+		await fs.bulkIngest(files);
+
+		expect(bulkIngestMock).toHaveBeenCalledOnce();
+		expect(bulkIngestMock.mock.calls[0]?.[1]).toBe(files);
+		// Advisory lock must be acquired (write path), not the read-only setSandboxContext.
+		expect(setSandboxContextWithLockMock.mock.calls.length).toBeGreaterThan(lockCallsBefore);
+		// reload() ran loadAllPaths exactly once more after the mutation.
+		expect(loadAllPathsMock.mock.calls.length).toBe(loadCallsBefore + 1);
+		// dirty must be set AFTER reload() so publishVersionIfDirty sees the
+		// mutation and bumps the cross-replica version counter.
+		expect(fs.wasDirty()).toBe(true);
+	});
+
+	it("after bulkIngest + reload, stat() returns the new entry from the refreshed pathCache", async () => {
+		const files: BulkIngestFile[] = [{ path: "/home/user/x.txt", content: new TextEncoder().encode("x"), mode: 0o644 }];
+
+		// Stub loadAllPaths to return the post-ingest tree on reload.
+		loadAllPathsMock.mockResolvedValueOnce([
+			dirEntry("/", 1n),
+			dirEntry("/home", 10n),
+			dirEntry("/home/user", 11n),
+			fileEntry("/home/user/x.txt", 20n, 1),
+		]);
+
+		await fs.bulkIngest(files);
+
+		const stat = await fs.stat("/home/user/x.txt");
+		expect(stat.isFile).toBe(true);
+		expect(stat.size).toBe(1);
+	});
+
+	it("propagates dialect.bulkIngest errors and does NOT call reload()", async () => {
+		const loadCallsBefore = loadAllPathsMock.mock.calls.length;
+		bulkIngestMock.mockRejectedValueOnce(Object.assign(new Error("boom"), { code: "EINVAL" }));
+
+		const files: BulkIngestFile[] = [{ path: "/a.txt", content: new TextEncoder().encode("a"), mode: 0o644 }];
+
+		await expect(fs.bulkIngest(files)).rejects.toMatchObject({ code: "EINVAL" });
+		expect(loadAllPathsMock.mock.calls.length).toBe(loadCallsBefore);
+	});
+});

--- a/src/fs/sql-fs/sql-fs.bulkingest.test.ts
+++ b/src/fs/sql-fs/sql-fs.bulkingest.test.ts
@@ -33,6 +33,11 @@ function makeDialect(): {
 	const bulkIngestMock = vi.fn();
 	const loadAllPathsMock = vi.fn(async () => [] as Array<{ path: string } & PathCacheEntry>);
 	const setSandboxContextWithLockMock = vi.fn();
+	// `as unknown as SqlDialect<unknown>` (not `satisfies`) is required here because
+	// `SqlDialect.transaction` is a generic method `<T>(fn) => Promise<T>`, and a
+	// `vi.fn(...)` mock collapses the type parameter so it cannot structurally
+	// match the variance. Same pattern used by the other dialect-mock tests in
+	// this directory (sql-fs.read.test.ts etc.).
 	const dialect: SqlDialect<unknown> = {
 		connect: vi.fn(),
 		disconnect: vi.fn(),
@@ -112,7 +117,9 @@ describe("SqlFs.bulkIngest", () => {
 		await fs.bulkIngest(files);
 
 		expect(bulkIngestMock).toHaveBeenCalledOnce();
-		expect(bulkIngestMock.mock.calls[0]?.[1]).toBe(files);
+		// bulkIngest forwards a normalized copy (paths run through validatePath),
+		// not the caller's array — assert by value, not by reference.
+		expect(bulkIngestMock.mock.calls[0]?.[1]).toEqual(files);
 		// Advisory lock must be acquired (write path), not the read-only setSandboxContext.
 		expect(setSandboxContextWithLockMock.mock.calls.length).toBeGreaterThan(lockCallsBefore);
 		// reload() ran loadAllPaths exactly once more after the mutation.
@@ -148,5 +155,43 @@ describe("SqlFs.bulkIngest", () => {
 
 		await expect(fs.bulkIngest(files)).rejects.toMatchObject({ code: "EINVAL" });
 		expect(loadAllPathsMock.mock.calls.length).toBe(loadCallsBefore);
+	});
+
+	it("normalizes paths through validatePath before forwarding to the dialect", async () => {
+		loadAllPathsMock.mockResolvedValueOnce([dirEntry("/", 1n)]);
+
+		await fs.bulkIngest([
+			{ path: "/home/user/./a.txt", content: new TextEncoder().encode("a"), mode: 0o644 },
+			{ path: "/home/user/sub/../b.txt", content: new TextEncoder().encode("b"), mode: 0o644 },
+		]);
+
+		expect(bulkIngestMock).toHaveBeenCalledOnce();
+		const forwarded = bulkIngestMock.mock.calls[0]?.[1] as BulkIngestFile[];
+		expect(forwarded.map((f) => f.path)).toEqual(["/home/user/a.txt", "/home/user/b.txt"]);
+	});
+
+	it("rejects EINVAL on null byte in path before opening a transaction", async () => {
+		const txCallsBefore = transactionMock.mock.calls.length;
+
+		await expect(
+			fs.bulkIngest([{ path: "/home/user/\0bad.txt", content: new Uint8Array(0), mode: 0o644 }]),
+		).rejects.toMatchObject({ code: "EINVAL" });
+
+		expect(bulkIngestMock).not.toHaveBeenCalled();
+		expect(transactionMock.mock.calls.length).toBe(txCallsBefore);
+	});
+
+	it("rejects EEXIST when two inputs normalize to the same path, before opening a transaction", async () => {
+		const txCallsBefore = transactionMock.mock.calls.length;
+
+		await expect(
+			fs.bulkIngest([
+				{ path: "/home/user/a.txt", content: new TextEncoder().encode("first"), mode: 0o644 },
+				{ path: "/home/user/./a.txt", content: new TextEncoder().encode("second"), mode: 0o644 },
+			]),
+		).rejects.toMatchObject({ code: "EEXIST" });
+
+		expect(bulkIngestMock).not.toHaveBeenCalled();
+		expect(transactionMock.mock.calls.length).toBe(txCallsBefore);
 	});
 });

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -366,10 +366,24 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	// `#dirty = true` must be set AFTER `reload()` because `reload()` clears it,
 	// and `publishVersionIfDirty` at session-finalize needs to see dirty=true so
 	// other replicas pick up the new tree.
+	//
+	// Every input path is normalized via `validatePath` (rejects null bytes,
+	// resolves `.`/`..`) before reaching the dialect, matching the contract used
+	// by every other write method on this class. Two inputs that normalize to
+	// the same final path are rejected with EEXIST rather than silently
+	// shadowing each other — the dialect would commit only one and drop the rest.
 	async bulkIngest(files: BulkIngestFile[]): Promise<void> {
 		if (files.length === 0) return;
+		const normalized: BulkIngestFile[] = [];
+		const seen = new Set<string>();
+		for (const file of files) {
+			const path = validatePath(file.path);
+			if (seen.has(path)) throw createEexist(path);
+			seen.add(path);
+			normalized.push({ path, content: file.content, mode: file.mode });
+		}
 		await this.#withTx(async (tx) => {
-			await this.#dialect.bulkIngest(tx, files);
+			await this.#dialect.bulkIngest(tx, normalized);
 		});
 		await this.reload();
 		this.#dirty = true;

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -22,7 +22,7 @@ import {
 	createEperm,
 } from "./errors.js";
 import { type RedisPathSnapshot, versionKey } from "./redis-path-snapshot.js";
-import { INODE_KIND, type PathCacheEntry, type SqlDialect } from "./types.js";
+import { type BulkIngestFile, INODE_KIND, type PathCacheEntry, type SqlDialect } from "./types.js";
 
 /**
  * Normalize a virtual filesystem path: resolve `.` and `..` components,
@@ -94,6 +94,12 @@ export interface ICoherentFs extends IFileSystem {
 	wasDirty(): boolean;
 	/** Resets the dirty flag — called after publishing a new version. */
 	clearDirty(): void;
+	/**
+	 * Bulk-inserts files into the sandbox in minimal DB round-trips, creating
+	 * any missing parent directories. After commit, repopulates the in-memory
+	 * pathCache via reload() and marks the FS dirty.
+	 */
+	bulkIngest(files: BulkIngestFile[]): Promise<void>;
 }
 
 export class SqlFs<Tx = unknown> implements ICoherentFs {
@@ -355,6 +361,25 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		})();
 		this.#pendingReload = p;
 		return p;
+	}
+
+	/**
+	 * Bulk-inserts files via the dialect's `bulkIngest` (multi-row INSERT for
+	 * blobs/inodes/dirents) inside one transaction. Cache coherence is restored
+	 * by `reload()`; contentCache fills lazily on first read.
+	 *
+	 * The dirty flag is set AFTER `reload()` because `reload()` resets it to
+	 * false on completion. Setting it last preserves the multi-replica version
+	 * bookkeeping contract (publishVersionIfDirty needs to see dirty=true at
+	 * session-finalize so other replicas pick up the new tree).
+	 */
+	async bulkIngest(files: BulkIngestFile[]): Promise<void> {
+		if (files.length === 0) return;
+		await this.#withTx(async (tx) => {
+			await this.#dialect.bulkIngest(tx, files);
+		});
+		await this.reload();
+		this.#dirty = true;
 	}
 
 	// ── IFileSystem: cache-served methods ────────────────────────────────────────

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -363,16 +363,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		return p;
 	}
 
-	/**
-	 * Bulk-inserts files via the dialect's `bulkIngest` (multi-row INSERT for
-	 * blobs/inodes/dirents) inside one transaction. Cache coherence is restored
-	 * by `reload()`; contentCache fills lazily on first read.
-	 *
-	 * The dirty flag is set AFTER `reload()` because `reload()` resets it to
-	 * false on completion. Setting it last preserves the multi-replica version
-	 * bookkeeping contract (publishVersionIfDirty needs to see dirty=true at
-	 * session-finalize so other replicas pick up the new tree).
-	 */
+	// `#dirty = true` must be set AFTER `reload()` because `reload()` clears it,
+	// and `publishVersionIfDirty` at session-finalize needs to see dirty=true so
+	// other replicas pick up the new tree.
 	async bulkIngest(files: BulkIngestFile[]): Promise<void> {
 		if (files.length === 0) return;
 		await this.#withTx(async (tx) => {


### PR DESCRIPTION
## Summary

- Wires the existing `PostgresDialect.bulkIngest` end-to-end via a new public `SqlFs.bulkIngest()` so `POST /v1/sandboxes/:id/ingest-files` commits the whole batch in ~5 DB round-trips instead of 3N sequential round-trips.
- Removes the tar.gz `POST /v1/sandboxes/:id/ingest` route — it cannot complete within ACA's 240 s gateway window because `tar -xzf` inside just-bash forces 3N round-trips.
- Updates the `/virtualfs-api` slash command and skill reference suite to match (drops the deleted route from docs, adds a focused `examples/ingest-files.sh` for uploading a local folder).

Closes #14. Follow-up tracked in #16 (`pnpm push` CLI helper).

## Why

\`POST /ingest\` (tar.gz) and the previous \`POST /ingest-files\` (per-file \`writeFile\` loop) both made 3 sequential Postgres round-trips per file (\`upsertBlob\` → \`createInode\` → \`insertDirent\`). On AUS-East → Neon at ~300 ms/round-trip, ~120 TS files = ~36 s minimum, plus interpreter overhead — reliably tripping the ACA 240 s gateway timeout. The dialect already had \`bulkIngest\` (US-017) doing the whole job in ~5 round-trips total via multi-row INSERTs, but no route was calling it.

## Manual verification (local Docker postgres + redis)

| Scenario | Before | After |
|---|---|---|
| 37 files (~310 KB JSON) | n/a (route hung) | **200 OK in 58 ms** |
| 151 files (~1.2 MB JSON) | exceeds 240 s | **200 OK in 69 ms** |
| Redis \`vfs:default:ver:<sandbox>\` after ingest | — | bumps to 1 ✅ |
| \`exec-sync\` \`ls && wc -l && head\` against ingested tree | n/a | exit=0, contents match |
| \`POST /ingest\` (deleted route) | n/a | **404** ✅ |

Subtle bug caught during live verification: \`SqlFs.reload()\` clears \`#dirty\` at its tail, so the original ordering (\`#dirty = true\` then \`await reload()\`) silently broke \`publishVersionIfDirty\` and other replicas would never see the new tree. Fix: set \`#dirty = true\` **after** \`reload()\`. Confirmed via the Redis version key flipping from absent → 1 after the post-fix ingest.

## Cache-coherence wrapper contract

\`SqlFs.bulkIngest()\`:
1. No-op for empty file list (no tx, no reload).
2. Runs \`dialect.bulkIngest\` inside \`#withTx\` — acquires the per-sandbox advisory lock + sets \`app.sandbox_id\` for RLS.
3. Calls \`reload()\` afterward to rebuild \`pathCache\` via the recursive CTE; \`contentCache\` fills lazily.
4. Sets \`#dirty = true\` AFTER reload so the leader/follower version bookkeeping fires.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint:fix\` — no fixes
- [x] \`pnpm test:unit\` — 457 pass / 4 skipped (no DB)
  - New: \`src/fs/sql-fs/sql-fs.bulkingest.test.ts\` — 4 tests covering empty no-op, write-tx + lock + reload, post-reload \`stat()\` visibility, dialect-error propagation
  - New: bulkIngest-invocation regression test in \`src/api/__tests__/ingest.test.ts\` (asserts the route calls \`bulkIngest\` exactly once with the expected \`BulkIngestFile[]\`)
  - Removed: tar.gz \`/ingest\` tests
- [ ] \`pnpm test:integration\` against Postgres — new e2e test \`SqlFs.bulkIngest — end-to-end through cache-coherence wrapper\` ingests ~50 files across nested dirs and asserts \`stat\` + \`readFile\` for every entry (skips without \`DATABASE_URL\`)
- [x] Manual verification against local Docker Postgres+Redis (table above)

## Out of scope

- \`pnpm push <localDir> <sandboxId>\` CLI helper — tracked in #16
- Chunked uploads for very large repos — follow-up to #16
- MySQL / Azure SQL \`bulkIngest\` implementations — those dialects don't exist yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable example script to upload entire local folders via the JSON-manifest ingest and increased default batching for faster bulk uploads.
* **Documentation**
  * Consolidated docs to state a single supported ingest method, show recursive folder uploads, and update performance/timeout guidance for bulk uploads.
* **Deprecations**
  * Removed the legacy tar.gz ingest endpoint.
* **Tests**
  * Added and updated tests to validate manifest ingest, bulk ingest behavior, and strict path/base64 validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->