### PR TITLE
feat(auth): harden /v1/auth/admin and add per-route rate limit (#23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,22 @@ DATABASE_DIRECT_URL=postgres://postgres:test@localhost:5432/virtualfs
 # Server
 PORT=8080
 AUTH_SECRET=change-me-in-production
+# Required for POST /v1/auth/admin (token rotation by an existing Bearer holder).
+# Compared against X-Admin-Secret header via timing-safe sha256-digest compare.
+# ADMIN_SECRET=change-me-in-production
 
 # Session
 SESSION_IDLE_MS=600000
+
+# Auth rate limits (issue #23). Per-replica in-memory limiter; multi-replica
+# leakage is acknowledged. /v1/auth/admin is keyed by IP and Bearer sub
+# (tripping either returns 429); /v1/auth/bootstrap is keyed by IP only.
+ADMIN_RATE_LIMIT_WINDOW_MS=60000
+ADMIN_RATE_LIMIT_MAX=5
+BOOTSTRAP_RATE_LIMIT_WINDOW_MS=60000
+BOOTSTRAP_RATE_LIMIT_MAX=5
+# Trust X-Forwarded-For / X-Real-IP for rate-limit keying. Default `false` —
+# only enable when running behind an ingress that STRIPS inbound forwarding
+# headers (otherwise an attacker can spoof these to bypass per-IP buckets,
+# especially on the unauthenticated /v1/auth/bootstrap endpoint).
+# TRUST_PROXY_HEADERS=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-04-28
+
+### Added
+
+- `jti` claim on tokens minted by `POST /v1/auth/admin`, generated via `randomUUID()` and recorded in the `admin_token_issued` audit log so a leaked-token incident can be correlated back to the issuing log line.
+- `admin_token_issued`, `admin_token_denied`, and `admin_token_misconfigured` audit log events on `POST /v1/auth/admin` (matching issue #23 names; bootstrap retains the existing `auth_bootstrap_*` events).
+- `auth_rate_limited` audit log event emitted when a rate-limited request is rejected.
+- `src/api/rate-limit.ts` — in-memory rate-limit primitive with injectable store and clock. Mounted on `/v1/auth/admin` (keyed by IP and Bearer sub) and `/v1/auth/bootstrap` (keyed by IP).
+- Env vars: `ADMIN_RATE_LIMIT_WINDOW_MS` (default `60000`), `ADMIN_RATE_LIMIT_MAX` (default `5`), `BOOTSTRAP_RATE_LIMIT_WINDOW_MS` (default `60000`), `BOOTSTRAP_RATE_LIMIT_MAX` (default `5`), `TRUST_PROXY_HEADERS` (default `false`).
+- `InMemoryRateLimitStore` now caps live keys (default `10000`) with FIFO eviction so attacker-controlled key cardinality (e.g. spoofed `X-Forwarded-For` against unauthenticated bootstrap) cannot grow the store unbounded within a window.
+- HTTP `429 RATE_LIMITED` response (with `Retry-After` header) on both auth endpoints when the limit is tripped.
+
+### Changed
+
+- `constantTimeEqual()` in `src/api/routes/auth.ts` now compares SHA-256 digests of the inputs, removing the early-return length oracle. Used by both `POST /v1/auth/bootstrap` and `POST /v1/auth/admin`.
+- `POST /v1/auth/admin` is now structured as pre-middleware → `validateBody` → handler so the `X-Admin-Secret` check runs before body parsing. Wrong/missing secrets now return 403 even for malformed bodies (previously returned 400 from Zod). The handler also hard-fails with 500 `AUTH_NOT_CONFIGURED` when `AUTH_SECRET` is unset.
+- Rate-limit `clientIp()` no longer reads `X-Forwarded-For` / `X-Real-IP` by default — those headers are spoofable. Operators behind a trusted ingress that strips inbound forwarding headers must opt in via `TRUST_PROXY_HEADERS=true`. Otherwise the connecting socket's `remoteAddress` is used. See `plugins/virtualfs/skills/api/SETUP.md` for the full trust-proxy note.
+
 ## [0.2.7] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All `/v1/*` endpoints require `Authorization: Bearer <JWT>`. Three ways to mint 
 
 2. **CLI** (when you have the repo cloned): `AUTH_SECRET=... pnpm token:create -- --sub agent-1 --expires 30d`.
 
-3. **Admin endpoint** (`POST /v1/admin/tokens`) — requires both an existing Bearer JWT *and* `X-Admin-Secret`. Use this once you already have a token and want to mint others without exposing `AUTH_SECRET`.
+3. **Admin endpoint** (`POST /v1/auth/admin`) — requires both an existing Bearer JWT *and* `X-Admin-Secret`. Use this once you already have a token and want to mint others without exposing `AUTH_SECRET`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Persistent filesystem backends (Postgres/MySQL/Azure SQL/FileShare) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/plugins/virtualfs/skills/api/SETUP.md
+++ b/plugins/virtualfs/skills/api/SETUP.md
@@ -139,6 +139,7 @@ alias vfs-bootstrap='curl -fsS -X POST "$VIRTUALFS_BASE_URL/v1/auth/bootstrap" -
 | `{"error":"forbidden","code":"FORBIDDEN"}` | Sandbox owned by a different `sub`, OR wrong/missing `X-Auth-Secret` on bootstrap | Use the token that created the sandbox; double-check `AUTH_SECRET` |
 | `{"error":"auth_not_configured","code":"AUTH_NOT_CONFIGURED"}` | Server has no `AUTH_SECRET` env var | Ask the deployer to set `AUTH_SECRET` |
 | `{"error":"admin_not_configured","code":"ADMIN_NOT_CONFIGURED"}` | Server has no `ADMIN_SECRET` env var | Ask the deployer to set `ADMIN_SECRET` |
+| `{"error":"rate_limited","code":"RATE_LIMITED"}` | Too many requests to `/v1/auth/bootstrap` or `/v1/auth/admin` (default 5 / 60s). Response includes `Retry-After` header. | Wait `Retry-After` seconds, or raise `*_RATE_LIMIT_*` env vars. |
 
 ---
 
@@ -147,9 +148,69 @@ alias vfs-bootstrap='curl -fsS -X POST "$VIRTUALFS_BASE_URL/v1/auth/bootstrap" -
 `POST /v1/auth/bootstrap` is unauthenticated by design — it is itself the credential-bootstrap
 endpoint. Its hardening:
 
-- **Constant-time comparison** of `X-Auth-Secret` against `AUTH_SECRET` (`crypto.timingSafeEqual`) — no timing oracle
+- **Constant-time comparison** of `X-Auth-Secret` against `AUTH_SECRET` using a SHA-256-digest `crypto.timingSafeEqual` — no length oracle and no early-return timing leak
 - **Hard-fail when `AUTH_SECRET` is unset** — returns `500 AUTH_NOT_CONFIGURED`, never signs with an empty string
 - **Secret check before body parsing** — callers without the correct secret cannot probe the request schema with cheap 400s
 - **Tenant validation** — rejects unknown `tenant` values before signing
 - **Audit log** — emits `auth_bootstrap_issued` / `auth_bootstrap_denied` (with `reason`: `mismatch`, `missing_header`, `unknown_tenant`) on every call
 - **Method-scoped exemption** — only `POST /v1/auth/bootstrap` bypasses Bearer auth; `GET` (or any other method) on the same path is still gated
+- **Per-IP rate limit** — defaults to 5 requests / 60s (configurable via `BOOTSTRAP_RATE_LIMIT_WINDOW_MS` / `BOOTSTRAP_RATE_LIMIT_MAX`). 429 responses include a `Retry-After` header.
+
+---
+
+## POST /v1/auth/admin — security notes
+
+`POST /v1/auth/admin` lives behind the standard Bearer middleware *and* requires
+`X-Admin-Secret`. Its hardening:
+
+- **SHA-256-digest timing-safe compare** of `X-Admin-Secret` against `ADMIN_SECRET` — same helper as bootstrap, no length leak
+- **Secret check before body parsing** — wrong/missing `X-Admin-Secret` returns 403 even for malformed bodies (no schema-probing via 400s)
+- **Hard-fail on missing `AUTH_SECRET`** — returns `500 AUTH_NOT_CONFIGURED` instead of signing with an empty key
+- **`jti` claim on every issued token** — UUID generated server-side, included in the JWT, and recorded in the `admin_token_issued` audit log so a leaked token can be correlated to its issuance
+- **Audit log** — emits `admin_token_issued` (with `caller`, `callerTenant`, `sub`, `tenant`, `expiresIn`, `jti`, `ip`, `ua`), `admin_token_denied` (with `reason`: `mismatch` / `missing_header` / `unknown_tenant`), and `admin_token_misconfigured` (when `ADMIN_SECRET` or `AUTH_SECRET` is unset). Issued tokens are **never** logged.
+- **Per-IP and per-Bearer-`sub` rate limit** — defaults to 5 requests / 60s. Either key tripping returns 429. Configure via `ADMIN_RATE_LIMIT_WINDOW_MS` / `ADMIN_RATE_LIMIT_MAX`.
+
+### Rate limit env vars
+
+| Variable | Default | Description |
+|---|---|---|
+| `ADMIN_RATE_LIMIT_WINDOW_MS` | `60000` | Window length for the admin endpoint, in milliseconds. |
+| `ADMIN_RATE_LIMIT_MAX` | `5` | Max requests per `(ip)` and per `(sub)` in one window. |
+| `BOOTSTRAP_RATE_LIMIT_WINDOW_MS` | `60000` | Window length for the bootstrap endpoint. |
+| `BOOTSTRAP_RATE_LIMIT_MAX` | `5` | Max requests per `(ip)` in one window. |
+| `TRUST_PROXY_HEADERS` | `false` | Honour `X-Forwarded-For` / `X-Real-IP` for rate-limit keying. **See trust-proxy note below.** |
+
+> **Trust-proxy note (security-critical for `/v1/auth/bootstrap`).** `/v1/auth/bootstrap`
+> is unauthenticated, so its rate limit is the only barrier against `AUTH_SECRET`
+> brute-forcing. The IP used for keying must come from a source the caller cannot
+> spoof:
+>
+> - **Default (`TRUST_PROXY_HEADERS=false`)** — the connecting socket's
+>   `remoteAddress` is the key. Inbound `X-Forwarded-For` / `X-Real-IP` headers
+>   are ignored. Safe behind any deployment, but if the API sits behind a cloud
+>   load balancer that terminates TCP, every request appears to come from the
+>   load balancer's IP and the bucket is *shared by all callers* — usually too
+>   tight for production.
+> - **`TRUST_PROXY_HEADERS=true`** — the leftmost `X-Forwarded-For` value is
+>   used. **Only safe if the ingress strips inbound forwarding headers** (so
+>   the leftmost value is one the proxy itself stamped). If the ingress merely
+>   *appends* to the chain (Azure Container Apps, many K8s ingresses), an
+>   attacker can prepend an arbitrary value and bypass per-IP rate limiting on
+>   `/v1/auth/bootstrap`. Verify by sending a request with a synthetic
+>   `X-Forwarded-For: 9.9.9.9` header from outside and inspecting the audit
+>   log: if the recorded `ip` is `9.9.9.9`, the proxy is *not* sanitising and
+>   you must not enable this flag.
+
+### Audit log events
+
+All audit events are emitted as single JSON lines on stdout for log-aggregator ingestion.
+
+| Event | Emitted by | Notable fields |
+|---|---|---|
+| `auth_bootstrap_issued` | `POST /v1/auth/bootstrap` (success) | `ip`, `ua`, `sub`, `tenant`, `expiresIn`, `expiresAt` |
+| `auth_bootstrap_denied` | `POST /v1/auth/bootstrap` (403/400) | `ip`, `ua`, `reason` |
+| `auth_bootstrap_misconfigured` | `POST /v1/auth/bootstrap` (500) | `ip`, `ua` |
+| `admin_token_issued` | `POST /v1/auth/admin` (success) | `caller`, `callerTenant`, `sub`, `tenant`, `expiresIn`, `expiresAt`, `jti`, `ip`, `ua` |
+| `admin_token_denied` | `POST /v1/auth/admin` (403/400) | `caller`, `ip`, `ua`, `reason` |
+| `admin_token_misconfigured` | `POST /v1/auth/admin` (500) | `caller`, `ip`, `ua`, `reason` (e.g. `auth_secret_unset`) |
+| `auth_rate_limited` | rate-limit middleware (429) | `scope` (`admin`/`bootstrap`), `keys`, `trippedKey`, `ip`, `sub`, `path` |

--- a/plugins/virtualfs/skills/api/ref/endpoints.md
+++ b/plugins/virtualfs/skills/api/ref/endpoints.md
@@ -47,6 +47,12 @@ Error responses:
 - `403 FORBIDDEN` — `X-Auth-Secret` missing or doesn't match server `AUTH_SECRET`
 - `500 AUTH_NOT_CONFIGURED` — server has no `AUTH_SECRET` env var set
 - `400 INVALID_INPUT` — body validation failed (missing `sub`, unknown tenant, invalid `expiresIn`)
+- `429 RATE_LIMITED` — too many requests from this IP (default 5 / 60s, configurable via `BOOTSTRAP_RATE_LIMIT_*`). Response includes a `Retry-After` header (seconds).
+
+Audit log shape (`auth_bootstrap_issued`):
+```json
+{"event":"auth_bootstrap_issued","ip":"1.2.3.4","ua":"curl/...","sub":"admin","tenant":null,"expiresIn":"30d","expiresAt":"2026-05-26T..."}
+```
 
 ---
 
@@ -80,10 +86,24 @@ Response `201`:
 { "token": "<jwt>", "sub": "agent-1", "tenant": null, "expiresAt": "2026-05-02T..." }
 ```
 
+Issued tokens carry a `jti` (JWT ID) claim — a server-generated UUID that is also written
+to the `admin_token_issued` audit log so a leaked token can be correlated back to its
+issuance. The token string itself is **never** logged.
+
 Error responses:
 - `403 FORBIDDEN` — `X-Admin-Secret` missing or doesn't match server `ADMIN_SECRET`
 - `500 ADMIN_NOT_CONFIGURED` — server has no `ADMIN_SECRET` env var set
-- `400 INVALID_INPUT` — body validation failed (bad `sub`, unknown tenant, invalid `expiresIn`)
+- `500 AUTH_NOT_CONFIGURED` — server has no `AUTH_SECRET` env var set (cannot sign tokens)
+- `400 INVALID_INPUT` — body validation failed (bad `sub`, unknown tenant, invalid `expiresIn`). Only checked **after** `X-Admin-Secret` validates; wrong secret returns 403, never 400.
+- `429 RATE_LIMITED` — too many requests (default 5 / 60s per IP and per Bearer `sub`; either key tripping returns 429). Configurable via `ADMIN_RATE_LIMIT_*`. Response includes a `Retry-After` header (seconds).
+
+Audit log shapes:
+```json
+{"event":"admin_token_issued","ts":"2026-04-28T...","caller":"admin","callerTenant":"default","sub":"agent-1","tenant":null,"expiresIn":"30d","expiresAt":"2026-05-28T...","jti":"<uuid>","ip":"1.2.3.4","ua":"curl/..."}
+{"event":"admin_token_denied","ts":"...","caller":"admin","ip":"1.2.3.4","ua":"...","reason":"mismatch"}
+{"event":"admin_token_misconfigured","ts":"...","caller":"admin","ip":"1.2.3.4","ua":"...","reason":"auth_secret_unset"}
+{"event":"auth_rate_limited","ts":"...","scope":"admin","keys":["admin:ip:1.2.3.4","admin:sub:admin"],"trippedKey":"admin:ip:1.2.3.4","ip":"1.2.3.4","sub":"admin","path":"/v1/auth/admin"}
+```
 
 ---
 

--- a/src/api/__tests__/admin.test.ts
+++ b/src/api/__tests__/admin.test.ts
@@ -2,8 +2,11 @@
  * Unit tests for POST /v1/auth/admin (US-057c)
  */
 
+import { Hono } from "hono";
 import { SignJWT, jwtVerify } from "jose";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRateLimitStore } from "../rate-limit.js";
+import { authRoutes } from "../routes/auth.js";
 import { app } from "../server.js";
 
 const AUTH_SECRET = "test-secret-for-admin-endpoint-exactly-32b";
@@ -21,6 +24,7 @@ describe("POST /v1/auth/admin", () => {
 	const originalTenantDatabases = process.env.TENANT_DATABASES;
 
 	beforeEach(() => {
+		defaultRateLimitStore.reset();
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		process.env.ADMIN_SECRET = ADMIN_SECRET;
 		// The admin route now validates tenant against the configured tenants;
@@ -199,5 +203,172 @@ describe("POST /v1/auth/admin", () => {
 		expect(res.status).toBe(403);
 		const body = (await res.json()) as { code: string };
 		expect(body.code).toBe("FORBIDDEN");
+	});
+
+	it("returns 403 when X-Admin-Secret length differs from configured secret", async () => {
+		// Regression: pre-PR helper short-circuited on length mismatch (length oracle).
+		// The new sha256-digest compare must still return false without throwing.
+		const callerToken = await makeCallerToken("admin");
+		const res = await app.request("/v1/auth/admin", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${callerToken}`,
+				"Content-Type": "application/json",
+				"X-Admin-Secret": "x",
+			},
+			body: JSON.stringify({ sub: "agent-001" }),
+		});
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("FORBIDDEN");
+	});
+
+	it("returns 500 ADMIN_NOT_CONFIGURED when ADMIN_SECRET is unset", async () => {
+		Reflect.deleteProperty(process.env, "ADMIN_SECRET");
+		const callerToken = await makeCallerToken("admin");
+		const res = await app.request("/v1/auth/admin", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${callerToken}`,
+				"Content-Type": "application/json",
+				"X-Admin-Secret": "anything",
+			},
+			body: JSON.stringify({ sub: "agent-001" }),
+		});
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("ADMIN_NOT_CONFIGURED");
+	});
+
+	it("does not run validateBody when X-Admin-Secret is wrong (403 not 400)", async () => {
+		// Body is invalid (sub empty). Secret check must run first → 403, not 400.
+		const callerToken = await makeCallerToken("admin");
+		const res = await app.request("/v1/auth/admin", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${callerToken}`,
+				"Content-Type": "application/json",
+				"X-Admin-Secret": "wrong-secret",
+			},
+			body: JSON.stringify({ sub: "" }),
+		});
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("FORBIDDEN");
+	});
+
+	it("emits admin_token_issued audit log with jti matching token claim, no token in log", async () => {
+		const logs: string[] = [];
+		const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			for (const a of args) {
+				if (typeof a === "string") logs.push(a);
+			}
+		});
+
+		try {
+			const callerToken = await makeCallerToken("admin");
+			const res = await app.request("/v1/auth/admin", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${callerToken}`,
+					"Content-Type": "application/json",
+					"X-Admin-Secret": ADMIN_SECRET,
+				},
+				body: JSON.stringify({ sub: "agent-jti", expiresIn: "24h" }),
+			});
+			expect(res.status).toBe(201);
+			const body = (await res.json()) as { token: string };
+
+			const issued = logs
+				.map((l) => {
+					try {
+						return JSON.parse(l) as Record<string, unknown>;
+					} catch {
+						return null;
+					}
+				})
+				.find((o): o is Record<string, unknown> => o !== null && o.event === "admin_token_issued");
+
+			expect(issued).toBeDefined();
+			expect(typeof issued?.jti).toBe("string");
+			expect(issued?.sub).toBe("agent-jti");
+			expect(issued?.caller).toBe("admin");
+
+			// Token string must NEVER appear in any log line.
+			for (const line of logs) {
+				expect(line.includes(body.token)).toBe(false);
+			}
+
+			const key = new TextEncoder().encode(AUTH_SECRET);
+			const { payload } = await jwtVerify(body.token, key, { algorithms: ["HS256"] });
+			expect(payload.jti).toBe(issued?.jti);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("returns 500 AUTH_NOT_CONFIGURED when AUTH_SECRET is unset (route-level branch)", async () => {
+		// The full app's Bearer middleware would 401 first when AUTH_SECRET is
+		// unset, masking the route-level branch. Mount `authRoutes()` behind a
+		// stub middleware that injects `owner`/`tenant` so the route branch is
+		// reachable and the 500 path is exercised end-to-end.
+		Reflect.deleteProperty(process.env, "AUTH_SECRET");
+		const isolated = new Hono<{ Variables: { owner: string; tenant: string } }>();
+		isolated.use("*", async (c, next) => {
+			c.set("owner", "stub-caller");
+			c.set("tenant", "default");
+			await next();
+		});
+		isolated.route("/v1/auth", authRoutes());
+
+		const res = await isolated.request("/v1/auth/admin", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Admin-Secret": ADMIN_SECRET,
+			},
+			body: JSON.stringify({ sub: "agent-001" }),
+		});
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("AUTH_NOT_CONFIGURED");
+	});
+
+	it("emits admin_token_denied audit log on 403", async () => {
+		const logs: string[] = [];
+		const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			for (const a of args) {
+				if (typeof a === "string") logs.push(a);
+			}
+		});
+
+		try {
+			const callerToken = await makeCallerToken("admin");
+			const res = await app.request("/v1/auth/admin", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${callerToken}`,
+					"Content-Type": "application/json",
+					"X-Admin-Secret": "wrong-secret",
+				},
+				body: JSON.stringify({ sub: "agent-001" }),
+			});
+			expect(res.status).toBe(403);
+
+			const denied = logs
+				.map((l) => {
+					try {
+						return JSON.parse(l) as Record<string, unknown>;
+					} catch {
+						return null;
+					}
+				})
+				.find((o): o is Record<string, unknown> => o !== null && o.event === "admin_token_denied");
+			expect(denied).toBeDefined();
+			expect(denied?.reason).toBe("mismatch");
+			expect(denied?.caller).toBe("admin");
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });

