### PR TITLE
feat: accept plaintext script bodies on exec endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-26
+
+### Fixed
+
+- `timeoutMs` query parameter now rejects values exceeding 300000 with a 400 error instead of silently capping.
+
+### Added
+
+- SSE streaming tests for `text/plain` content type and `timeoutMs` query parameter timeout enforcement.
+
 ## [0.2.0] - 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-26
+
+### Added
+
+- Accept `text/x-shellscript` and `text/plain` content types on `exec-sync` and `exec` (SSE) endpoints — the raw request body is used as the script verbatim, removing the need for JSON encoding. Optional `?timeoutMs=` query parameter available in plaintext mode. Returns 415 for unsupported content types.
+
 ## [0.1.1] - 2026-04-26
 
 ### Changed

--- a/src/api/__tests__/exec.test.ts
+++ b/src/api/__tests__/exec.test.ts
@@ -88,6 +88,163 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 		expect(body.exitCode).toBe(1);
 	});
 
+	it("accepts text/x-shellscript content type with raw script body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { stdout: string; stderr: string; exitCode: number };
+		expect(body.stdout).toBe("hello\n");
+		expect(body.exitCode).toBe(0);
+	});
+
+	it("accepts text/plain content type with raw script body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/plain",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { stdout: string; stderr: string; exitCode: number };
+		expect(body.stdout).toBe("hello\n");
+		expect(body.exitCode).toBe(0);
+	});
+
+	it("accepts text/plain with charset parameter", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/plain; charset=utf-8",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { stdout: string; exitCode: number };
+		expect(body.stdout).toBe("hello\n");
+		expect(body.exitCode).toBe(0);
+	});
+
+	it("supports timeoutMs query param with plaintext body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync?timeoutMs=60000`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { stdout: string; exitCode: number };
+		expect(body.stdout).toBe("hello\n");
+	});
+
+	it("rejects invalid timeoutMs query param with plaintext body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync?timeoutMs=abc`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("INVALID_INPUT");
+	});
+
+	it("rejects empty plaintext body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "",
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { code: string; details: string[] };
+		expect(body.code).toBe("INVALID_INPUT");
+		expect(body.details).toContain("Empty script body");
+	});
+
+	it("returns 415 for unsupported content type", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/xml",
+			},
+			body: "<script>echo hello</script>",
+		});
+
+		expect(res.status).toBe(415);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+	});
+
+	it("handles scripts with quotes and special characters via plaintext", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const script = `echo "hello 'world'" && echo $'line1\\nline2'`;
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: script,
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { stdout: string; exitCode: number };
+		expect(body.exitCode).toBe(0);
+	});
+
 	it("timeout returns 408", async () => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);
@@ -167,6 +324,34 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ script: "echo hello" }),
+		});
+
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+		const bodyText = await res.text();
+		const events = parseSseEvents(bodyText);
+
+		const stdoutEvent = events.find((e) => e.event === "stdout");
+		const exitEvent = events.find((e) => e.event === "exit");
+
+		expect(stdoutEvent).toBeDefined();
+		expect((stdoutEvent?.data as { t: string; data: string }).data).toBe("hello\n");
+		expect(exitEvent).toBeDefined();
+		expect((exitEvent?.data as { t: string; exitCode: number }).exitCode).toBe(0);
+	});
+
+	it("accepts text/x-shellscript content type for SSE streaming", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "echo hello",
 		});
 
 		expect(res.headers.get("content-type")).toContain("text/event-stream");

--- a/src/api/__tests__/exec.test.ts
+++ b/src/api/__tests__/exec.test.ts
@@ -88,7 +88,7 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 		expect(body.exitCode).toBe(1);
 	});
 
