### PR TITLE
feat: list sandboxes endpoint, MCP tool, and sandbox name (v0.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-04-28
+
+### Added
+
+- `GET /v1/sandboxes` — list all sandboxes owned by the authenticated user, queried directly from Postgres for accuracy across replicas.
+- `sandbox_list` MCP tool providing the same listing capability to MCP clients.
+- `name` field on sandboxes: optional human-readable name (`TEXT`, max 255 chars) set at creation time via `POST /v1/sandboxes` body or `sandbox_create` MCP tool. Returned in create, get, and list responses.
+- Postgres migration `0003_add_sandbox_name.sql` adding the `name` column.
+- `listSandboxes` method on `SqlDialect` interface and Postgres dialect implementation.
+- OpenAPI spec updated with the new list endpoint and `name` field on all sandbox schemas.
+
 ## [0.2.5] - 2026-04-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,13 +247,17 @@ tasks/
   IMPLEMENT.md                   ← 6-phase implementation plan
 ```
 
-## Changelog Requirement
+## Changelog & Version Bump Requirement
 
-**Always update `CHANGELOG.md` before pushing any branch.** Rules:
+**Always update `CHANGELOG.md` AND bump the version before pushing any branch.** Rules:
 
 - **Never use `[Unreleased]`** — always use a concrete version number.
 - **Always auto-increment** from the current topmost version: patch bump (`0.1.0` → `0.1.1`) for fixes/chores/docs; minor bump (`0.1.x` → `0.2.0`) for new features; major bump for breaking changes.
 - Add a dated section header: `## [x.y.z] - YYYY-MM-DD` and one or more bullets under `Added` / `Changed` / `Fixed` / `Removed`.
+- **Bump the version in ALL of these places** (they must all match the new CHANGELOG version):
+  - `package.json` → `"version"` field
+  - `pnpm-lock.yaml` → run `pnpm install --lockfile-only` after updating package.json
+  - `src/api/openapi-spec.ts` → `info.version` field
 - The release pipeline reads the topmost versioned section to determine whether to cut a new GitHub Release — if the tag already exists it skips; a new version triggers a release automatically on merge to `main`.
 
 ## Implementation Guidance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.1.0",
+	"version": "0.2.6",
 	"description": "Persistent filesystem backends (Postgres/MySQL/Azure SQL/FileShare) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/src/api/__tests__/exec-batch.test.ts
+++ b/src/api/__tests__/exec-batch.test.ts
@@ -212,7 +212,12 @@ describe("POST /v1/sandboxes/:id/exec-sync-batch", () => {
 		});
 		await mgr.withSession("default", SANDBOX_ID, async (session) => {
 			session.owner = "agent-1";
-			await mgr.persistSandboxMeta("default", SANDBOX_ID, { owner: "agent-1", python: false, javascript: false });
+			await mgr.persistSandboxMeta("default", SANDBOX_ID, {
+				owner: "agent-1",
+				name: null,
+				python: false,
+				javascript: false,
+			});
 		});
 
 		const app = makeTestApp(mgr);

--- a/src/api/__tests__/exec.test.ts
+++ b/src/api/__tests__/exec.test.ts
@@ -511,6 +511,7 @@ describe("POST /v1/sandboxes/:id/exec (SSE streaming)", () => {
 			session.owner = "agent-1";
 			await ownerManager.persistSandboxMeta("default", SANDBOX_ID, {
 				owner: "agent-1",
+				name: null,
 				python: false,
 				javascript: false,
 			});

--- a/src/api/__tests__/files.test.ts
+++ b/src/api/__tests__/files.test.ts
@@ -188,6 +188,7 @@ describe("PUT /v1/sandboxes/:id/files/*path", () => {
 			session.owner = "agent-1";
 			await ownerManager.persistSandboxMeta("default", SANDBOX_ID, {
 				owner: "agent-1",
+				name: null,
 				python: false,
 				javascript: false,
 			});

--- a/src/api/__tests__/ingest.test.ts
+++ b/src/api/__tests__/ingest.test.ts
@@ -273,6 +273,7 @@ describe("POST /v1/sandboxes/:id/ingest-files", () => {
 			session.owner = "agent-1";
 			await ownerManager.persistSandboxMeta("default", SANDBOX_ID, {
 				owner: "agent-1",
+				name: null,
 				python: false,
 				javascript: false,
 			});

--- a/src/api/__tests__/session-manager.rehydrate.test.ts
+++ b/src/api/__tests__/session-manager.rehydrate.test.ts
@@ -33,7 +33,7 @@ function makeSessionManager(): SessionManager {
 	});
 }
 
-const DEFAULT_META: SandboxMeta = { owner: null, python: false, javascript: false };
+const DEFAULT_META: SandboxMeta = { owner: null, name: null, python: false, javascript: false };
 
 describe("SessionManager.withSessionOrRehydrate()", () => {
 	let sm: SessionManager;
@@ -102,7 +102,7 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 	});
 
 	it("restores owner from PG metadata on rehydration", async () => {
-		pgSandboxes.set("sb-owned", { owner: "user-a", python: false, javascript: false });
+		pgSandboxes.set("sb-owned", { owner: "user-a", name: null, python: false, javascript: false });
 
 		let capturedOwner = "";
 		await sm.withSessionOrRehydrate("default", "sb-owned", async (session) => {
@@ -112,7 +112,7 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 	});
 
 	it("restores runtime options from PG metadata on rehydration", async () => {
-		pgSandboxes.set("sb-py", { owner: null, python: true, javascript: false });
+		pgSandboxes.set("sb-py", { owner: null, name: null, python: true, javascript: false });
 
 		let capturedRuntime = { python: false, javascript: false };
 		await sm.withSessionOrRehydrate("default", "sb-py", async (session) => {
@@ -124,7 +124,12 @@ describe("SessionManager.withSessionOrRehydrate()", () => {
 	it("persistSandboxMeta writes to store and is readable on rehydration", async () => {
 		await sm.withSession("default", "sb-meta", async (session) => {
 			session.owner = "creator";
-			await sm.persistSandboxMeta("default", "sb-meta", { owner: "creator", python: true, javascript: false });
+			await sm.persistSandboxMeta("default", "sb-meta", {
+				owner: "creator",
+				name: null,
+				python: true,
+				javascript: false,
+			});
 		});
 
 		// Simulate pool eviction by creating a new manager with same store

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -23,20 +23,24 @@ const MAX_TIMEOUT_MS = 300_000;
 export function registerTools(server: McpServer, sessionManager: SessionManager, owner: string, tenant: string): void {
 	server.tool(
 		"sandbox_create",
-		"Create an isolated bash sandbox with a virtual filesystem. Optional runtime flags opt in to python3/python (CPython WASM, stdlib only) and js-exec/node (QuickJS WASM) commands.",
+		"Create an isolated bash sandbox with a virtual filesystem. Optional runtime flags opt in to python3/python (CPython WASM, stdlib only) and js-exec/node (QuickJS WASM) commands. Optional name for human-readable identification.",
 		{
+			name: z.string().max(255).optional().describe("Human-readable name for the sandbox"),
 			python: z.boolean().optional(),
 			javascript: z.boolean().optional(),
 		},
 		async (args) => {
 			const id = randomUUID();
+			const name = args.name ?? null;
 			const runtimeOptions = {
 				python: args.python ?? false,
 				javascript: args.javascript ?? false,
 			};
-			await sessionManager.getOrCreate(tenant, id, runtimeOptions, owner);
+			const session = await sessionManager.getOrCreate(tenant, id, runtimeOptions, owner);
+			session.name = name;
 			await sessionManager.persistSandboxMeta(tenant, id, {
 				owner,
+				name,
 				python: runtimeOptions.python,
 				javascript: runtimeOptions.javascript,
 			});
@@ -44,10 +48,43 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				content: [
 					{
 						type: "text" as const,
-						text: JSON.stringify({ id, python: runtimeOptions.python, javascript: runtimeOptions.javascript }),
+						text: JSON.stringify({ id, name, python: runtimeOptions.python, javascript: runtimeOptions.javascript }),
 					},
 				],
 			};
+		},
+	);
+
+	server.tool(
+		"sandbox_list",
+		"List all sandboxes owned by the current user. Returns id, name, owner, createdAt, and runtime flags for each sandbox.",
+		{},
+		async () => {
+			try {
+				const sandboxes = await sessionManager.listSandboxes(tenant, owner);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								sandboxes: sandboxes.map((s) => ({
+									id: s.id,
+									name: s.name,
+									owner: s.owner,
+									createdAt: s.createdAt.toISOString(),
+									python: s.python,
+									javascript: s.javascript,
+								})),
+							}),
+						},
+					],
+				};
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return {
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+				};
+			}
 		},
 	);
 

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -17,23 +17,25 @@ const sandboxSchema = {
 	type: "object",
 	properties: {
 		id: { type: "string", format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" },
+		name: { type: "string", nullable: true, example: "my-project-sandbox" },
 		owner: { type: "string", example: "alice" },
 		createdAt: { type: "string", format: "date-time" },
 		python: { type: "boolean", example: false },
 		javascript: { type: "boolean", example: false },
 	},
-	required: ["id", "owner", "createdAt", "python", "javascript"],
+	required: ["id", "name", "owner", "createdAt", "python", "javascript"],
 } as const;
 
 const sandboxInfoSchema = {
 	type: "object",
 	properties: {
 		id: { type: "string", format: "uuid" },
+		name: { type: "string", nullable: true },
 		owner: { type: "string" },
 		createdAt: { type: "string", format: "date-time" },
 		lastUsedAt: { type: "string", format: "date-time" },
 	},
-	required: ["id", "owner", "createdAt", "lastUsedAt"],
+	required: ["id", "name", "owner", "createdAt", "lastUsedAt"],
 } as const;
 
 const treeEntrySchema = {
@@ -76,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.3",
+		version: "0.2.6",
 		description:
 			"Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres, MySQL, Azure SQL, or Azure FileShare.",
 	},
@@ -241,6 +243,30 @@ export const openapiSpec = {
 
 		// ── Sandboxes ─────────────────────────────────────────────────────────────
 		"/sandboxes": {
+			get: {
+				tags: ["Sandboxes"],
+				summary: "List sandboxes",
+				description: "List all sandboxes owned by the authenticated user.",
+				responses: {
+					"200": {
+						description: "Sandbox list",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										sandboxes: {
+											type: "array",
+											items: { $ref: "#/components/schemas/Sandbox" },
+										},
+									},
+									required: ["sandboxes"],
+								},
+							},
+						},
+					},
+				},
+			},
 			post: {
 				tags: ["Sandboxes"],
 				summary: "Create sandbox",
@@ -252,6 +278,11 @@ export const openapiSpec = {
 							schema: {
 								type: "object",
 								properties: {
+									name: {
+										type: "string",
+										maxLength: 255,
+										description: "Human-readable name for the sandbox",
+									},
 									env: {
 										type: "object",
 										additionalProperties: { type: "string" },

--- a/src/api/routes/sandboxes.ts
+++ b/src/api/routes/sandboxes.ts
@@ -13,6 +13,7 @@ import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from
 import type { SessionManager } from "../session-manager.js";
 
 const createBodySchema = z.object({
+	name: z.string().max(255).optional(),
 	env: z.record(z.string()).optional(),
 	files: z.record(z.string()).optional(),
 	python: z.boolean().optional(),
@@ -23,6 +24,7 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 	const router = new Hono<{ Variables: AuthVariables }>();
 
 	router.post("/", async (c) => {
+		let name: string | null = null;
 		let files: Record<string, string> | undefined;
 		let python = false;
 		let javascript = false;
@@ -35,6 +37,7 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 				const details = result.error.issues.map((i) => i.message);
 				return c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode);
 			}
+			name = result.data.name ?? null;
 			files = result.data.files;
 			python = result.data.python ?? false;
 			javascript = result.data.javascript ?? false;
@@ -52,8 +55,9 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 			sandboxId,
 			async (session) => {
 				if (!session.owner) session.owner = owner;
+				session.name = name;
 				session.createdAt = createdAt;
-				await sessionManager.persistSandboxMeta(tenant, sandboxId, { owner, python, javascript });
+				await sessionManager.persistSandboxMeta(tenant, sandboxId, { owner, name, python, javascript });
 				if (files !== undefined) {
 					for (const [path, content] of Object.entries(files)) {
 						await session.fs.writeFile(path, content);
@@ -64,7 +68,31 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 			owner,
 		);
 
-		return c.json({ id: sandboxId, owner, createdAt, python, javascript }, 201 as ContentfulStatusCode);
+		return c.json({ id: sandboxId, name, owner, createdAt, python, javascript }, 201 as ContentfulStatusCode);
+	});
+
+	router.get("/", async (c) => {
+		const tenant = c.get("tenant");
+		const caller = c.get("owner");
+		try {
+			const sandboxes = await sessionManager.listSandboxes(tenant, caller);
+			return c.json({
+				sandboxes: sandboxes.map((s) => ({
+					id: s.id,
+					name: s.name,
+					owner: s.owner,
+					createdAt: s.createdAt.toISOString(),
+					python: s.python,
+					javascript: s.javascript,
+				})),
+			});
+		} catch (err) {
+			const code = (err as Error & { code?: string }).code;
+			if (code === "ENOTSUP") {
+				return c.json({ error: "listing not supported", code: "ENOTSUP" }, 501 as ContentfulStatusCode);
+			}
+			throw err;
+		}
 	});
 
 	router.get("/:id", (c) => {
@@ -80,6 +108,7 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 		}
 		return c.json({
 			id,
+			name: session.name,
 			owner: session.owner,
 			createdAt: session.createdAt,
 			lastUsedAt: new Date(session.lastUsed).toISOString(),

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11,7 +11,7 @@ import { PostgresDialect } from "../fs/sql-fs/dialects/postgres.js";
 import { translateSqlError } from "../fs/sql-fs/errors.js";
 import { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { RedisPathSnapshot } from "../fs/sql-fs/redis-path-snapshot.js";
-import type { SandboxMeta } from "../fs/sql-fs/types.js";
+import type { SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { getRedisClient } from "../redis/client.js";
 import { parseNonNegativeInt } from "../redis/config.js";
 import { type AuthVariables, createAuthMiddleware } from "./auth.js";
@@ -116,6 +116,16 @@ async function persistSandboxMetaFn(tenantId: string, sandboxId: string, meta: S
 	}
 }
 
+async function listSandboxesFn(tenantId: string, owner?: string): Promise<SandboxListEntry[]> {
+	const backend = getOrInitMetaBackend(tenantId);
+	await ensureMetaConnected(backend);
+	try {
+		return await backend.dialect.transaction((tx) => backend.dialect.listSandboxes(tx, owner));
+	} catch (err) {
+		throw translateSqlError(err, "listSandboxes");
+	}
+}
+
 async function closeMetaFns(): Promise<void> {
 	for (const backend of metaBackends.values()) {
 		if (backend.connected) {
@@ -137,6 +147,7 @@ const sessionManager = new SessionManager({
 			: undefined,
 	getSandboxMetaFn,
 	persistSandboxMetaFn,
+	listSandboxesFn,
 });
 
 // ── Auth middleware (all /v1/* routes) ────────────────────────────────────────

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -21,7 +21,7 @@ import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/in
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import type { ICoherentFs } from "../fs/sql-fs/sql-fs.js";
-import type { PathCacheEntry, SandboxMeta } from "../fs/sql-fs/types.js";
+import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import type { TenantConfig } from "./tenants.js";
 
@@ -76,6 +76,7 @@ export interface Session {
 	readonly mutex: Mutex;
 	state: "active" | "closing";
 	owner: string;
+	name: string | null;
 	createdAt: string;
 	pathCacheBytes: number;
 	overBudget: boolean;
@@ -119,6 +120,11 @@ export interface SessionManagerOptions {
 	 * Called from `persistSandboxMeta` after sandbox creation.
 	 */
 	readonly persistSandboxMetaFn?: (tenantId: string, sandboxId: string, meta: SandboxMeta) => Promise<void>;
+	/**
+	 * Lists all sandboxes from the persistent store for the given tenant,
+	 * optionally filtered by owner.
+	 */
+	readonly listSandboxesFn?: (tenantId: string, owner?: string) => Promise<SandboxListEntry[]>;
 }
 
 interface Semaphore {
@@ -144,6 +150,7 @@ export class SessionManager {
 	private readonly blobCacheFactory: ((tenantId: string) => RedisBlobCache | undefined) | undefined;
 	private readonly getSandboxMetaFn?: (tenantId: string, sandboxId: string) => Promise<SandboxMeta | null>;
 	private readonly persistSandboxMetaFn?: (tenantId: string, sandboxId: string, meta: SandboxMeta) => Promise<void>;
+	private readonly listSandboxesFn?: (tenantId: string, owner?: string) => Promise<SandboxListEntry[]>;
 
 	private readonly pythonSem: Semaphore;
 	private readonly jsSem: Semaphore;
@@ -162,6 +169,7 @@ export class SessionManager {
 		blobCacheFactory,
 		getSandboxMetaFn,
 		persistSandboxMetaFn,
+		listSandboxesFn,
 	}: SessionManagerOptions) {
 		this.tenantConfig = tenantConfig;
 		this.createFsOverride = createFs;
@@ -180,6 +188,7 @@ export class SessionManager {
 		this.blobCacheFactory = blobCacheFactory;
 		this.getSandboxMetaFn = getSandboxMetaFn;
 		this.persistSandboxMetaFn = persistSandboxMetaFn;
+		this.listSandboxesFn = listSandboxesFn;
 		this.pythonSem = {
 			limit: maxConcurrentPython ?? Number(process.env.MAX_CONCURRENT_PYTHON ?? "5"),
 			inFlight: 0,
@@ -297,6 +306,7 @@ export class SessionManager {
 					mutex: new Mutex(),
 					state: "active",
 					owner: resolvedOwner,
+					name: null,
 					createdAt: new Date().toISOString(),
 					pathCacheBytes,
 					overBudget: pathCacheBytes > this.pathCacheMaxBytes,
@@ -487,6 +497,9 @@ export class SessionManager {
 		if (meta?.owner) {
 			session.owner = meta.owner;
 		}
+		if (meta?.name !== undefined) {
+			session.name = meta.name;
+		}
 		return this.withSessionEntry(tenantId, sandboxId, session, fn);
 	}
 
@@ -494,6 +507,13 @@ export class SessionManager {
 		if (this.persistSandboxMetaFn !== undefined) {
 			await this.persistSandboxMetaFn(tenantId, sandboxId, meta);
 		}
+	}
+
+	async listSandboxes(tenantId: string, owner?: string): Promise<SandboxListEntry[]> {
+		if (this.listSandboxesFn === undefined) {
+			throw Object.assign(new Error("listSandboxes not configured"), { code: "ENOTSUP" });
+		}
+		return this.listSandboxesFn(tenantId, owner);
 	}
 
 	async destroy(tenantId: string, sandboxId: string): Promise<boolean> {

--- a/src/fs/sql-fs/dialects/postgres.advisory-lock.test.ts
+++ b/src/fs/sql-fs/dialects/postgres.advisory-lock.test.ts
@@ -141,7 +141,7 @@ describe("PostgresDialect metadata helpers — SQL error translation", () => {
 		const { tx } = makeFakeTx();
 
 		await expect(
-			dialect.updateSandboxMeta(tx, "sandbox-missing", { owner: null, python: false, javascript: false }),
+			dialect.updateSandboxMeta(tx, "sandbox-missing", { owner: null, name: null, python: false, javascript: false }),
 		).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
@@ -150,7 +150,7 @@ describe("PostgresDialect metadata helpers — SQL error translation", () => {
 		const tx = makeRejectingTx(new Error("permission denied on /var/lib/postgresql/data/base"));
 
 		await expect(
-			dialect.updateSandboxMeta(tx, "sandbox-meta", { owner: null, python: false, javascript: false }),
+			dialect.updateSandboxMeta(tx, "sandbox-meta", { owner: null, name: null, python: false, javascript: false }),
 		).rejects.toMatchObject({
 			message: expect.stringContaining("[redacted]"),
 		});

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -15,6 +15,7 @@ import type {
 	InodeKind,
 	InodeRow,
 	PathCacheEntry,
+	SandboxListEntry,
 	SandboxMeta,
 	SqlDialect,
 	UpdateInodeOpts,
@@ -124,12 +125,12 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 
 	async getSandboxMeta(tx: PgTx, sandboxId: string): Promise<SandboxMeta | null> {
 		try {
-			const rows = await tx<{ owner: string | null; python: boolean; javascript: boolean }[]>`
-				SELECT owner, python, javascript FROM sandboxes WHERE id = ${sandboxId}
+			const rows = await tx<{ owner: string | null; name: string | null; python: boolean; javascript: boolean }[]>`
+				SELECT owner, name, python, javascript FROM sandboxes WHERE id = ${sandboxId}
 			`;
 			if (rows.length === 0) return null;
 			const r = rows[0]!;
-			return { owner: r.owner, python: r.python, javascript: r.javascript };
+			return { owner: r.owner, name: r.name, python: r.python, javascript: r.javascript };
 		} catch (err) {
 			throw translateSqlError(err, sandboxId);
 		}
@@ -140,7 +141,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		try {
 			rows = await tx<{ id: string }[]>`
 				UPDATE sandboxes
-				SET owner = ${meta.owner}, python = ${meta.python}, javascript = ${meta.javascript}
+				SET owner = ${meta.owner}, name = ${meta.name}, python = ${meta.python}, javascript = ${meta.javascript}
 				WHERE id = ${sandboxId}
 				RETURNING id
 			`;
@@ -149,6 +150,43 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		}
 		if (rows.length === 0) {
 			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+		}
+	}
+
+	async listSandboxes(tx: PgTx, owner?: string): Promise<SandboxListEntry[]> {
+		try {
+			const rows =
+				owner !== undefined
+					? await tx<
+							{
+								id: string;
+								name: string | null;
+								owner: string | null;
+								created_at: Date;
+								python: boolean;
+								javascript: boolean;
+							}[]
+						>`SELECT id, name, owner, created_at, python, javascript FROM sandboxes WHERE owner = ${owner} ORDER BY created_at DESC`
+					: await tx<
+							{
+								id: string;
+								name: string | null;
+								owner: string | null;
+								created_at: Date;
+								python: boolean;
+								javascript: boolean;
+							}[]
+						>`SELECT id, name, owner, created_at, python, javascript FROM sandboxes ORDER BY created_at DESC`;
+			return rows.map((r) => ({
+				id: r.id,
+				name: r.name,
+				owner: r.owner,
+				createdAt: r.created_at,
+				python: r.python,
+				javascript: r.javascript,
+			}));
+		} catch (err) {
+			throw translateSqlError(err, "listSandboxes");
 		}
 	}
 

--- a/src/fs/sql-fs/index.ts
+++ b/src/fs/sql-fs/index.ts
@@ -23,7 +23,7 @@ import { RedisPathSnapshot } from "./redis-path-snapshot.js";
 import { SqlFs } from "./sql-fs.js";
 import type { StorageBackend } from "./types.js";
 
-export type { InodeKind, StorageBackend } from "./types.js";
+export type { InodeKind, SandboxListEntry, StorageBackend } from "./types.js";
 
 /**
  * Options passed to the tenant-aware Postgres factory.

--- a/src/fs/sql-fs/migrations/postgres/0003_add_sandbox_name.sql
+++ b/src/fs/sql-fs/migrations/postgres/0003_add_sandbox_name.sql
@@ -1,0 +1,2 @@
+-- 0003: Add optional human-readable name to sandboxes
+ALTER TABLE sandboxes ADD COLUMN IF NOT EXISTS name TEXT;

--- a/src/fs/sql-fs/types.ts
+++ b/src/fs/sql-fs/types.ts
@@ -60,6 +60,17 @@ export interface PathCacheEntry {
 /** Persisted sandbox metadata needed for session rehydration on cold replicas. */
 export interface SandboxMeta {
 	readonly owner: string | null;
+	readonly name: string | null;
+	readonly python: boolean;
+	readonly javascript: boolean;
+}
+
+/** A single entry returned by the list-sandboxes query. */
+export interface SandboxListEntry {
+	readonly id: string;
+	readonly name: string | null;
+	readonly owner: string | null;
+	readonly createdAt: Date;
 	readonly python: boolean;
 	readonly javascript: boolean;
 }
@@ -164,6 +175,9 @@ export interface SqlDialect<Tx = unknown> {
 
 	/** Writes owner and runtime-option metadata to the sandbox row. */
 	updateSandboxMeta(tx: Tx, sandboxId: string, meta: SandboxMeta): Promise<void>;
+
+	/** Lists all sandboxes, optionally filtered by owner. */
+	listSandboxes(tx: Tx, owner?: string): Promise<SandboxListEntry[]>;
 
 	// ── Inode CRUD ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `GET /v1/sandboxes` HTTP endpoint to list all sandboxes owned by the authenticated caller, queried directly from Postgres for accuracy across replicas.
- Add `sandbox_list` MCP tool providing the same listing capability.
- Add optional `name` field (TEXT, max 255 chars) to sandboxes — accepted at creation via both HTTP and MCP, returned in create/get/list responses.
- New Postgres migration `0003_add_sandbox_name.sql` for the `name` column.
- Bump version to 0.2.6 across `package.json`, `pnpm-lock.yaml`, OpenAPI spec, and CHANGELOG.
- Update `CLAUDE.md` to document version bump requirements (package.json + lockfile + OpenAPI spec).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:fix` passes
- [x] `pnpm test:unit` — all 539 tests pass
- [x] Manual HTTP testing against local Postgres: create with/without name, get, list, delete, ownership isolation
- [x] Manual MCP testing against local Postgres: `sandbox_create` with/without name, `sandbox_list`, `sandbox_delete`, verified empty list after cleanup
- [ ] Integration tests against real Postgres (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated endpoint to list user sandboxes with metadata (creation time, runtime configuration)
  * Sandboxes now support optional name field assignable at creation and included in responses
  * New sandbox_list MCP tool for enumerating user sandboxes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->