--- a/src/api/__tests__/auth-bootstrap.test.ts
+++ b/src/api/__tests__/auth-bootstrap.test.ts
@@ -4,6 +4,7 @@
 
 import { jwtVerify } from "jose";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultRateLimitStore } from "../rate-limit.js";
 import { app } from "../server.js";
 
 const AUTH_SECRET = "test-bootstrap-secret-exactly-32-bytes";
@@ -14,6 +15,7 @@ describe("POST /v1/auth/bootstrap", () => {
 	const originalTenantDatabases = process.env.TENANT_DATABASES;
 
 	beforeEach(() => {
+		defaultRateLimitStore.reset();
 		process.env.AUTH_SECRET = AUTH_SECRET;
 		process.env.TENANT_DATABASES = JSON.stringify({
 			default: "postgres://test@localhost:5432/test_default",

--- a/src/api/__tests__/rate-limit.test.ts
+++ b/src/api/__tests__/rate-limit.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the rate-limit primitive (issue #23).
+ */
+
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryRateLimitStore, clientIp, rateLimit } from "../rate-limit.js";
+
+describe("InMemoryRateLimitStore", () => {
+	it("allows up to max in window then denies", () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		for (let i = 1; i <= 5; i++) {
+			expect(store.hit("k", 60_000, 5, now).allowed).toBe(true);
+		}
+		expect(store.hit("k", 60_000, 5, now).allowed).toBe(false);
+	});
+
+	it("rolls window over after windowMs", () => {
+		const store = new InMemoryRateLimitStore();
+		const t0 = 1_000_000;
+		for (let i = 0; i < 5; i++) store.hit("k", 60_000, 5, t0);
+		expect(store.hit("k", 60_000, 5, t0).allowed).toBe(false);
+		// Advance past window
+		expect(store.hit("k", 60_000, 5, t0 + 60_001).allowed).toBe(true);
+	});
+
+	it("reset clears all entries", () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		for (let i = 0; i < 5; i++) store.hit("k", 60_000, 5, now);
+		store.reset();
+		expect(store.hit("k", 60_000, 5, now).allowed).toBe(true);
+	});
+
+	it("tracks keys independently", () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		for (let i = 0; i < 5; i++) store.hit("a", 60_000, 5, now);
+		expect(store.hit("a", 60_000, 5, now).allowed).toBe(false);
+		expect(store.hit("b", 60_000, 5, now).allowed).toBe(true);
+	});
+
+	it("caps live keys via FIFO eviction under attacker-controlled cardinality", () => {
+		// Simulate /bootstrap under spoofed XFF: each request gets a fresh key.
+		// Without the cap, the Map would grow to N. With maxEntries=4 it stays
+		// bounded and the *oldest* keys get evicted (so a returning attacker
+		// gets a fresh bucket — acceptable because we are protecting memory,
+		// not state).
+		const store = new InMemoryRateLimitStore({ maxEntries: 4 });
+		const now = 1_000_000;
+		for (let i = 0; i < 50; i++) {
+			store.hit(`ip:${i}`, 60_000, 5, now);
+		}
+		expect(store.size()).toBe(4);
+		// The most-recently-inserted keys survive (FIFO eviction = oldest first).
+		expect(store.hit("ip:49", 60_000, 5, now).remaining).toBe(3); // existing bucket: count 2
+		expect(store.hit("ip:0", 60_000, 5, now).remaining).toBe(4); // evicted long ago, fresh bucket
+	});
+});
+
+describe("rateLimit middleware", () => {
+	let logs: string[];
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logs = [];
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			for (const a of args) {
+				if (typeof a === "string") logs.push(a);
+			}
+		});
+	});
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore();
+	});
+
+	function findEvent(event: string): Record<string, unknown> | undefined {
+		return logs
+			.map((l) => {
+				try {
+					return JSON.parse(l) as Record<string, unknown>;
+				} catch {
+					return null;
+				}
+			})
+			.find((o): o is Record<string, unknown> => o !== null && o.event === event);
+	}
+
+	it("enforces 5/min per IP — 6th request returns 429 with Retry-After", async () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		const app = new Hono();
+		app.use(
+			"/admin",
+			rateLimit({
+				windowMs: 60_000,
+				max: 5,
+				scope: "admin",
+				keys: () => ["admin:ip:1.2.3.4"],
+				store,
+				now: () => now,
+			}),
+		);
+		app.post("/admin", (c) => c.json({ ok: true }));
+
+		for (let i = 1; i <= 5; i++) {
+			const res = await app.request("/admin", { method: "POST" });
+			expect(res.status).toBe(200);
+		}
+		const res = await app.request("/admin", { method: "POST" });
+		expect(res.status).toBe(429);
+		expect(res.headers.get("Retry-After")).toBeTruthy();
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("RATE_LIMITED");
+	});
+
+	it("trips on per-sub key even when per-IP key would still allow", async () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		const app = new Hono<{ Variables: { owner: string } }>();
+		// Set owner so the limiter can read c.get("owner") via keys()
+		app.use("/admin", async (c, next) => {
+			c.set("owner", "alice");
+			await next();
+		});
+		// Rotate IP via X-Forwarded-For header per request, but key by sub.
+		app.use(
+			"/admin",
+			rateLimit({
+				windowMs: 60_000,
+				max: 5,
+				scope: "admin",
+				keys: (c) => {
+					const ip = c.req.header("x-forwarded-for") ?? "unknown";
+					const sub = (c.get("owner") as string | undefined) ?? "anon";
+					return [`admin:ip:${ip}`, `admin:sub:${sub}`];
+				},
+				store,
+				now: () => now,
+			}),
+		);
+		app.post("/admin", (c) => c.json({ ok: true }));
+
+		for (let i = 1; i <= 5; i++) {
+			const res = await app.request("/admin", {
+				method: "POST",
+				headers: { "X-Forwarded-For": `10.0.0.${i}` },
+			});
+			expect(res.status).toBe(200);
+		}
+		const res = await app.request("/admin", {
+			method: "POST",
+			headers: { "X-Forwarded-For": "10.0.0.99" },
+		});
+		expect(res.status).toBe(429);
+	});
+
+	it("emits auth_rate_limited audit log on 429", async () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		const app = new Hono();
+		app.use(
+			"/admin",
+			rateLimit({
+				windowMs: 60_000,
+				max: 1,
+				scope: "admin",
+				keys: () => ["admin:ip:1.1.1.1"],
+				store,
+				now: () => now,
+			}),
+		);
+		app.post("/admin", (c) => c.json({ ok: true }));
+
+		await app.request("/admin", { method: "POST" });
+		const res = await app.request("/admin", { method: "POST" });
+		expect(res.status).toBe(429);
+
+		const evt = findEvent("auth_rate_limited");
+		expect(evt).toBeDefined();
+		expect(evt?.scope).toBe("admin");
+		expect(evt?.path).toBe("/admin");
+	});
+
+	it("bootstrap limiter does not crash when c.get('owner') is unset", async () => {
+		const store = new InMemoryRateLimitStore();
+		const now = 1_000_000;
+		const app = new Hono();
+		app.use(
+			"/bootstrap",
+			rateLimit({
+				windowMs: 60_000,
+				max: 5,
+				scope: "bootstrap",
+				// Only IP key — must not read c.get("owner")
+				keys: () => ["bootstrap:ip:9.9.9.9"],
+				store,
+				now: () => now,
+			}),
+		);
+		app.post("/bootstrap", (c) => c.json({ ok: true }));
+
+		for (let i = 1; i <= 5; i++) {
+			const res = await app.request("/bootstrap", { method: "POST" });
+			expect(res.status).toBe(200);
+		}
+		const res = await app.request("/bootstrap", { method: "POST" });
+		expect(res.status).toBe(429);
+	});
+
+	it("clientIp ignores X-Forwarded-For unless TRUST_PROXY_HEADERS=true", async () => {
+		const original = process.env.TRUST_PROXY_HEADERS;
+		try {
+			Reflect.deleteProperty(process.env, "TRUST_PROXY_HEADERS");
+			const seen: string[] = [];
+			const app = new Hono();
+			app.post("/p", (c) => {
+				seen.push(clientIp(c));
+				return c.json({ ok: true });
+			});
+			await app.request("/p", { method: "POST", headers: { "X-Forwarded-For": "1.2.3.4" } });
+			expect(seen[0]).toBe("unknown");
+
+			process.env.TRUST_PROXY_HEADERS = "true";
+			await app.request("/p", { method: "POST", headers: { "X-Forwarded-For": "1.2.3.4" } });
+			expect(seen[1]).toBe("1.2.3.4");
+		} finally {
+			if (original === undefined) Reflect.deleteProperty(process.env, "TRUST_PROXY_HEADERS");
+			else process.env.TRUST_PROXY_HEADERS = original;
+		}
+	});
+
+	it("clientIp prefers socket.remoteAddress when TRUST_PROXY_HEADERS is unset", async () => {
+		const original = process.env.TRUST_PROXY_HEADERS;
+		try {
+			Reflect.deleteProperty(process.env, "TRUST_PROXY_HEADERS");
+			const seen: string[] = [];
+			const app = new Hono();
+			app.post("/p", (c) => {
+				seen.push(clientIp(c));
+				return c.json({ ok: true });
+			});
+			// Inject a fake `incoming` on c.env via Hono's `app.fetch` env arg.
+			await app.fetch(
+				new Request("http://localhost/p", {
+					method: "POST",
+					headers: { "X-Forwarded-For": "1.2.3.4" },
+				}),
+				{ incoming: { socket: { remoteAddress: "10.0.0.1" } } },
+			);
+			// Socket wins over spoofed XFF in default (untrusted) mode.
+			expect(seen[0]).toBe("10.0.0.1");
+		} finally {
+			if (original === undefined) Reflect.deleteProperty(process.env, "TRUST_PROXY_HEADERS");
+			else process.env.TRUST_PROXY_HEADERS = original;
+		}
+	});
+
+	it("window rolls over via injected clock", async () => {
+		const store = new InMemoryRateLimitStore();
+		let now = 1_000_000;
+		const app = new Hono();
+		app.use(
+			"/admin",
+			rateLimit({
+				windowMs: 60_000,
+				max: 1,
+				scope: "admin",
+				keys: () => ["admin:ip:1.1.1.1"],
+				store,
+				now: () => now,
+			}),
+		);
+		app.post("/admin", (c) => c.json({ ok: true }));
+
+		expect((await app.request("/admin", { method: "POST" })).status).toBe(200);
+		expect((await app.request("/admin", { method: "POST" })).status).toBe(429);
+		now += 60_001;
+		expect((await app.request("/admin", { method: "POST" })).status).toBe(200);
+	});
+});