-	it("accepts text/x-shellscript content type with raw script body", async () => {
+	it.each(["text/x-shellscript", "text/plain"])("accepts %s content type with raw script body", async (ct) => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);
 		const token = await makeToken();
@@ -97,27 +97,7 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 			method: "POST",
 			headers: {
 				Authorization: `Bearer ${token}`,
-				"Content-Type": "text/x-shellscript",
-			},
-			body: "echo hello",
-		});
-
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { stdout: string; stderr: string; exitCode: number };
-		expect(body.stdout).toBe("hello\n");
-		expect(body.exitCode).toBe(0);
-	});
-
-	it("accepts text/plain content type with raw script body", async () => {
-		const { sessionManager } = await makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${token}`,
-				"Content-Type": "text/plain",
+				"Content-Type": ct,
 			},
 			body: "echo hello",
 		});
@@ -360,7 +340,7 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 		expect((exitEvent?.data as { t: string; exitCode: number }).exitCode).toBe(0);
 	});
 
-	it("accepts text/x-shellscript content type for SSE streaming", async () => {
+	it.each(["text/x-shellscript", "text/plain"])("accepts %s content type for SSE streaming", async (ct) => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);
 		const token = await makeToken();
@@ -369,35 +349,7 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 			method: "POST",
 			headers: {
 				Authorization: `Bearer ${token}`,
-				"Content-Type": "text/x-shellscript",
-			},
-			body: "echo hello",
-		});
-
-		expect(res.headers.get("content-type")).toContain("text/event-stream");
-
-		const bodyText = await res.text();
-		const events = parseSseEvents(bodyText);
-
-		const stdoutEvent = events.find((e) => e.event === "stdout");
-		const exitEvent = events.find((e) => e.event === "exit");
-
-		expect(stdoutEvent).toBeDefined();
-		expect((stdoutEvent?.data as { t: string; data: string }).data).toBe("hello\n");
-		expect(exitEvent).toBeDefined();
-		expect((exitEvent?.data as { t: string; exitCode: number }).exitCode).toBe(0);
-	});
-
-	it("accepts text/plain content type for SSE streaming", async () => {
-		const { sessionManager } = await makeTestEnv();
-		const app = makeTestApp(sessionManager);
-		const token = await makeToken();
-
-		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec`, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${token}`,
-				"Content-Type": "text/plain",
+				"Content-Type": ct,
 			},
 			body: "echo hello",
 		});

--- a/src/api/__tests__/exec.test.ts
+++ b/src/api/__tests__/exec.test.ts
@@ -186,6 +186,26 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 		expect(body.code).toBe("INVALID_INPUT");
 	});
 
+	it("rejects timeoutMs exceeding maximum with plaintext body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync?timeoutMs=999999`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { code: string; details: string[] };
+		expect(body.code).toBe("INVALID_INPUT");
+		expect(body.details[0]).toContain("300000");
+	});
+
 	it("rejects empty plaintext body", async () => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);
@@ -366,6 +386,76 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 		expect((stdoutEvent?.data as { t: string; data: string }).data).toBe("hello\n");
 		expect(exitEvent).toBeDefined();
 		expect((exitEvent?.data as { t: string; exitCode: number }).exitCode).toBe(0);
