### PR TITLE
ci: GHCR image publish + CHANGELOG-driven GitHub releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build & push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,13 @@ jobs:
 
       - name: Get version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! [[ "$VERSION" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
+            echo "::error::Tag '$GITHUB_REF' produced invalid VERSION='$VERSION'. Docker tags must match [a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127} (no '+' build metadata, no leading '.' or '-')."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Extract CHANGELOG section for version
         id: changelog
@@ -53,6 +59,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Compute lowercase image name
+        id: image
+        run: |
+          REPO_LC=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+          echo "NAME=ghcr.io/${REPO_LC}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -64,7 +76,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.NAME }}
           tags: |
             type=raw,value=v${{ steps.version.outputs.VERSION }}
 
@@ -89,6 +101,6 @@ jobs:
 
             ---
 
-            **Image:** `ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.VERSION }}`
+            **Image:** `${{ steps.image.outputs.NAME }}:v${{ steps.version.outputs.VERSION }}`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
           fi
 
           CONTENT=$(awk -v ver="$VERSION" '
-            $0 ~ "^## \\["ver"\\]" { found=1; next }
+            BEGIN { header = "## [" ver "]" }
+            index($0, header) == 1 { found=1; next }
             found && /^## \[/ { exit }
             found { print }
           ' CHANGELOG.md | sed '/^$/d')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,17 @@ jobs:
             $0 ~ "^## \\["ver"\\]" { found=1; next }
             found && /^## \[/ { exit }
             found { print }
-          ' CHANGELOG.md | sed '/^$/d' | head -c 10000)
+          ' CHANGELOG.md | sed '/^$/d')
 
           if [ -z "$CONTENT" ] || [ "${CONTENT// /}" = "" ]; then
             echo "::error::No CHANGELOG entry found for version [$VERSION] in CHANGELOG.md"
             echo "::error::Please add a changelog entry with format: ## [$VERSION]"
+            exit 1
+          fi
+
+          BYTES=$(printf '%s' "$CONTENT" | wc -c)
+          if [ "$BYTES" -gt 10000 ]; then
+            echo "::error::CHANGELOG entry for [$VERSION] is $BYTES bytes; max 10000. Shorten the entry or raise the limit intentionally."
             exit 1
           fi
 
@@ -61,7 +67,6 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=v${{ steps.version.outputs.VERSION }}
-            type=raw,value=latest
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: Build, push & GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract CHANGELOG section for version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md not found"
+            exit 1
+          fi
+
+          CONTENT=$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\["ver"\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md | sed '/^$/d' | head -c 10000)
+
+          if [ -z "$CONTENT" ] || [ "${CONTENT// /}" = "" ]; then
+            echo "::error::No CHANGELOG entry found for version [$VERSION] in CHANGELOG.md"
+            echo "::error::Please add a changelog entry with format: ## [$VERSION]"
+            exit 1
+          fi
+
+          {
+            echo "CONTENT<<EOF"
+            echo "$CONTENT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=v${{ steps.version.outputs.VERSION }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release v${{ steps.version.outputs.VERSION }}
+          body: |
+            ## Release v${{ steps.version.outputs.VERSION }}
+
+            ${{ steps.changelog.outputs.CONTENT }}
+
+            ---
+
+            **Image:** `ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.VERSION }}`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-26
+
+### Added
+- Initial release of `virtualfs-api`: persistent filesystem backend + HTTP/MCP API for `just-bash` sandboxes.
+- SQL-backed `IFileSystem` implementation (`SqlFs`) with Postgres, MySQL, and Azure SQL dialects.
+- Adjacency-list directory model with content-addressable blob storage and global dedup.
+- Path cache (eager) and content cache (lazy LRU, 50 MB/session) for low-latency reads.
+- HTTP API (Hono): sandboxes CRUD, file operations, exec (sync + SSE), ingest/export, admin GC.
+- MCP server with 10 tools over streamable HTTP transport.
+- Bearer-token auth, RLS-based sandbox isolation, default-deny symlinks, error sanitization.
+- Multi-tenant routing and session rehydration.
+- Docker image and Azure Container Apps deployment config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-04-26
 
 ### Added
+
 - Initial release of `virtualfs-api`: persistent filesystem backend + HTTP/MCP API for `just-bash` sandboxes.
 - SQL-backed `IFileSystem` implementation (`SqlFs`) with Postgres, MySQL, and Azure SQL dialects.
 - Adjacency-list directory model with content-addressable blob storage and global dedup.


### PR DESCRIPTION
## Summary
- **`docker.yml`** — on every push to `main`, builds the API image and pushes `ghcr.io/<owner>/<repo>:latest` and `:sha-<short>` to GHCR. Uses the workflow's `GITHUB_TOKEN` (no PAT required), with GHA build cache.
- **`release.yml`** — on push of a `v*` tag, extracts the matching `## [<version>]` section from `CHANGELOG.md`, builds + pushes `:v<version>` and `:latest`, and creates a GitHub Release whose body is that changelog section. Fails loudly if no matching CHANGELOG entry exists for the tag.
- **`CHANGELOG.md`** — seeded in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with `## [Unreleased]` and `## [0.1.0]` sections.

## Release flow
1. Move items from `## [Unreleased]` into a new dated section (e.g. `## [0.2.0] - 2026-05-01`).
2. Merge to `main` — image auto-publishes via `docker.yml`.
3. `git tag v0.2.0 && git push origin v0.2.0` — `release.yml` fires, creates the GitHub Release with the changelog body and pins `:v0.2.0` in GHCR.

## Notes
- Repo name lowercases to `virtualfs` in the image path (`docker/metadata-action` handles that).
- The GHCR package is public, so no pull credentials are needed downstream.
- No deploy step (Azure / ACA) — this PR is image publishing + releases only.
- `docker.yml` runs in parallel with `ci.yml`; it does not gate on CI passing. Branch protection on `main` should require CI before merge.

## Test plan
- [ ] Merge this PR → confirm `Docker` workflow runs and `ghcr.io/<owner>/virtualfs:latest` + `:sha-<short>` appear in the Packages tab.
- [ ] After merge, push `git tag v0.1.0 && git push origin v0.1.0` → confirm `Release` workflow extracts the `[0.1.0]` section, publishes `:v0.1.0`, and creates a GitHub Release.
- [ ] Push a tag with no matching CHANGELOG entry → confirm the workflow fails with the expected error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image build & publish pipeline on pushes to main, producing tagged images (latest + SHA).
  * Added a release automation that validates version tags, builds and pushes release images, and creates GitHub Releases with extracted changelog content.
* **Documentation**
  * Added a CHANGELOG.md (Keep a Changelog) with an Unreleased section and an initial 0.1.0 entry summarizing core features and deployment notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->