--- a/src/api/lib/audit.ts
+++ b/src/api/lib/audit.ts
@@ -1,3 +1,4 @@
 export function logAudit(event: string, fields: Record<string, unknown>): void {
-	console.log(JSON.stringify({ event, ...fields }));
+	// `event` last so callers cannot spoof it by passing `event` in `fields`.
+	console.log(JSON.stringify({ ...fields, event }));
 }

--- a/src/api/lib/audit.ts
+++ b/src/api/lib/audit.ts
@@ -1,0 +1,3 @@
+export function logAudit(event: string, fields: Record<string, unknown>): void {
+	console.log(JSON.stringify({ event, ...fields }));
+}

--- a/src/api/lib/jwt.test.ts
+++ b/src/api/lib/jwt.test.ts
@@ -47,4 +47,22 @@ describe("signToken / verifyToken", () => {
 		expect(payloadNone.exp).toBeUndefined();
 		expect(payloadNever.exp).toBeUndefined();
 	});
+
+	it("includes jti claim when provided", async () => {
+		const token = await signToken({ sub: "agent-1", jti: "abc-123", secret: SECRET });
+		const body = JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8")) as Record<
+			string,
+			unknown
+		>;
+		expect(body.jti).toBe("abc-123");
+	});
+
+	it("omits jti claim when not provided", async () => {
+		const token = await signToken({ sub: "agent-1", secret: SECRET });
+		const body = JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8")) as Record<
+			string,
+			unknown
+		>;
+		expect("jti" in body).toBe(false);
+	});
 });