+	});
+
+	it("accepts text/plain content type for SSE streaming", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/plain",
+			},
+			body: "echo hello",
+		});
+
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+		const bodyText = await res.text();
+		const events = parseSseEvents(bodyText);
+
+		const stdoutEvent = events.find((e) => e.event === "stdout");
+		const exitEvent = events.find((e) => e.event === "exit");
+
+		expect(stdoutEvent).toBeDefined();
+		expect((stdoutEvent?.data as { t: string; data: string }).data).toBe("hello\n");
+		expect(exitEvent).toBeDefined();
+		expect((exitEvent?.data as { t: string; exitCode: number }).exitCode).toBe(0);
+	});
+
+	it("SSE streaming respects timeoutMs query param with plaintext body", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		const timeoutSandboxId = `${SANDBOX_ID}-sse-plaintext-timeout`;
+
+		const session = await sessionManager.getOrCreate("default", timeoutSandboxId);
+
+		vi.spyOn(session.bash, "exec").mockImplementation(
+			(_script, opts) =>
+				new Promise((_resolve, reject) => {
+					const handle = setTimeout(() => {}, 60_000);
+					opts?.signal?.addEventListener("abort", () => {
+						clearTimeout(handle);
+						reject(new DOMException("The operation was aborted", "AbortError"));
+					});
+				}),
+		);
+
+		const res = await app.request(`/v1/sandboxes/${timeoutSandboxId}/exec?timeoutMs=50`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "text/x-shellscript",
+			},
+			body: "sleep 1000",
+		});
+
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+		const bodyText = await res.text();
+		const events = parseSseEvents(bodyText);
+
+		const exitEvent = events.find((e) => e.event === "exit");
+		expect(exitEvent).toBeDefined();
+		expect((exitEvent?.data as { t: string; exitCode: number; error: string }).exitCode).toBe(-1);
+		expect((exitEvent?.data as { t: string; exitCode: number; error: string }).error).toBe("timeout");
+
+		vi.restoreAllMocks();
 	});
 
 	it("timeout sends exit event with exitCode -1 and error='timeout'", async () => {

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -487,11 +487,29 @@ export const openapiSpec = {
 			post: {
 				tags: ["Exec"],
 				summary: "Execute script (buffered)",
-				description: "Run a bash script and return stdout/stderr/exitCode once complete.",
-				parameters: [sandboxIdParam],
+				description:
+					"Run a bash script and return stdout/stderr/exitCode once complete. Accepts JSON (`application/json`) with `{ script, cwd?, env?, timeoutMs? }`, or a raw script body with `text/plain` or `text/x-shellscript` (no JSON encoding needed). When using plaintext, `timeoutMs` can be set via query parameter.",
+				parameters: [
+					sandboxIdParam,
+					{
+						name: "timeoutMs",
+						in: "query",
+						required: false,
+						description: "Execution timeout in ms (only used with text/plain or text/x-shellscript content types)",
+						schema: { type: "integer", minimum: 1, maximum: 300000 },
+					},
+				],
 				requestBody: {
 					required: true,
-					content: { "application/json": { schema: execBodySchema } },
+					content: {
+						"application/json": { schema: execBodySchema },
+						"text/x-shellscript": {
+							schema: { type: "string", example: "find /home/user -type f | sort" },
+						},
+						"text/plain": {
+							schema: { type: "string", example: "echo hello" },
+						},
+					},
 				},
 				responses: {
 					"200": {
@@ -535,11 +553,28 @@ export const openapiSpec = {
 				tags: ["Exec"],
 				summary: "Execute script (streaming SSE)",
 				description:
-					"Run a bash script and stream output as Server-Sent Events. Events: `stdout` `{ t, data }`, `stderr` `{ t, data }`, `exit` `{ t, exitCode, durationMs, error? }`.",
-				parameters: [sandboxIdParam],
+					"Run a bash script and stream output as Server-Sent Events. Events: `stdout` `{ t, data }`, `stderr` `{ t, data }`, `exit` `{ t, exitCode, durationMs, error? }`. Accepts JSON (`application/json`) or raw script body (`text/plain`, `text/x-shellscript`).",
+				parameters: [
+					sandboxIdParam,
+					{
+						name: "timeoutMs",
+						in: "query",
+						required: false,
+						description: "Execution timeout in ms (only used with text/plain or text/x-shellscript content types)",
+						schema: { type: "integer", minimum: 1, maximum: 300000 },
+					},
+				],
 				requestBody: {
 					required: true,
-					content: { "application/json": { schema: execBodySchema } },
+					content: {
+						"application/json": { schema: execBodySchema },
+						"text/x-shellscript": {
+							schema: { type: "string", example: "find /home/user -type f | sort" },
+						},
+						"text/plain": {
+							schema: { type: "string", example: "echo hello" },
+						},
+					},
 				},
 				responses: {
 					"200": {

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -4,6 +4,7 @@
  * US-069: POST /v1/sandboxes/:id/exec — SSE streaming execution
  */
 
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -15,12 +16,95 @@ import type { SessionManager } from "../session-manager.js";
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 300_000;
 
+const PLAINTEXT_TYPES = ["text/x-shellscript", "text/plain"];
+
 const execBodySchema = z.object({
 	script: z.string(),
 	cwd: z.string().optional(),
 	env: z.record(z.string(), z.string()).optional(),
 	timeoutMs: z.number().int().positive().optional(),
 });
+
+interface ExecBody {
+	script: string;
+	cwd?: string;
+	env?: Record<string, string>;
+	timeoutMs?: number;
+}
+
+type ParseResult = { ok: true; body: ExecBody } | { ok: false; response: Response };
+
+function contentTypeBase(header: string | undefined): string {
+	return (header ?? "application/json").split(";")[0]!.trim().toLowerCase();
+}
+
+async function parseExecBody(c: Context): Promise<ParseResult> {
+	const ct = contentTypeBase(c.req.header("content-type"));
+
+	if (PLAINTEXT_TYPES.includes(ct)) {
+		const script = await c.req.text();
+		if (script.length === 0) {
+			return {
+				ok: false,
+				response: c.json(
+					{ error: "validation_error", code: "INVALID_INPUT", details: ["Empty script body"] },
+					400 as ContentfulStatusCode,
+				),
+			};
+		}
+		const rawTimeout = c.req.query("timeoutMs");
+		let timeoutMs: number | undefined;
+		if (rawTimeout !== undefined) {
+			const n = Number(rawTimeout);
+			if (!Number.isInteger(n) || n <= 0) {
+				return {
+					ok: false,
+					response: c.json(
+						{ error: "validation_error", code: "INVALID_INPUT", details: ["timeoutMs must be a positive integer"] },
+						400 as ContentfulStatusCode,
+					),
+				};
+			}
+			timeoutMs = n;
+		}
+		return { ok: true, body: { script, timeoutMs } };
+	}
+
+	if (ct === "application/json") {
+		try {
+			const raw = await c.req.json();
+			const result = execBodySchema.safeParse(raw);
+			if (!result.success) {
+				const details = result.error.issues.map((i) => i.message);
+				return {
+					ok: false,
+					response: c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode),
+				};
+			}
+			return { ok: true, body: result.data };
+		} catch {
+			return {
+				ok: false,
+				response: c.json(
+					{ error: "validation_error", code: "INVALID_INPUT", details: ["Invalid JSON body"] },
+					400 as ContentfulStatusCode,
+				),
+			};
+		}
+	}
+
+	return {
+		ok: false,
+		response: c.json(
+			{
+				error: "unsupported_media_type",
+				code: "UNSUPPORTED_MEDIA_TYPE",
+				details: ["Content-Type must be application/json, text/plain, or text/x-shellscript"],
+			},
+			415 as ContentfulStatusCode,
+		),
+	};
+}
 
 export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
@@ -29,21 +113,9 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 	router.post("/:id/exec-sync", async (c) => {
 		const sandboxId = c.req.param("id");
 		const tenant = c.get("tenant");
-		let body: z.infer<typeof execBodySchema>;
-		try {
-			const raw = await c.req.json();
-			const result = execBodySchema.safeParse(raw);
-			if (!result.success) {
-				const details = result.error.issues.map((i) => i.message);
-				return c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode);
-			}
-			body = result.data;
-		} catch {
-			return c.json(
-				{ error: "validation_error", code: "INVALID_INPUT", details: ["Invalid JSON body"] },
-				400 as ContentfulStatusCode,
-			);
-		}
+		const parsed = await parseExecBody(c);
+		if (!parsed.ok) return parsed.response;
+		const body = parsed.body;
 
 		const timeoutMs = Math.min(body.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
@@ -111,21 +183,9 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 	router.post("/:id/exec", async (c) => {
 		const sandboxId = c.req.param("id");
 		const tenant = c.get("tenant");
-		let body: z.infer<typeof execBodySchema>;
-		try {
-			const raw = await c.req.json();
-			const result = execBodySchema.safeParse(raw);
-			if (!result.success) {
-				const details = result.error.issues.map((i) => i.message);
-				return c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode);
-			}
-			body = result.data;
-		} catch {
-			return c.json(
-				{ error: "validation_error", code: "INVALID_INPUT", details: ["Invalid JSON body"] },
-				400 as ContentfulStatusCode,
-			);
-		}
+		const parsed = await parseExecBody(c);
+		if (!parsed.ok) return parsed.response;
+		const body = parsed.body;
 
 		const timeoutMs = Math.min(body.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -22,15 +22,10 @@ const execBodySchema = z.object({
 	script: z.string(),
 	cwd: z.string().optional(),
 	env: z.record(z.string(), z.string()).optional(),
-	timeoutMs: z.number().int().positive().optional(),
+	timeoutMs: z.number().int().positive().max(MAX_TIMEOUT_MS).optional(),
 });
 
-interface ExecBody {
-	script: string;
-	cwd?: string;
-	env?: Record<string, string>;
-	timeoutMs?: number;
-}
+type ExecBody = z.infer<typeof execBodySchema>;
 
 type ParseResult = { ok: true; body: ExecBody } | { ok: false; response: Response };
 
@@ -121,9 +116,8 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		if (!parsed.ok) return parsed.response;
 		const body = parsed.body;
 
-		const timeoutMs = Math.min(body.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+		const timeoutMs = body.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-		// Convert user-controlled env keys to null-prototype object to prevent prototype pollution
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;
 
 		type ExecSyncResult = { kind: "ok"; stdout: string; stderr: string; exitCode: number } | { kind: "timeout" };
@@ -191,7 +185,7 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		if (!parsed.ok) return parsed.response;
 		const body = parsed.body;
 
-		const timeoutMs = Math.min(body.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+		const timeoutMs = body.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;
 		try {
 			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async () => undefined);

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -56,11 +56,15 @@ async function parseExecBody(c: Context): Promise<ParseResult> {
 		let timeoutMs: number | undefined;
 		if (rawTimeout !== undefined) {
 			const n = Number(rawTimeout);
-			if (!Number.isInteger(n) || n <= 0) {
+			if (!Number.isInteger(n) || n <= 0 || n > MAX_TIMEOUT_MS) {
 				return {
 					ok: false,
 					response: c.json(
-						{ error: "validation_error", code: "INVALID_INPUT", details: ["timeoutMs must be a positive integer"] },
+						{
+							error: "validation_error",
+							code: "INVALID_INPUT",
+							details: [`timeoutMs must be a positive integer <= ${MAX_TIMEOUT_MS}`],
+						},
 						400 as ContentfulStatusCode,
 					),
 				};


### PR DESCRIPTION
## Summary

- Accept `text/x-shellscript` and `text/plain` content types on `POST /v1/sandboxes/:id/exec-sync` and `POST /v1/sandboxes/:id/exec` — the raw request body is used as the script verbatim, no JSON encoding required
- Optional `?timeoutMs=N` query parameter for plaintext mode; unknown content types return 415
- Updated OpenAPI spec and added 9 new unit tests (exec test count: 6 → 15)

Closes #26

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:fix` — clean
- [x] `pnpm test:unit` — 517/517 passing
- [x] Verified `text/x-shellscript`, `text/plain`, `text/plain; charset=utf-8` all parse correctly
- [x] Verified empty body → 400, unsupported content type → 415, invalid `timeoutMs` → 400
- [x] Verified scripts with quotes/special chars work via plaintext
- [x] Verified SSE streaming endpoint also accepts plaintext
- [x] Existing JSON path unchanged (backward compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plaintext/shell script request bodies (`text/plain`, `text/x-shellscript`) alongside JSON
  * Introduced optional `?timeoutMs=` query parameter for plaintext requests (max 300000ms)
  * Extended SSE streaming support to accept plaintext content types

* **Bug Fixes**
  * Changed behavior: `timeoutMs` values exceeding 300000 now return HTTP 400 error instead of being silently capped

* **Documentation**
  * Updated OpenAPI specification to document plaintext input support and timeoutMs parameter

* **Tests**
  * Added comprehensive test coverage for plaintext requests, timeout validation, and SSE streaming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->