--- a/src/api/lib/jwt.ts
+++ b/src/api/lib/jwt.ts
@@ -11,6 +11,8 @@ export interface SignTokenOptions {
 	tenant?: string;
 	expiresIn?: string; // e.g. "30d", "1y", "24h", "never" or undefined = no expiry
 	secret: string;
+	/** Optional JWT id claim. When set, allows correlating an issued token with audit logs. */
+	jti?: string;
 }
 
 export interface VerifyTokenOptions {
@@ -35,7 +37,7 @@ export interface TokenPayload {
  * @param opts.secret - HS256 signing secret.
  * @returns The signed token string.
  */
-export async function signToken({ sub, tenant, expiresIn, secret }: SignTokenOptions): Promise<string> {
+export async function signToken({ sub, tenant, expiresIn, secret, jti }: SignTokenOptions): Promise<string> {
 	const key = new TextEncoder().encode(secret);
 	const body: Record<string, unknown> = { sub };
 	if (tenant !== undefined) {
@@ -45,6 +47,10 @@ export async function signToken({ sub, tenant, expiresIn, secret }: SignTokenOpt
 
 	if (expiresIn && expiresIn !== "never") {
 		jwt.setExpirationTime(expiresIn);
+	}
+
+	if (jti !== undefined) {
+		jwt.setJti(jti);
 	}
 
 	return jwt.sign(key);

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.7",
+		version: "0.2.8",
 		description:
 			"Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres, MySQL, Azure SQL, or Azure FileShare.",
 	},
@@ -168,6 +168,14 @@ export const openapiSpec = {
 						description: "Wrong or missing X-Auth-Secret",
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
 					},
+					"429": {
+						description:
+							"Rate limited. The bootstrap endpoint is per-IP rate limited (defaults: 5 requests / 60s). The `Retry-After` response header gives seconds until the next request is allowed.",
+						headers: {
+							"Retry-After": { schema: { type: "integer" }, description: "Seconds until the next request is allowed" },
+						},
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
 					"500": {
 						description: "AUTH_SECRET not configured on the server",
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
@@ -230,11 +238,19 @@ export const openapiSpec = {
 						},
 					},
 					"403": {
-						description: "Wrong X-Admin-Secret",
+						description: "Wrong or missing X-Admin-Secret",
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
+					"429": {
+						description:
+							"Rate limited. The admin endpoint is per-IP and per-Bearer-`sub` rate limited (defaults: 5 requests / 60s). Either key tripping returns 429; the `Retry-After` response header gives seconds until the next request is allowed.",
+						headers: {
+							"Retry-After": { schema: { type: "integer" }, description: "Seconds until the next request is allowed" },
+						},
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
 					},
 					"500": {
-						description: "ADMIN_SECRET not configured",
+						description: "ADMIN_SECRET or AUTH_SECRET not configured",
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
 					},
 				},

--- a/src/api/rate-limit.ts
+++ b/src/api/rate-limit.ts
@@ -152,7 +152,11 @@ export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
 
 		for (const key of keys) {
 			const decision = store.hit(key, opts.windowMs, opts.max, t);
-			if (!decision.allowed && trippedKey === undefined) {
+			// Track the *latest* resetAt across all denied keys so Retry-After
+			// reflects the longest remaining wait — not the first bucket tripped.
+			// Otherwise a client could wake up while a slower-resetting bucket
+			// is still in violation and immediately receive another 429.
+			if (!decision.allowed && decision.resetAt >= trippedResetAt) {
 				trippedKey = key;
 				trippedResetAt = decision.resetAt;
 			}

--- a/src/api/rate-limit.ts
+++ b/src/api/rate-limit.ts
@@ -64,12 +64,21 @@ export class InMemoryRateLimitStore implements RateLimitStore {
 		const existing = this.entries.get(key);
 		if (existing === undefined || existing.resetAt <= now) {
 			// New (or rolled-over) bucket. Cap live keys: when we'd exceed the
-			// max, evict the oldest insertion-order entry. Map preserves insertion
-			// order, which approximates oldest-resetAt in steady state and bounds
-			// memory under attacker-controlled key cardinality.
+			// max, first purge expired entries so we don't evict a still-live
+			// tracker while dead space is sitting in the map (the every-1024-hits
+			// lazy GC may not have run yet under bursty traffic). If the store
+			// is still full after that, fall back to FIFO eviction.
 			if (existing === undefined && this.entries.size >= this.maxEntries) {
-				const oldest = this.entries.keys().next().value;
-				if (oldest !== undefined) this.entries.delete(oldest);
+				for (const [k, v] of this.entries) {
+					if (v.resetAt <= now) {
+						this.entries.delete(k);
+						if (this.entries.size < this.maxEntries) break;
+					}
+				}
+				if (this.entries.size >= this.maxEntries) {
+					const oldest = this.entries.keys().next().value;
+					if (oldest !== undefined) this.entries.delete(oldest);
+				}
 			}
 			const resetAt = now + windowMs;
 			// Re-insert (delete + set) so the entry moves to the tail of the

--- a/src/api/rate-limit.ts
+++ b/src/api/rate-limit.ts
@@ -1,0 +1,181 @@
+/**
+ * In-memory per-route rate limiter (issue #23).
+ *
+ * Mounted on auth routes so brute-forcing X-Admin-Secret / X-Auth-Secret is
+ * bounded. The store is in-process per replica — multi-replica leakage is
+ * acknowledged; a follow-up will swap in a Redis-backed store via the existing
+ * `getRedisClient()`.
+ *
+ * The store and clock are injectable so tests can drive deterministic windows
+ * without sleeping.
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { logAudit } from "./lib/audit.js";
+
+export interface RateLimitDecision {
+	allowed: boolean;
+	/** Unix-ms timestamp when the current window expires. */
+	resetAt: number;
+	/** Requests still allowed in the current window after this hit. */
+	remaining: number;
+}
+
+export interface RateLimitStore {
+	hit(key: string, windowMs: number, max: number, now: number): RateLimitDecision;
+	reset(): void;
+}
+
+interface Entry {
+	count: number;
+	resetAt: number;
+}
+
+/**
+ * Default cap on live keys. With attacker-controlled key cardinality (e.g.
+ * rotating IPs against unauthenticated bootstrap), the unbounded variant could
+ * grow within a single window. Each entry is ~80 bytes; 10k = ~0.8 MB worst-case.
+ */
+const DEFAULT_MAX_ENTRIES = 10_000;
+
+export interface InMemoryRateLimitStoreOptions {
+	maxEntries?: number;
+}
+
+export class InMemoryRateLimitStore implements RateLimitStore {
+	private readonly entries: Map<string, Entry> = new Map();
+	private readonly maxEntries: number;
+	private hits = 0;
+
+	constructor(opts: InMemoryRateLimitStoreOptions = {}) {
+		this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+	}
+
+	hit(key: string, windowMs: number, max: number, now: number): RateLimitDecision {
+		this.hits++;
+		// Lazy GC: every 1024 hits, drop expired entries first (cheap path).
+		if (this.hits % 1024 === 0) {
+			for (const [k, v] of this.entries) {
+				if (v.resetAt <= now) this.entries.delete(k);
+			}
+		}
+
+		const existing = this.entries.get(key);
+		if (existing === undefined || existing.resetAt <= now) {
+			// New (or rolled-over) bucket. Cap live keys: when we'd exceed the
+			// max, evict the oldest insertion-order entry. Map preserves insertion
+			// order, which approximates oldest-resetAt in steady state and bounds
+			// memory under attacker-controlled key cardinality.
+			if (existing === undefined && this.entries.size >= this.maxEntries) {
+				const oldest = this.entries.keys().next().value;
+				if (oldest !== undefined) this.entries.delete(oldest);
+			}
+			const resetAt = now + windowMs;
+			// Re-insert (delete + set) so the entry moves to the tail of the
+			// insertion order, keeping the FIFO eviction behaviour stable when a
+			// previously-tracked key rolls over.
+			if (existing !== undefined) this.entries.delete(key);
+			this.entries.set(key, { count: 1, resetAt });
+			return { allowed: 1 <= max, resetAt, remaining: Math.max(0, max - 1) };
+		}
+
+		existing.count += 1;
+		return {
+			allowed: existing.count <= max,
+			resetAt: existing.resetAt,
+			remaining: Math.max(0, max - existing.count),
+		};
+	}
+
+	reset(): void {
+		this.entries.clear();
+		this.hits = 0;
+	}
+
+	/** Visible for tests. */
+	size(): number {
+		return this.entries.size;
+	}
+}
+
+/** Process-wide default store. Tests should call `defaultRateLimitStore.reset()` in `beforeEach`. */
+export const defaultRateLimitStore = new InMemoryRateLimitStore();
+
+export interface RateLimitOptions {
+	windowMs: number;
+	max: number;
+	scope: "admin" | "bootstrap";
+	/** One or more keys to evaluate. Tripping any key returns 429. */
+	keys: (c: Context) => string[];
+	store?: RateLimitStore;
+	now?: () => number;
+}
+
+/**
+ * Extract the client IP for rate-limit keying.
+ *
+ * Forwarding headers (`X-Forwarded-For`, `X-Real-IP`) are spoofable by any
+ * caller that can reach the application, so we only honour them when the
+ * operator opts in via `TRUST_PROXY_HEADERS=true`. That mode is appropriate
+ * when the application sits behind an ingress that strips inbound forwarding
+ * headers and re-emits its own. Otherwise we fall back to the connecting
+ * socket's remote address (set by `@hono/node-server` on `c.env.incoming`).
+ *
+ * Failure mode: when neither source is available (e.g. the in-process
+ * `app.request()` test harness), we return "unknown" — a single shared bucket
+ * is the *safe* default for rate-limit keying.
+ */
+export function clientIp(c: Context): string {
+	if (process.env.TRUST_PROXY_HEADERS === "true") {
+		const fwd = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+		if (fwd) return fwd;
+		const real = c.req.header("x-real-ip");
+		if (real) return real;
+	}
+	const incoming = (c.env as { incoming?: { socket?: { remoteAddress?: string | null } } } | undefined)?.incoming;
+	const remote = incoming?.socket?.remoteAddress;
+	if (remote) return remote;
+	return "unknown";
+}
+
+export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
+	const store = opts.store ?? defaultRateLimitStore;
+	const now = opts.now ?? (() => Date.now());
+
+	return async (c, next) => {
+		const t = now();
+		const keys = opts.keys(c);
+
+		let trippedKey: string | undefined;
+		let trippedResetAt = 0;
+
+		for (const key of keys) {
+			const decision = store.hit(key, opts.windowMs, opts.max, t);
+			if (!decision.allowed && trippedKey === undefined) {
+				trippedKey = key;
+				trippedResetAt = decision.resetAt;
+			}
+		}
+
+		if (trippedKey !== undefined) {
+			const ip = clientIp(c);
+			// `c.get("owner")` is set by Bearer middleware on /admin; on
+			// /bootstrap it is undefined (the path is exempt). Read defensively.
+			const sub = (c.get("owner") as string | undefined) ?? undefined;
+			logAudit("auth_rate_limited", {
+				ts: new Date(t).toISOString(),
+				scope: opts.scope,
+				keys,
+				trippedKey,
+				ip,
+				sub,
+				path: c.req.path,
+			});
+			c.header("Retry-After", String(Math.ceil((trippedResetAt - t) / 1000)));
+			return c.json({ error: "rate_limited", code: "RATE_LIMITED" }, 429 as ContentfulStatusCode);
+		}
+
+		await next();
+	};
+}

--- a/src/api/rate-limit.ts
+++ b/src/api/rate-limit.ts
@@ -50,10 +50,9 @@ export class InMemoryRateLimitStore implements RateLimitStore {
 
 	constructor(opts: InMemoryRateLimitStoreOptions = {}) {
 		if (opts.maxEntries !== undefined && (!Number.isInteger(opts.maxEntries) || opts.maxEntries <= 0)) {
-			throw Object.assign(
-				new Error(`opts.maxEntries must be a positive integer, got ${opts.maxEntries}`),
-				{ code: "ERR_INVALID_RATE_LIMIT" },
-			);
+			throw Object.assign(new Error(`opts.maxEntries must be a positive integer, got ${opts.maxEntries}`), {
+				code: "ERR_INVALID_RATE_LIMIT",
+			});
 		}
 		this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
 	}
@@ -156,16 +155,14 @@ export function clientIp(c: Context): string {
 
 export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
 	if (!Number.isInteger(opts.windowMs) || opts.windowMs <= 0) {
-		throw Object.assign(
-			new Error(`opts.windowMs must be a positive integer, got ${opts.windowMs}`),
-			{ code: "ERR_INVALID_RATE_LIMIT" },
-		);
+		throw Object.assign(new Error(`opts.windowMs must be a positive integer, got ${opts.windowMs}`), {
+			code: "ERR_INVALID_RATE_LIMIT",
+		});
 	}
 	if (!Number.isInteger(opts.max) || opts.max <= 0) {
-		throw Object.assign(
-			new Error(`opts.max must be a positive integer, got ${opts.max}`),
-			{ code: "ERR_INVALID_RATE_LIMIT" },
-		);
+		throw Object.assign(new Error(`opts.max must be a positive integer, got ${opts.max}`), {
+			code: "ERR_INVALID_RATE_LIMIT",
+		});
 	}
 	const store = opts.store ?? defaultRateLimitStore;
 	const now = opts.now ?? (() => Date.now());

--- a/src/api/rate-limit.ts
+++ b/src/api/rate-limit.ts
@@ -49,6 +49,12 @@ export class InMemoryRateLimitStore implements RateLimitStore {
 	private hits = 0;
 
 	constructor(opts: InMemoryRateLimitStoreOptions = {}) {
+		if (opts.maxEntries !== undefined && (!Number.isInteger(opts.maxEntries) || opts.maxEntries <= 0)) {
+			throw Object.assign(
+				new Error(`opts.maxEntries must be a positive integer, got ${opts.maxEntries}`),
+				{ code: "ERR_INVALID_RATE_LIMIT" },
+			);
+		}
 		this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
 	}
 
@@ -149,6 +155,18 @@ export function clientIp(c: Context): string {
 }
 
 export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
+	if (!Number.isInteger(opts.windowMs) || opts.windowMs <= 0) {
+		throw Object.assign(
+			new Error(`opts.windowMs must be a positive integer, got ${opts.windowMs}`),
+			{ code: "ERR_INVALID_RATE_LIMIT" },
+		);
+	}
+	if (!Number.isInteger(opts.max) || opts.max <= 0) {
+		throw Object.assign(
+			new Error(`opts.max must be a positive integer, got ${opts.max}`),
+			{ code: "ERR_INVALID_RATE_LIMIT" },
+		);
+	}
 	const store = opts.store ?? defaultRateLimitStore;
 	const now = opts.now ?? (() => Date.now());
 

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -5,12 +5,15 @@
  * POST /v1/auth/admin      (Bearer + X-Admin-Secret) — mint tokens for arbitrary subs.
  */
 
-import { timingSafeEqual } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
+import { parseNonNegativeInt } from "../../redis/config.js";
 import type { AuthVariables } from "../auth.js";
+import { logAudit } from "../lib/audit.js";
 import { signToken } from "../lib/jwt.js";
+import { clientIp, rateLimit } from "../rate-limit.js";
 import { loadTenantConfig } from "../tenants.js";
 import { validateBody } from "../validation.js";
 
@@ -32,14 +35,11 @@ const EXPIRES_IN_SECONDS: Record<string, number> = {
 };
 
 function constantTimeEqual(a: string, b: string): boolean {
-	const aBuf = Buffer.from(a, "utf8");
-	const bBuf = Buffer.from(b, "utf8");
-	if (aBuf.length !== bBuf.length) return false;
-	return timingSafeEqual(aBuf, bBuf);
-}
-
-function logAudit(event: string, fields: Record<string, unknown>): void {
-	console.log(JSON.stringify({ event, ...fields }));
+	// Hash both inputs to fixed-length 32-byte digests so timingSafeEqual cannot
+	// throw on length mismatch and there is no length oracle from an early return.
+	const aDigest = createHash("sha256").update(a, "utf8").digest();
+	const bDigest = createHash("sha256").update(b, "utf8").digest();
+	return timingSafeEqual(aDigest, bDigest);
 }
 
 function expiresAt(expiresIn: string): string | null {
@@ -51,6 +51,32 @@ function expiresAt(expiresIn: string): string | null {
 export function authRoutes(): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
+	// ── Rate limiters ──────────────────────────────────────────────────────────
+	// Per-route limits so brute-forcing X-Admin-Secret / X-Auth-Secret is bounded.
+	// Bootstrap is unauthenticated (no `c.get("owner")`) so it is keyed by IP only;
+	// admin is keyed by both IP and Bearer sub, tripping on either to defeat
+	// rotating-IP attackers reusing the same Bearer token.
+	const adminLimiter = rateLimit({
+		windowMs: parseNonNegativeInt("ADMIN_RATE_LIMIT_WINDOW_MS", 60_000),
+		max: parseNonNegativeInt("ADMIN_RATE_LIMIT_MAX", 5),
+		scope: "admin",
+		keys: (c) => {
+			const ip = clientIp(c);
+			const sub = (c.get("owner") as string | undefined) ?? "anon";
+			return [`admin:ip:${ip}`, `admin:sub:${sub}`];
+		},
+	});
+
+	const bootstrapLimiter = rateLimit({
+		windowMs: parseNonNegativeInt("BOOTSTRAP_RATE_LIMIT_WINDOW_MS", 60_000),
+		max: parseNonNegativeInt("BOOTSTRAP_RATE_LIMIT_MAX", 5),
+		scope: "bootstrap",
+		keys: (c) => [`bootstrap:ip:${clientIp(c)}`],
+	});
+
+	router.use("/admin", adminLimiter);
+	router.use("/bootstrap", bootstrapLimiter);
+
 	// ── POST /v1/auth/bootstrap ────────────────────────────────────────────────
 	// Unauthenticated. Exempt from Bearer middleware via UNAUTHENTICATED_PATHS.
 	// Authorization is AUTH_SECRET sent as X-Auth-Secret (constant-time compare).
@@ -60,7 +86,7 @@ export function authRoutes(): Hono<{ Variables: AuthVariables }> {
 			// Secret check runs before body parsing — callers without the correct
 			// secret cannot probe the schema with cheap 400s.
 			const authSecret = process.env.AUTH_SECRET;
-			const ip = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? "unknown";
+			const ip = clientIp(c);
 			const ua = c.req.header("user-agent") ?? "";
 
 			if (!authSecret) {
@@ -78,7 +104,7 @@ export function authRoutes(): Hono<{ Variables: AuthVariables }> {
 		},
 		validateBody(bootstrapBodySchema),
 		async (c) => {
-			const ip = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? "unknown";
+			const ip = clientIp(c);
 			const ua = c.req.header("user-agent") ?? "";
 			const authSecret = process.env.AUTH_SECRET;
 			if (!authSecret) {
@@ -111,32 +137,97 @@ export function authRoutes(): Hono<{ Variables: AuthVariables }> {
 
 	// ── POST /v1/auth/admin ────────────────────────────────────────────────────
 	// Requires Bearer JWT (enforced by /v1/* middleware) + X-Admin-Secret header.
-	router.post("/admin", validateBody(tokenBodySchema), async (c) => {
-		const adminSecret = process.env.ADMIN_SECRET;
-		if (!adminSecret) {
-			return c.json({ error: "admin_not_configured", code: "ADMIN_NOT_CONFIGURED" }, 500 as ContentfulStatusCode);
-		}
+	// Pre-middleware verifies the admin secret with timing-safe compare BEFORE
+	// body validation, so callers without the correct secret cannot probe the
+	// schema with cheap 400s.
+	router.post(
+		"/admin",
+		async (c, next) => {
+			const adminSecret = process.env.ADMIN_SECRET;
+			const ip = clientIp(c);
+			const ua = c.req.header("user-agent") ?? "";
+			const caller = c.get("owner");
 
-		const providedSecret = c.req.header("X-Admin-Secret");
-		if (providedSecret !== adminSecret) {
-			return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
-		}
+			if (!adminSecret) {
+				logAudit("admin_token_misconfigured", { ts: new Date().toISOString(), ip, ua, caller });
+				return c.json({ error: "admin_not_configured", code: "ADMIN_NOT_CONFIGURED" }, 500 as ContentfulStatusCode);
+			}
 
-		const { sub, tenant, expiresIn = "30d" } = c.get("body");
+			const provided = c.req.header("X-Admin-Secret");
+			if (!provided || !constantTimeEqual(provided, adminSecret)) {
+				logAudit("admin_token_denied", {
+					ts: new Date().toISOString(),
+					ip,
+					ua,
+					caller,
+					reason: provided ? "mismatch" : "missing_header",
+				});
+				return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
+			}
 
-		if (tenant !== undefined && !loadTenantConfig().hasTenant(tenant)) {
-			return c.json({ error: "unknown_tenant", code: "INVALID_INPUT" }, 400 as ContentfulStatusCode);
-		}
+			await next();
+		},
+		validateBody(tokenBodySchema),
+		async (c) => {
+			const ip = clientIp(c);
+			const ua = c.req.header("user-agent") ?? "";
+			const caller = c.get("owner");
+			const callerTenant = c.get("tenant");
 
-		const authSecret = process.env.AUTH_SECRET;
-		if (!authSecret) {
-			return c.json({ error: "auth_not_configured", code: "AUTH_NOT_CONFIGURED" }, 500 as ContentfulStatusCode);
-		}
+			const authSecret = process.env.AUTH_SECRET;
+			if (!authSecret) {
+				logAudit("admin_token_misconfigured", {
+					ts: new Date().toISOString(),
+					ip,
+					ua,
+					caller,
+					reason: "auth_secret_unset",
+				});
+				return c.json({ error: "auth_not_configured", code: "AUTH_NOT_CONFIGURED" }, 500 as ContentfulStatusCode);
+			}
 
-		const token = await signToken({ sub, tenant, expiresIn, secret: authSecret });
-		const at = expiresAt(expiresIn);
-		return c.json({ token, sub, tenant, expiresAt: at }, 201 as ContentfulStatusCode);
-	});
+			const {
+				sub,
+				tenant,
+				expiresIn = "30d",
+			} = c.get("body") as {
+				sub: string;
+				tenant?: string;
+				expiresIn?: "30d" | "1y" | "24h" | "never";
+			};
+
+			if (tenant !== undefined && !loadTenantConfig().hasTenant(tenant)) {
+				logAudit("admin_token_denied", {
+					ts: new Date().toISOString(),
+					ip,
+					ua,
+					caller,
+					reason: "unknown_tenant",
+					tenant,
+				});
+				return c.json({ error: "unknown_tenant", code: "INVALID_INPUT" }, 400 as ContentfulStatusCode);
+			}
+
+			const jti = randomUUID();
+			const token = await signToken({ sub, tenant, expiresIn, secret: authSecret, jti });
+			const at = expiresAt(expiresIn);
+
+			logAudit("admin_token_issued", {
+				ts: new Date().toISOString(),
+				caller,
+				callerTenant,
+				sub,
+				tenant,
+				expiresIn,
+				expiresAt: at,
+				jti,
+				ip,
+				ua,
+			});
+
+			return c.json({ token, sub, tenant, expiresAt: at }, 201 as ContentfulStatusCode);
+		},
+	);
 
 	return router;
 }

--- a/tasks/IMPLEMENT-issue-23-admin-token-hardening.md
+++ b/tasks/IMPLEMENT-issue-23-admin-token-hardening.md
@@ -1,0 +1,587 @@
+# IMPLEMENT — Issue #23: Harden `POST /v1/auth/admin`
+
+> **Read this first if you're new to the issue.** The scope is limited to `src/api/`. No DB schema changes, no migration work, no `just-bash` changes. The goal is to bring one auth endpoint up to security parity with its sibling and add a missing rate-limit primitive. Plan-only document — do not start coding until you've read all of §1–§3.
+
+---
+
+## 1. Background — what is this and why
+
+`virtualfs-api` mints HS256 JWTs that callers attach as `Authorization: Bearer <jwt>` to every `/v1/*` request. Tokens are produced by two endpoints:
+
+| Endpoint | Auth required | Purpose |
+|---|---|---|
+| `POST /v1/auth/bootstrap` | `X-Auth-Secret` header == `AUTH_SECRET` env | First-time setup. Exempt from Bearer middleware (chicken-and-egg: how would you get the first JWT otherwise?). |
+| `POST /v1/auth/admin` | Bearer JWT **and** `X-Admin-Secret` header == `ADMIN_SECRET` env | Day-2 token rotation. Mints a JWT for any `sub`/`tenant`. |
+
+Both live in `src/api/routes/auth.ts`. The Bearer middleware that gates `/v1/*` lives in `src/api/auth.ts`; it skips bootstrap via the `UNAUTHENTICATED_PATHS` set (`src/api/auth.ts:45`).
+
+**The asymmetry that motivates this work:** when `bootstrap` was added, it was hardened from day one (timing-safe compare, audit logs, secret-check-before-validateBody, hard-fail on missing `AUTH_SECRET`). The older `admin` handler in the same file was never brought up to parity. Issue #23 enumerates six gaps in `admin` plus one cross-cutting gap (no rate limit anywhere).
+
+**Threat model:** the route is behind Bearer auth, so an anonymous internet attacker cannot reach it. The realistic threats are:
+1. A holder of any valid Bearer token escalating to mint other `sub`s by brute-forcing `ADMIN_SECRET` (no rate limit + timing leak).
+2. `ADMIN_SECRET` leaks somehow → no audit log to tell who used it or what they minted.
+3. An operator misconfigures `AUTH_SECRET` → silently signs unverifiable tokens.
+
+> **Note on issue text vs. code.** Issue #23 references `src/api/routes/admin.ts` and `POST /v1/admin/tokens`. That file/path no longer exists — the route was relocated. The current location is `POST /v1/auth/admin` in `src/api/routes/auth.ts:114-139`. All findings still apply, just at the new path. `README.md:22` is stale and must be updated.
+
+---
+
+## 2. Current state — exact lines
+
+You will edit / read these files:
+
+| File | What's there now |
+|---|---|
+| `src/api/routes/auth.ts:34-39` | `constantTimeEqual()` helper — has a length-leak bug (early return on length mismatch). Used by bootstrap; will be used by admin too. |
+| `src/api/routes/auth.ts:41-43` | `logAudit()` helper — JSON-line stdout. Reuse as-is. |
+| `src/api/routes/auth.ts:57-110` | `POST /bootstrap` — already hardened. Use it as the structural template for `/admin`. |
+| `src/api/routes/auth.ts:114-139` | `POST /admin` — the handler this PR rewrites. |
+| `src/api/auth.ts:45` | `UNAUTHENTICATED_PATHS = new Set(["POST /v1/auth/bootstrap"])`. Do **not** add `/admin` here — admin must stay behind Bearer. |
+| `src/api/auth.ts:54-58` | Bearer middleware rejects any non-`Bearer` `Authorization` header with 401. This is why we **cannot** add an `Authorization: AdminSecret …` scheme — it would 401 before reaching the handler. |
+| `src/api/lib/jwt.ts:8-14` | `SignTokenOptions`. Add optional `jti?: string`. |
+| `src/api/server.ts:155-160` | Where Bearer middleware mounts and `authRoutes()` mounts. Rate-limit middleware mounts here too. |
+| `src/api/__tests__/admin.test.ts` | Existing tests. Will gain ~10 new cases. |
+| `plugins/virtualfs/skills/api/SETUP.md` | Operator-facing docs. Must mention new env vars. **Note:** there is no top-level `SETUP.md`; this is the only one. |
+| `plugins/virtualfs/skills/api/ref/endpoints.md` | Endpoint reference. Add audit log shapes + 429. |
+| `README.md:22` | Stale `POST /v1/admin/tokens` reference — fix it. |
+| `CHANGELOG.md`, `package.json`, `pnpm-lock.yaml`, `src/api/openapi-spec.ts` | Per CLAUDE.md, all four version fields must be bumped together. |
+
+---
+
+## 3. Architectural decisions made up-front (with rationale)
+
+A reviewer flagged six issues with the first draft of this plan. The decisions below are the resolutions; if you disagree, raise it before coding.
+
+### 3.1. Keep `X-Admin-Secret`. **Drop** the `Authorization: AdminSecret` proposal.
+
+The original issue text suggested moving the admin secret onto the `Authorization` header for redirect-stripping safety. This is incompatible with the current architecture: `/v1/auth/admin` lives under `/v1/*`, which the Bearer middleware (`src/api/auth.ts:54-58`) already requires for. A second auth scheme on the same header would either be 401'd by the middleware, or require us to skip Bearer for admin — which would *remove* the defense-in-depth that issue #23 explicitly calls a strength.
+
+→ Keep `X-Admin-Secret`. File a separate ticket for redirect-safe admin auth (would need its own design — likely a dedicated `Admin-Authorization` header or moving admin off `/v1/*`).
+
+### 3.2. Replace `constantTimeEqual()` with a SHA-256-digest compare.
+
+The current helper (`src/api/routes/auth.ts:34-39`) returns early on length mismatch, which is itself a length oracle. Issue #23 explicitly asks for `timingSafeEqual` over equal-length SHA-256 digests. We update the shared helper, which fixes bootstrap and admin in one change.
+
+### 3.3. Rate-limit policy is per-route, not blanket `/v1/auth/*`.
+
+Bootstrap is unauthenticated (no `c.get("owner")`), so a per-`sub` key would crash there. Admin is authenticated, so per-`sub` is meaningful and necessary (otherwise a rotating-IP attacker bypasses per-IP). Therefore:
+
+- `POST /v1/auth/admin` — limited by `(ip, sub)`. Either trip → 429.
+- `POST /v1/auth/bootstrap` — limited by `(ip)` only.
+
+### 3.4. Rate-limit store is in-memory and **injectable**.
+
+Multi-replica leakage is acknowledged (a follow-up ticket will swap to Redis using the existing `getRedisClient()`). For tests, the store and clock are injectable, and a module-level default store exposes `.reset()` so `beforeEach` can wipe state between tests. Without this, the existing `admin.test.ts` will start failing as soon as the limiter is mounted.
+
+### 3.5. `jti` is generated **before** signing, included in claims, and logged.
+
+The audit log records the `jti`; the token also carries it. This lets an operator correlate a leaked-token incident back to the exact `admin_token_issued` log line. Add `jti?: string` to `SignTokenOptions` and `.setJti(jti)` in `signToken`.
+
+### 3.6. Audit event names follow issue #23: `admin_token_issued` / `admin_token_denied` / `admin_token_misconfigured`.
+
+Bootstrap's existing names (`auth_bootstrap_*`) stay as-is — they've shipped. The naming inconsistency between the two routes is an intentional, documented deviation in this PR; normalize in a follow-up ticket. Error codes (`ADMIN_NOT_CONFIGURED`, `AUTH_NOT_CONFIGURED`) stay as the more-specific values already in the code rather than the issue's `INTERNAL_ERROR`.
+
+### 3.7. Out of scope for this PR
+
+- Redirect-safe admin auth (see §3.1).
+- Redis-backed rate limit (in-memory v1 only).
+- Audit-name normalization across both routes (see §3.6).
+- JWT → opaque DB tokens, mTLS — deferred per issue.
+
+---
+
+## 4. Phased implementation
+
+Each phase has a single, testable outcome. Run the verification at the end of each phase before moving on. **Do not batch phases.** Type-check and lint after every phase: `pnpm typecheck && pnpm lint:fix`.
+
+### Phase 1 — Fix the shared `constantTimeEqual` helper
+
+**Touch:** `src/api/routes/auth.ts:34-39`.
+
+```ts
+import { createHash, timingSafeEqual } from "node:crypto";
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aDigest = createHash("sha256").update(a, "utf8").digest();
+  const bDigest = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(aDigest, bDigest);
+}
+```
+
+**Why first:** smallest, lowest-risk change. Bootstrap continues working (its callers always have correct length today), and we'll have the safe helper ready when admin starts using it in Phase 3.
+
+**Verification:**
+- [ ] `pnpm typecheck` passes.
+- [ ] Existing bootstrap tests still pass: `pnpm test -- src/api/__tests__/bootstrap` (or wherever they live).
+- [ ] New unit test: `constantTimeEqual` returns `false` for two strings of different lengths and does **not** early-return (assert by checking it took the digest path — easiest proxy is to spy on `createHash`).
+
+### Phase 2 — Plumb `jti` through `signToken`
+
+**Touch:** `src/api/lib/jwt.ts`.
+
+```ts
+export interface SignTokenOptions {
+  sub: string;
+  tenant?: string;
+  expiresIn?: string;
+  secret: string;
+  jti?: string;          // NEW
+}
+
+// in signToken(...)
+if (jti !== undefined) {
+  jwt.setJti(jti);
+}
+```
+
+**Verification:**
+- [ ] Unit test: `signToken({ ..., jti: "abc-123" })` produces a token whose decoded payload has `jti === "abc-123"`.
+- [ ] Unit test: omitting `jti` produces a token with no `jti` claim (regression — bootstrap still works).
+- [ ] `pnpm typecheck && pnpm test:unit` green.
+
+### Phase 3 — Harden `POST /v1/auth/admin`
+
+**Touch:** `src/api/routes/auth.ts:114-139`. Replace the single-handler `router.post("/admin", validateBody(...), async (c) => { ... })` form with the same three-arg pattern bootstrap uses. Structure:
+
+```ts
+import { randomUUID } from "node:crypto";
+
+router.post(
+  "/admin",
+  // 1) Pre-middleware: secret check BEFORE body parsing.
+  async (c, next) => {
+    const adminSecret = process.env.ADMIN_SECRET;
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0].trim()
+      ?? c.req.header("x-real-ip") ?? "unknown";
+    const ua = c.req.header("user-agent") ?? "";
+    const caller = c.get("owner");
+
+    if (!adminSecret) {
+      logAudit("admin_token_misconfigured", { ts: new Date().toISOString(), ip, ua, caller });
+      return c.json(
+        { error: "admin_not_configured", code: "ADMIN_NOT_CONFIGURED" },
+        500 as ContentfulStatusCode,
+      );
+    }
+
+    const provided = c.req.header("X-Admin-Secret");
+    if (!provided || !constantTimeEqual(provided, adminSecret)) {
+      logAudit("admin_token_denied", {
+        ts: new Date().toISOString(),
+        ip, ua, caller,
+        reason: provided ? "mismatch" : "missing_header",
+      });
+      return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
+    }
+    await next();
+  },
+  // 2) Body validation — only runs once secret is verified.
+  validateBody(tokenBodySchema),
+  // 3) Handler.
+  async (c) => {
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0].trim()
+      ?? c.req.header("x-real-ip") ?? "unknown";
+    const ua = c.req.header("user-agent") ?? "";
+    const caller = c.get("owner");
+    const callerTenant = c.get("tenant");
+
+    const authSecret = process.env.AUTH_SECRET;
+    if (!authSecret) {
+      logAudit("admin_token_misconfigured", {
+        ts: new Date().toISOString(), ip, ua, caller, reason: "auth_secret_unset",
+      });
+      return c.json(
+        { error: "auth_not_configured", code: "AUTH_NOT_CONFIGURED" },
+        500 as ContentfulStatusCode,
+      );
+    }
+
+    const { sub, tenant, expiresIn = "30d" } = c.get("body");
+    if (tenant !== undefined && !loadTenantConfig().hasTenant(tenant)) {
+      logAudit("admin_token_denied", {
+        ts: new Date().toISOString(), ip, ua, caller, reason: "unknown_tenant", tenant,
+      });
+      return c.json({ error: "unknown_tenant", code: "INVALID_INPUT" }, 400 as ContentfulStatusCode);
+    }
+
+    const jti = randomUUID();
+    const token = await signToken({ sub, tenant, expiresIn, secret: authSecret, jti });
+    const at = expiresAt(expiresIn);
+
+    logAudit("admin_token_issued", {
+      ts: new Date().toISOString(),
+      caller, callerTenant,
+      sub, tenant, expiresIn, jti, ip, ua,
+      // NB: never log `token`.
+    });
+
+    return c.json({ token, sub, tenant, expiresAt: at }, 201 as ContentfulStatusCode);
+  },
+);
+```
+
+**Verification:**
+- [ ] All existing `admin.test.ts` cases pass (you may need a `beforeEach(() => vi.spyOn(console, "log"))` cleanup, but no assertions should change).
+- [ ] New unit tests (each one `it()`):
+  - `returns 403 with timing-safe compare on wrong X-Admin-Secret`
+  - `returns 403 when X-Admin-Secret header is missing`
+  - `returns 500 ADMIN_NOT_CONFIGURED when ADMIN_SECRET is unset`
+  - `returns 500 AUTH_NOT_CONFIGURED when AUTH_SECRET is unset`
+  - `does not run validateBody when secret is wrong` — POST a body that would fail Zod (e.g. `{ sub: "" }`) with a wrong secret; expect 403, not 400
+  - `emits admin_token_issued audit log` — capture `console.log`, parse JSON, assert shape, assert `jti` matches the decoded token's `jti`, assert the token string is **not** in the log
+  - `emits admin_token_denied audit log on 403`
+- [ ] `pnpm typecheck && pnpm lint:fix && pnpm test:unit` green.
+
+### Phase 4 — Rate-limit primitive
+
+**New file:** `src/api/rate-limit.ts`.
+
+Sketch:
+```ts
+import type { Context, MiddlewareHandler } from "hono";
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  resetAt: number;     // ms epoch
+  remaining: number;
+}
+export interface RateLimitStore {
+  hit(key: string, windowMs: number, max: number, now: number): RateLimitDecision;
+  reset(): void;
+}
+
+export class InMemoryRateLimitStore implements RateLimitStore {
+  // Map<key, { count: number; resetAt: number }>
+  // hit(): on first hit OR after window expiry, reset counter to 1
+  //        otherwise increment; allowed = count <= max
+  // reset(): clear the map (test hook)
+  // Lazy GC: every 1024 hits, drop entries with resetAt < now
+}
+
+export const defaultRateLimitStore = new InMemoryRateLimitStore();
+
+export interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+  scope: "admin" | "bootstrap";
+  keys: (c: Context) => string[];   // 1+ keys; trip on any
+  store?: RateLimitStore;
+  now?: () => number;
+}
+export function rateLimit(opts: RateLimitOptions): MiddlewareHandler {
+  // For each key, call store.hit(); if any returns allowed=false:
+  //   logAudit("auth_rate_limited", { ts, scope, keys, ip, sub, path })
+  //   c.header("Retry-After", String(Math.ceil((resetAt - now)/1000)))
+  //   return 429 { error: "rate_limited", code: "RATE_LIMITED" }
+  // Otherwise next().
+}
+
+// Tiny env helpers (or reuse src/redis/config.ts:parseNonNegativeInt if shape fits).
+export function parseEnvInt(name: string, fallback: number): number;
+export function parseEnvMs(name: string, fallback: number): number;
+```
+
+**Wire-up in `src/api/server.ts`** — mount per-route, after Bearer middleware so `c.get("owner")` is set for admin:
+
+```ts
+// In src/api/routes/auth.ts (or server.ts — pick one and stay consistent):
+const adminLimiter = rateLimit({
+  windowMs: parseEnvMs("ADMIN_RATE_LIMIT_WINDOW_MS", 60_000),
+  max: parseEnvInt("ADMIN_RATE_LIMIT_MAX", 5),
+  scope: "admin",
+  keys: (c) => {
+    const ip = clientIp(c);                  // shared helper or inline
+    const sub = c.get("owner") ?? "anon";
+    return [`admin:ip:${ip}`, `admin:sub:${sub}`];
+  },
+});
+
+const bootstrapLimiter = rateLimit({
+  windowMs: parseEnvMs("BOOTSTRAP_RATE_LIMIT_WINDOW_MS", 60_000),
+  max: parseEnvInt("BOOTSTRAP_RATE_LIMIT_MAX", 5),
+  scope: "bootstrap",
+  keys: (c) => [`bootstrap:ip:${clientIp(c)}`],
+});
+
+router.use("/admin", adminLimiter);
+router.use("/bootstrap", bootstrapLimiter);
+```
+
+**Verification:**
+- [ ] Unit tests with injected store + fake clock:
+  - `enforces 5/min per IP on /admin` — 6 requests in window, 6th = 429 with `Retry-After`
+  - `enforces 5/min per Bearer sub on /admin` — same caller, rotating IPs, still throttles
+  - `bootstrap is rate-limited per IP only` — 6 requests, 6th = 429
+  - `bootstrap is NOT subject to per-sub limit` — calling `c.get("owner")` would crash; assert no crash and only one key checked
+  - `429 emits auth_rate_limited audit log with {ts, scope, ip, sub, path}`
+  - `window rolls over` — advance fake clock past `windowMs`, request succeeds again
+- [ ] Existing test suites pass with `beforeEach(() => defaultRateLimitStore.reset())` added wherever the tests issue >5 requests.
+- [ ] `pnpm test:unit` green.
+
+### Phase 5 — Docs + version bump
+
+**Touch (in this exact set, per CLAUDE.md):**
+
+1. `plugins/virtualfs/skills/api/SETUP.md`:
+   - Document new env vars: `ADMIN_RATE_LIMIT_WINDOW_MS` (default 60000), `ADMIN_RATE_LIMIT_MAX` (default 5), `BOOTSTRAP_RATE_LIMIT_WINDOW_MS`, `BOOTSTRAP_RATE_LIMIT_MAX`.
+   - Document audit log events: `admin_token_issued`, `admin_token_denied`, `admin_token_misconfigured`, `auth_rate_limited`.
+   - Document `429 RATE_LIMITED` with `Retry-After`.
+2. `plugins/virtualfs/skills/api/ref/endpoints.md`:
+   - Add 429 row to `POST /v1/auth/admin` and `POST /v1/auth/bootstrap`.
+   - Add audit-log shape examples.
+3. `README.md:22`: replace `POST /v1/admin/tokens` → `POST /v1/auth/admin`.
+4. `CHANGELOG.md`: prepend `## [0.2.8] - 2026-04-28` with bullets under `Changed` (timing-safe compare uses sha256 digest; admin handler order; rate limit on auth routes) and `Added` (`jti` claim on admin tokens; `admin_token_*` audit events; `auth_rate_limited` audit event).
+5. `package.json`: `"version": "0.2.8"`.
+6. `pnpm-lock.yaml`: regenerate via `pnpm install --lockfile-only`.
+7. `src/api/openapi-spec.ts`: `info.version = "0.2.8"`; add `429 RATE_LIMITED` response to both auth ops.
+8. `.env.example`: add commented `ADMIN_SECRET=` line if missing (verify — currently absent).
+
+**Verification:**
+- [ ] All four version locations match `0.2.8` (CHANGELOG, package.json, pnpm-lock.yaml, openapi-spec.ts).
+- [ ] `pnpm typecheck && pnpm lint:fix && pnpm test` all green.
+- [ ] `grep -rn "v1/admin/tokens" .` returns no hits except in `tasks/` (historical) and `CHANGELOG.md`.
+
+---
+
+## 5. Manual end-to-end testing (docker postgres + redis + local API)
+
+Automated tests prove the units work. This section proves the assembled service behaves correctly for an operator.
+
+### 5.1. Prerequisites
+
+```bash
+# from the repo root
+cp .env.example .env   # if not already present
+```
+
+Edit `.env` to set:
+```bash
+FS_BACKEND=postgres
+DATABASE_URL=postgres://postgres:test@localhost:5432/virtualfs
+DATABASE_DIRECT_URL=postgres://postgres:test@localhost:5432/virtualfs
+PORT=8080
+AUTH_SECRET=local-auth-secret-please-change
+ADMIN_SECRET=local-admin-secret-please-change
+REDIS_URL=redis://localhost:6379
+SESSION_IDLE_MS=600000
+
+# new in this PR — defaults are 60000ms / 5 req
+ADMIN_RATE_LIMIT_WINDOW_MS=60000
+ADMIN_RATE_LIMIT_MAX=5
+BOOTSTRAP_RATE_LIMIT_WINDOW_MS=60000
+BOOTSTRAP_RATE_LIMIT_MAX=5
+```
+
+### 5.2. Bring up dependencies
+
+```bash
+docker compose -f docker-compose.local.yml up -d pg redis
+docker compose -f docker-compose.local.yml ps     # both healthy
+```
+
+Confirm:
+```bash
+psql "postgres://postgres:test@localhost:5432/virtualfs" -c '\dt'   # tables list (post-migration)
+redis-cli -u redis://localhost:6379 PING                            # PONG
+```
+
+### 5.3. Start the API locally
+
+```bash
+pnpm install
+pnpm dev    # runs migrations, then tsx watch on PORT=8080
+```
+
+Tail logs in a second terminal — the audit lines we add are JSON to stdout. A small jq filter helps:
+```bash
+# in the dev-server terminal, pipe through:
+pnpm dev 2>&1 | tee /tmp/api.log
+# in a third terminal:
+tail -f /tmp/api.log | jq -c 'select(.event | test("admin_token|auth_rate|auth_bootstrap"))'
+```
+
+### 5.4. E2E test script
+
+Run each block in order. Each block names the case, the command, and what to look for. **All curl commands assume `bash`.**
+
+#### 5.4.1. Bootstrap a Bearer token (sanity: nothing in this PR breaks the bootstrap path)
+
+```bash
+export AUTH_SECRET="local-auth-secret-please-change"
+export ADMIN_SECRET="local-admin-secret-please-change"
+
+BEARER=$(curl -sf -X POST http://localhost:8080/v1/auth/bootstrap \
+  -H "X-Auth-Secret: $AUTH_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"sub":"e2e-tester","expiresIn":"24h"}' | jq -r .token)
+
+echo "$BEARER" | cut -c1-30   # eyJ...
+```
+
+**Expect:** 201, valid JWT, audit log line `{"event":"auth_bootstrap_issued",...}`.
+
+#### 5.4.2. Happy path — admin mints a token
+
+```bash
+curl -sf -X POST http://localhost:8080/v1/auth/admin \
+  -H "Authorization: Bearer $BEARER" \
+  -H "X-Admin-Secret: $ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"sub":"freshly-minted","expiresIn":"30d"}' | jq
+```
+
+**Expect:**
+- HTTP 201, body `{token, sub:"freshly-minted", tenant:null, expiresAt}`.
+- Audit log: `{"event":"admin_token_issued","caller":"e2e-tester","sub":"freshly-minted","jti":"<uuid>",...}`.
+- Decode the returned token (`echo "<token>" | cut -d. -f2 | base64 -d`) — `jti` field must match the one in the audit log.
+- The token string itself must **not** appear in any log line.
+
+#### 5.4.3. Wrong `X-Admin-Secret` — 403, no schema leak, audit denial
+
+```bash
+# Body is intentionally invalid (sub is empty). Pre-PR behavior would 400 with Zod errors.
+curl -i -X POST http://localhost:8080/v1/auth/admin \
+  -H "Authorization: Bearer $BEARER" \
+  -H "X-Admin-Secret: wrong-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"sub":""}'
+```
+
+**Expect:**
+- HTTP 403 with `{"error":"forbidden","code":"FORBIDDEN"}` (NOT 400 — proves secret check runs before validateBody).
+- Audit log: `{"event":"admin_token_denied","reason":"mismatch",...}`.
+
+#### 5.4.4. Missing `X-Admin-Secret` — 403 with `reason: "missing_header"`
+
+```bash
+curl -i -X POST http://localhost:8080/v1/auth/admin \
+  -H "Authorization: Bearer $BEARER" \
+  -H "Content-Type: application/json" \
+  -d '{"sub":"foo"}'
+```
+
+**Expect:** HTTP 403, audit log `reason:"missing_header"`.
+
+#### 5.4.5. `ADMIN_SECRET` unset — 500 `ADMIN_NOT_CONFIGURED`
+
+In a separate shell, restart the dev server with the var unset:
+```bash
+ADMIN_SECRET= pnpm dev   # or unset and restart your shell session
+```
+
+```bash
+curl -i -X POST http://localhost:8080/v1/auth/admin \
+  -H "Authorization: Bearer $BEARER" \
+  -H "X-Admin-Secret: anything" \
+  -H "Content-Type: application/json" \
+  -d '{"sub":"foo"}'
+```
+
+**Expect:** HTTP 500, `{"error":"admin_not_configured","code":"ADMIN_NOT_CONFIGURED"}`. Audit log: `admin_token_misconfigured`. Restore `ADMIN_SECRET` afterward.
+
+#### 5.4.6. `AUTH_SECRET` unset — 500 `AUTH_NOT_CONFIGURED`
+
+This is harder to test because Bearer middleware also requires `AUTH_SECRET` (the request would 401 first). Test by *temporarily* clearing `AUTH_SECRET` mid-process is not possible; instead this case is fully covered by the unit test in Phase 3. Skip in the E2E run and note it in the PR description.
+
+#### 5.4.7. Rate limit — per-IP
+
+Restore `ADMIN_SECRET` and Bearer. Hit the endpoint 6 times back-to-back with **wrong** secret (cheaper, same limiter):
+
+```bash
+for i in $(seq 1 6); do
+  echo "--- attempt $i ---"
+  curl -s -o /dev/null -w "status=%{http_code} retry-after=%{header_retry_after}\n" \
+    -X POST http://localhost:8080/v1/auth/admin \
+    -H "Authorization: Bearer $BEARER" \
+    -H "X-Admin-Secret: wrong" \
+    -H "Content-Type: application/json" \
+    -d '{"sub":"foo"}'
+done
+```
+
+**Expect:** attempts 1–5 return 403; attempt 6 returns 429 with `Retry-After` header. Audit log shows `auth_rate_limited` with `scope:"admin"`. Wait `ADMIN_RATE_LIMIT_WINDOW_MS` (60s default) and confirm requests succeed again.
+
+#### 5.4.8. Rate limit — per-`sub`
+
+Lower the per-IP cap by setting `ADMIN_RATE_LIMIT_MAX=100` and restart. Then hit from rotating IPs (use `X-Forwarded-For`) but the same Bearer:
+
+```bash
+for i in $(seq 1 6); do
+  curl -s -o /dev/null -w "ip=%{header_x_forwarded_for_sent} status=%{http_code}\n" \
+    -X POST http://localhost:8080/v1/auth/admin \
+    -H "Authorization: Bearer $BEARER" \
+    -H "X-Forwarded-For: 10.0.0.$i" \
+    -H "X-Admin-Secret: wrong" \
+    -H "Content-Type: application/json" \
+    -d '{"sub":"foo"}'
+done
+```
+
+**Expect:** attempts 1–5 return 403; attempt 6 returns 429 (per-`sub` key tripped even though IP keys would still allow). Restore `ADMIN_RATE_LIMIT_MAX=5`.
+
+#### 5.4.9. Bootstrap rate limit — per-IP only, no crash on missing `sub`
+
+```bash
+for i in $(seq 1 6); do
+  curl -s -o /dev/null -w "status=%{http_code}\n" \
+    -X POST http://localhost:8080/v1/auth/bootstrap \
+    -H "X-Auth-Secret: wrong" \
+    -H "Content-Type: application/json" \
+    -d '{"sub":"x"}'
+done
+```
+
+**Expect:** attempts 1–5 return 403; attempt 6 returns 429. **No 500s** (proves bootstrap limiter doesn't try to read `c.get("owner")`).
+
+#### 5.4.10. Sanity — token returned in 5.4.2 actually authenticates
+
+```bash
+NEW_TOKEN=<copy from 5.4.2 response>
+curl -i http://localhost:8080/v1/sandboxes -H "Authorization: Bearer $NEW_TOKEN"
+```
+
+**Expect:** HTTP 200, JSON list (possibly empty). Proves the `jti` plumbing didn't break verification.
+
+### 5.5. Tear-down
+
+```bash
+docker compose -f docker-compose.local.yml down -v
+```
+
+---
+
+## 6. Pre-merge checklist
+
+Copy this into the PR description and tick off:
+
+- [ ] Phase 1: SHA-256 digest compare in `constantTimeEqual`. Bootstrap regression tests pass.
+- [ ] Phase 2: `jti` plumbed through `signToken`. Unit tests green.
+- [ ] Phase 3: `/v1/auth/admin` rewritten — pre-middleware order, audit logs, hard-fail on missing `AUTH_SECRET`, `jti` in claims+log. New unit tests added.
+- [ ] Phase 4: `src/api/rate-limit.ts` added. Per-route limiters mounted. Default store + injectable for tests. Existing tests reset the store in `beforeEach`.
+- [ ] Phase 5: Docs (SETUP.md, endpoints.md, README.md). All four version fields bumped to `0.2.8`. CHANGELOG written.
+- [ ] All E2E steps in §5.4.1–5.4.10 pass on a fresh `docker compose up`.
+- [ ] `pnpm typecheck && pnpm lint:fix && pnpm test` all green.
+- [ ] PR description names the deferred items (§3.1, §3.4 Redis, §3.6 audit-name normalization) and links follow-up tickets.
+- [ ] No `Co-Authored-By` trailer on commits (per repo convention).
+
+---
+
+## 7. File-by-file change summary
+
+| File | Change |
+|---|---|
+| `src/api/routes/auth.ts` | `constantTimeEqual` → sha256 digest. `/admin` handler split into pre-middleware + validateBody + handler. `admin_token_*` audit logs. `jti` from `randomUUID()`. Mount admin/bootstrap rate limiters. |
+| `src/api/lib/jwt.ts` | `jti?: string` in `SignTokenOptions`; `jwt.setJti(jti)` when present. |
+| `src/api/rate-limit.ts` | **NEW.** `RateLimitStore` interface, `InMemoryRateLimitStore`, `defaultRateLimitStore`, `rateLimit()` middleware factory, env helpers. |
+| `src/api/server.ts` | Import + mount limiters. (Or in `routes/auth.ts` — pick one.) |
+| `src/api/openapi-spec.ts` | 429 response on both auth ops. `info.version = "0.2.8"`. |
+| `src/api/__tests__/admin.test.ts` | ~7 new cases (Phase 3). `beforeEach` resets store + log spy. |
+| `src/api/__tests__/bootstrap.test.ts` (new or existing) | Rate-limit cases. |
+| `src/api/__tests__/rate-limit.test.ts` (new) | Store + middleware unit tests with fake clock. |
+| `plugins/virtualfs/skills/api/SETUP.md` | Env vars, audit events, 429. |
+| `plugins/virtualfs/skills/api/ref/endpoints.md` | 429 row, audit shapes. |
+| `README.md` | `POST /v1/admin/tokens` → `POST /v1/auth/admin` (line 22). |
+| `.env.example` | Add `ADMIN_SECRET=` and rate-limit env stubs. |
+| `CHANGELOG.md` | New `## [0.2.8] - 2026-04-28` section. |
+| `package.json` | `"version": "0.2.8"`. |
+| `pnpm-lock.yaml` | Regenerated via `pnpm install --lockfile-only`. |


### PR DESCRIPTION
## Summary

Closes issue #23 — bring `POST /v1/auth/admin` up to security parity with the
hardened `POST /v1/auth/bootstrap` and add the missing rate-limit primitive.

- **Hardening on `/v1/auth/admin`:** sha256-digest timing-safe compare (no length
  oracle), secret check before `validateBody`, hard-fail on missing
  `AUTH_SECRET`, server-generated `jti` recorded in `admin_token_issued` audit
  log, full `admin_token_*` audit-event suite. Token strings are never logged.
- **Rate limiter (`src/api/rate-limit.ts`):** in-memory store with injectable
  clock and FIFO entry cap (default `10000`) so attacker-controlled key
  cardinality cannot grow the Map unbounded. Mounted per-route — `/admin` keyed
  by `(ip, sub)` (either tripping returns 429 with `Retry-After`), `/bootstrap`
  keyed by `(ip)`.
- **`clientIp()` is safe-by-default:** ignores `X-Forwarded-For` / `X-Real-IP`
  unless `TRUST_PROXY_HEADERS=true`, preferring the connecting socket's
  `remoteAddress`. SETUP.md spells out when each mode is safe (ingresses that
  *append* to XFF — Azure Container Apps, most K8s ingresses — must NOT enable
  trust). Operator-visible behaviour change documented in CHANGELOG.

Tests: 18 new unit tests (rate-limit primitive, admin handler hardening, jwt
`jti` plumbing). Manual E2E run against docker pg + redis verified all 10 plan
steps including jti in token === jti in audit log, no token leak in logs,
both per-IP and per-sub rate-limit trips.

Out of scope per plan §3.7: redirect-safe admin auth (would need `Admin-Authorization`
header design), Redis-backed rate-limit store (follow-up via existing
`getRedisClient()`), audit-name normalisation across both routes.

## Test plan

- [x] `pnpm typecheck && pnpm lint:fix && pnpm test` all green (573 unit tests
      pass, 87 integration tests skipped without DB env)
- [x] Manual E2E against docker `pg-test` + `redis-test` + local API on `:8090`
      — covered §5.4.1 bootstrap, 5.4.2 admin happy path with `jti` correlation,
      5.4.3 wrong secret + invalid body → 403 (proves secret check before
      `validateBody`), 5.4.4 missing header → 403 `missing_header`, 5.4.5
      `ADMIN_SECRET` unset → 500 `ADMIN_NOT_CONFIGURED`, 5.4.7 per-IP rate
      limit (5×403, 6th=429 + `Retry-After: 49`), 5.4.8 per-sub rate limit
      (rotating `X-Forwarded-For`, same Bearer → `trippedKey:"admin:sub:..."`),
      5.4.9 bootstrap rate limit no-crash on missing `owner`, 5.4.10 minted
      admin token (with `jti`) authenticates `GET /v1/sandboxes` → 200.
- [ ] Reviewer to confirm `TRUST_PROXY_HEADERS` deployment story for Azure
      Container Apps is acceptable (see SETUP.md note).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-endpoint rate limiting for admin and bootstrap (configurable windows/limits, FIFO-bounded store, HTTP 429 + Retry-After) and auth_rate_limited audit events.
  * Admin-issued tokens include a unique JWT ID (jti).
  * New env vars to configure admin/bootstrap rate limits and proxy header trust; ADMIN_SECRET optional (commented).

* **Bug Fixes**
  * Timing-safe secret comparison; admin secret checked before body parsing; missing AUTH_SECRET can return a hard-fail 500.

* **Documentation**
  * README, changelog, OpenAPI and setup docs updated for routes, errors, rate limits, envs and audit events.

* **Tests**
  * Expanded coverage for rate limiting, admin edge cases, jti behavior, and audit logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->