### PR TITLE
ci(sdk): add Python SDK PyPI CI/CD pipeline and rename package to vir…

### DIFF
--- a/.github/workflows/python-sdk-ci.yml
+++ b/.github/workflows/python-sdk-ci.yml
@@ -1,0 +1,70 @@
+name: Python SDK CI
+
+on:
+  push:
+    branches: [main, "ci/**", "feat/**", "fix/**", "feature/**", "ralph/**"]
+    paths:
+      - "clients/python/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "clients/python/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: clients/python
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install --quiet ruff
+
+      - name: Check style
+        run: ruff format --check .
+
+      - name: Check lint
+        run: ruff check .
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install --quiet -e ".[dev]"
+
+      - run: mypy src/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip install --quiet -e ".[dev]"
+
+      - run: pytest -q

--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -25,8 +25,8 @@ jobs:
     # PyPI trusted-publisher config must use the same name in the Environment field.
     environment: release
     permissions:
-      # Scoped to this job only — minimises OIDC token exposure.
-      id-token: write
+      contents: write   # git push tag + GitHub Release creation
+      id-token: write   # OIDC token for PyPI trusted publisher
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -1,0 +1,186 @@
+name: Python SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "clients/python/**"
+
+concurrency:
+  group: python-sdk-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: clients/python
+
+jobs:
+  release:
+    name: Build & maybe publish
+    runs-on: ubuntu-latest
+    # 'release' maps to a GitHub Actions environment (Settings → Environments).
+    # PyPI trusted-publisher config must use the same name in the Environment field.
+    environment: release
+    permissions:
+      # Scoped to this job only — minimises OIDC token exposure.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ── 1. Detect version from clients/python/CHANGELOG.md ───────────────
+      - name: Detect version from CHANGELOG
+        id: detect
+        run: |
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::clients/python/CHANGELOG.md not found"
+            exit 1
+          fi
+
+          VERSION=$(awk '
+            /^## \[Unreleased\]/ { next }
+            /^## \[[^]]+\]/ {
+              line = $0
+              sub(/^## \[/, "", line)
+              sub(/\].*/, "", line)
+              print line
+              exit
+            }
+          ' CHANGELOG.md)
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::No versioned section (## [x.y.z]) found in clients/python/CHANGELOG.md"
+            exit 1
+          fi
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::CHANGELOG version '$VERSION' is not valid SemVer (expected MAJOR.MINOR.PATCH with optional -prerelease)"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+          TAG="python-sdk-v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "RELEASE=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists — skipping PyPI publish"
+          else
+            echo "RELEASE=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG not found — will build, publish to PyPI, and create GitHub Release"
+          fi
+
+      # ── 2. Verify pyproject.toml and _version.py match CHANGELOG ─────────
+      - name: Verify version consistency
+        if: steps.detect.outputs.RELEASE == 'true'
+        run: |
+          CHANGELOG_VER="${{ steps.detect.outputs.VERSION }}"
+
+          PYPROJECT_VER=$(awk -F'"' '/^version =/{print $2; exit}' pyproject.toml)
+          if [ "$CHANGELOG_VER" != "$PYPROJECT_VER" ]; then
+            echo "::error::Version mismatch: CHANGELOG=$CHANGELOG_VER, pyproject.toml=$PYPROJECT_VER"
+            exit 1
+          fi
+
+          VERSION_PY_VER=$(awk -F'"' '/^__version__/{print $2; exit}' src/virtualfs/_version.py)
+          if [ "$CHANGELOG_VER" != "$VERSION_PY_VER" ]; then
+            echo "::error::Version mismatch: CHANGELOG=$CHANGELOG_VER, _version.py=$VERSION_PY_VER"
+            exit 1
+          fi
+
+          echo "All three version files agree on $CHANGELOG_VER"
+
+      # ── 3. Extract CHANGELOG section for the release body ─────────────────
+      - name: Extract CHANGELOG section
+        if: steps.detect.outputs.RELEASE == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.detect.outputs.VERSION }}"
+
+          CONTENT=$(awk -v ver="$VERSION" '
+            BEGIN { header = "## [" ver "]" }
+            index($0, header) == 1 { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md | sed '/^[[:space:]]*$/d')
+
+          if [ -z "$CONTENT" ]; then
+            echo "::error::No CHANGELOG entry found for version [$VERSION]"
+            exit 1
+          fi
+
+          BYTES=$(printf '%s' "$CONTENT" | wc -c)
+          if [ "$BYTES" -gt 10000 ]; then
+            echo "::error::CHANGELOG entry for [$VERSION] is $BYTES bytes; max 10000"
+            exit 1
+          fi
+
+          {
+            echo "CONTENT<<EOF"
+            echo "$CONTENT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── 4. Build sdist + wheel ─────────────────────────────────────────────
+      - uses: actions/setup-python@v5
+        if: steps.detect.outputs.RELEASE == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        if: steps.detect.outputs.RELEASE == 'true'
+        run: |
+          pip install --quiet build
+          python -m build
+
+      - name: Upload build artifacts
+        if: steps.detect.outputs.RELEASE == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sdk-dist-${{ steps.detect.outputs.VERSION }}
+          path: clients/python/dist/
+          retention-days: 30
+
+      # ── 5. Publish to PyPI via OIDC trusted publisher ─────────────────────
+      # Set up trusted publisher on PyPI first:
+      #   Owner: <github-org>, Repo: virtualFS, Workflow: python-sdk-release.yml
+      # To use an API token instead, remove id-token permission above and add:
+      #   password: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish to PyPI
+        if: steps.detect.outputs.RELEASE == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/python/dist/
+
+      # ── 6. Tag and GitHub Release ──────────────────────────────────────────
+      - name: Create and push git tag
+        if: steps.detect.outputs.RELEASE == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "python-sdk-v${{ steps.detect.outputs.VERSION }}"
+          git push origin "python-sdk-v${{ steps.detect.outputs.VERSION }}"
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.RELEASE == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: python-sdk-v${{ steps.detect.outputs.VERSION }}
+          name: Python SDK v${{ steps.detect.outputs.VERSION }}
+          files: clients/python/dist/*
+          body: |
+            ## Python SDK v${{ steps.detect.outputs.VERSION }}
+
+            ${{ steps.changelog.outputs.CONTENT }}
+
+            ---
+
+            Install via pip:
+            ```
+            pip install virtualfs-sdk==${{ steps.detect.outputs.VERSION }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] - 2026-04-30
+
+### Added
+
+- `lefthook` pre-commit hooks: runs `ruff format --check` and `ruff check` against `clients/python/**` staged changes; runs `mypy src/` when `.py` files are staged. Hooks are installed automatically on `pnpm install` via the `prepare` script.
+- GitHub Actions workflow `python-sdk-ci.yml`: path-filtered CI for the Python SDK (lint, typecheck, test matrix on Python 3.9/3.11/3.13).
+- GitHub Actions workflow `python-sdk-release.yml`: automated PyPI publish via OIDC trusted publisher when `clients/python/**` changes land on `main`.
+- `clients/python/CHANGELOG.md` for Python SDK version tracking.
+
+### Changed
+
+- Python SDK PyPI distribution name renamed from `virtualfs` to `virtualfs-sdk`.
+- Fixed pre-existing mypy strict errors in `clients/python/src/virtualfs/_http.py` and `models.py`: typed `list`/`tuple` type arguments, cast `Literal` for `StreamEvent.type`.
+- Fixed pre-existing ruff lint/format issues in `clients/python/examples/perf_benchmark.py` and `tests/test_client.py`.
+
 ## [0.2.8] - 2026-04-28
 
 ### Added

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the VirtualFS Python SDK are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-30
+
+### Added
+
+- `Client` — synchronous HTTP client wrapping all VirtualFS API endpoints; supports
+  token-based auth, `auth_secret`/`sub` bootstrap, and `admin_secret` bootstrap.
+- `SandboxHandle` — fluent handle returned by `client.sandboxes.create()` / `.attach()` / `.get()`;
+  exposes `.fs`, `.exec()`, `.exec_batch()`, `.exec_stream()`, `.ingest_files()`, `.export()`.
+- `FsHandle` — file-system operations: `read`, `write`, `write_files`, `delete`, `mkdir`, `tree`.
+- `ExecResult` / `ExecStreamEvent` — typed result objects for sync and streaming execution.
+- Typed error hierarchy: `VirtualFsError`, `NotFoundError`, `ConflictError`, `AuthError`,
+  `ValidationError`, `RateLimitError`, `ExecTimeoutError`.
+- Automatic retry with exponential back-off on transient 5xx and network errors
+  (configurable via `max_retries`).
+- SSE streaming for `exec_stream()` with per-event typed parsing.
+- `ingest_files()` with base64 encoding of binary payloads.
+- `export()` returning raw `bytes` (tar.gz).
+- Full unit test suite using `respx` mock transport — no network required.
+- `examples/quickstart.py` and `examples/perf_benchmark.py`.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -7,7 +7,7 @@ Handles JWT minting, JSON serialization, retries, and streaming so callers don't
 ## Install
 
 ```bash
-pip install virtualfs
+pip install virtualfs-sdk
 ```
 
 Local (from this repo):

--- a/clients/python/examples/perf_benchmark.py
+++ b/clients/python/examples/perf_benchmark.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import statistics
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -92,7 +91,7 @@ def synth_dataset(count: int, avg_size: int) -> dict[str, bytes]:
     files: dict[str, bytes] = {}
     body_unit = (
         "def helper_{i}(x: int) -> int:\n"
-        "    \"\"\"TODO: tighten input validation.\"\"\"\n"
+        '    """TODO: tighten input validation."""\n'
         "    return x * {i} + {i}\n\n"
         "class Widget_{i}:\n"
         "    name = 'widget-{i}'\n"
@@ -121,11 +120,11 @@ def collect_folder(root: Path) -> dict[str, bytes]:
 
 
 def percentile(samples: list[float], p: float) -> float:
-    """Compute the p-th percentile (0–100) using nearest-rank."""
+    """Compute the p-th percentile (0-100) using nearest-rank."""
     if not samples:
         return float("nan")
     s = sorted(samples)
-    idx = max(0, min(len(s) - 1, int(round(p / 100.0 * (len(s) - 1)))))
+    idx = max(0, min(len(s) - 1, round(p / 100.0 * (len(s) - 1))))
     return s[idx]
 
 
@@ -180,10 +179,10 @@ def bench_ingest(
     n = len(files)
     print(f"[4/8] ingest — comparing 3 methods on {n} files / {total_bytes:,} B ...")
 
-    # 4a: per-file fs.write — quadratic in N round-trips. Capped to PERFILE_CAP
+    # 4a: per-file fs.write — quadratic in N round-trips. Capped to perfile_cap
     # so the benchmark stays bounded; we extrapolate to "estimated full" too.
-    PERFILE_CAP = min(20, n)
-    sub_files = list(files.items())[:PERFILE_CAP]
+    perfile_cap = min(20, n)
+    sub_files = list(files.items())[:perfile_cap]
     sub_bytes = sum(len(v) for _, v in sub_files)
     sb = client.sandboxes.create(name="bench-ingest-perfile")
     try:
@@ -192,21 +191,24 @@ def bench_ingest(
             sb.fs.write(f"{SANDBOX_BASE}/{path}", content)
         ms = (time.perf_counter() - t) * 1000
         kbs = (sub_bytes / 1024) / (ms / 1000) if ms > 0 else None
-        per_file_ms = ms / PERFILE_CAP
+        per_file_ms = ms / perfile_cap
+        est_full = f"~{per_file_ms:.0f} ms/file -> est. {per_file_ms * n / 1000:.1f} s for full {n}"
         rows.append(
             Row(
                 "ingest",
-                f"per-file fs.write × {PERFILE_CAP}  ({sub_bytes:,} B)",
+                f"per-file fs.write x{perfile_cap}  ({sub_bytes:,} B)",
                 ms=ms,
                 throughput_kbs=kbs,
-                note=f"~{per_file_ms:.0f} ms/file → est. {per_file_ms * n / 1000:.1f} s for full {n}",
+                note=est_full,
             )
         )
     finally:
         client.sandboxes.delete(sb.id)
 
     # 4b: fs.write_files — single round-trip, plain JSON (UTF-8 text only).
-    text_only = {f"{SANDBOX_BASE}/{p}": v.decode("utf-8", errors="replace") for p, v in files.items()}
+    text_only = {
+        f"{SANDBOX_BASE}/{p}": v.decode("utf-8", errors="replace") for p, v in files.items()
+    }
     sb = client.sandboxes.create(name="bench-ingest-writefiles")
     try:
         ms, _ = time_call(lambda: sb.fs.write_files(text_only))
@@ -265,7 +267,7 @@ def bench_exec(rows: list[Row], sb: Sandbox) -> None:
     rows.append(
         Row(
             "exec",
-            "exec(':') × 12 — p50",
+            "exec(':') x12 — p50",
             ms=percentile(samples, 50),
             extra={"samples_ms": samples},
         )
@@ -280,9 +282,12 @@ def bench_exec(rows: list[Row], sb: Sandbox) -> None:
         rows.append(
             Row(
                 "exec",
-                f"exec_batch × {n}",
+                f"exec_batch x{n}",
                 ms=ms,
-                note=f"avg {ms / n:.1f} ms/script (vs {percentile(samples, 50):.0f} ms each individually)",
+                note=(
+                    f"avg {ms / n:.1f} ms/script"
+                    f" (vs {percentile(samples, 50):.0f} ms each individually)"
+                ),
             )
         )
 
@@ -296,7 +301,12 @@ def bench_cache(rows: list[Row], sb: Sandbox) -> None:
     # Metadata-only command: pathCache hit, no DB content fetch.
     ms, r = time_call(lambda: sb.exec(find_cmd, timeout_ms=15_000))
     rows.append(
-        Row("cache", "find -type f | wc -l", ms=ms, note=f"{r.stdout.strip()} files (pathCache only)")
+        Row(
+            "cache",
+            "find -type f | wc -l",
+            ms=ms,
+            note=f"{r.stdout.strip()} files (pathCache only)",
+        )
     )
 
     # First content scan — cold contentCache: 1 SQL roundtrip per blob.
@@ -384,24 +394,34 @@ def render_table(rows: list[Row]) -> str:
 
 # ── main ─────────────────────────────────────────────────────────────────────
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
         "--folder",
         type=Path,
         help="Use a real folder for the ingest dataset (default: synthetic)",
     )
-    parser.add_argument("--files", type=int, default=100, help="synthetic file count (default: 100)")
     parser.add_argument(
-        "--file-size", type=int, default=10 * 1024, help="synthetic avg file size in bytes (default: 10240)"
+        "--files", type=int, default=100, help="synthetic file count (default: 100)"
+    )
+    parser.add_argument(
+        "--file-size",
+        type=int,
+        default=10 * 1024,
+        help="synthetic avg file size in bytes (default: 10240)",
     )
     parser.add_argument("--json", type=Path, help="also write results as JSON to PATH")
     parser.add_argument(
         "--skip",
         type=str,
         default="",
-        help="comma-separated section ids to skip (auth,lifecycle,single,ingest,tree,exec,cache,export)",
+        help="comma-separated section ids to skip: "
+        "auth,lifecycle,single,ingest,tree,exec,cache,export",
     )
-    parser.add_argument("--sub", type=str, default="bench-runner", help="JWT subject (default: bench-runner)")
+    parser.add_argument(
+        "--sub", type=str, default="bench-runner", help="JWT subject (default: bench-runner)"
+    )
     args = parser.parse_args(argv)
 
     base_url = os.environ.get("BASE_URL")
@@ -422,7 +442,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"dataset: walking {args.folder} ...")
         files = collect_folder(args.folder)
     else:
-        print(f"dataset: synthetic {args.files} files × ~{args.file_size} B ...")
+        print(f"dataset: synthetic {args.files} files x ~{args.file_size} B ...")
         files = synth_dataset(args.files, args.file_size)
     total_bytes = sum(len(v) for v in files.values())
     print(f"  {len(files)} files, {total_bytes:,} bytes")
@@ -433,7 +453,11 @@ def main(argv: Optional[list[str]] = None) -> int:
             "__meta__",
             "dataset",
             note=f"{len(files)} files, {total_bytes:,} bytes",
-            extra={"files": len(files), "bytes": total_bytes, "source": str(args.folder) if args.folder else "synthetic"},
+            extra={
+                "files": len(files),
+                "bytes": total_bytes,
+                "source": str(args.folder) if args.folder else "synthetic",
+            },
         )
     )
 

--- a/clients/python/examples/perf_benchmark.py
+++ b/clients/python/examples/perf_benchmark.py
@@ -412,7 +412,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 2
 
     skip = {s.strip() for s in args.skip.split(",") if s.strip()}
-    print(f"virtualfs-python {__version__}  →  {base_url}")
+    print(f"virtualfs-sdk {__version__}  →  {base_url}")
     print(f"skip={sorted(skip) or 'none'}")
 
     if args.folder:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "virtualfs"
+name = "virtualfs-sdk"
 version = "0.1.0"
 description = "Python SDK for the VirtualFS API — persistent bash sandboxes for AI agents"
 readme = "README.md"

--- a/clients/python/src/virtualfs/_http.py
+++ b/clients/python/src/virtualfs/_http.py
@@ -15,7 +15,7 @@ import json
 import random
 import time
 from collections.abc import Iterator, Mapping
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 
 import httpx
@@ -39,7 +39,7 @@ RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
 DEFAULT_TIMEOUT_S = 30.0
 
 
-JsonType = Union[Dict[str, Any], list, str, int, float, bool, None]
+JsonType = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
 
 
 def encode_path(path: str) -> str:
@@ -70,13 +70,9 @@ class Transport:
         http_client: Optional[httpx.Client] = None,
     ) -> None:
         if not (token or auth_secret or admin_secret):
-            raise ValueError(
-                "Provide one of: token=..., auth_secret=..., or admin_secret=..."
-            )
+            raise ValueError("Provide one of: token=..., auth_secret=..., or admin_secret=...")
         if (auth_secret or admin_secret) and not sub:
-            raise ValueError(
-                "`sub` is required when bootstrapping a token from a secret"
-            )
+            raise ValueError("`sub` is required when bootstrapping a token from a secret")
 
         self._base_url = base_url.rstrip("/")
         self._token = token
@@ -189,9 +185,7 @@ class Transport:
             except httpx.TransportError as e:
                 last_exc = e
                 if attempt >= self._max_retries:
-                    raise TransportError(
-                        f"network error after {attempt + 1} attempts: {e}"
-                    ) from e
+                    raise TransportError(f"network error after {attempt + 1} attempts: {e}") from e
                 self._sleep_backoff(attempt)
                 continue
 
@@ -285,12 +279,12 @@ class Transport:
     def _sleep_backoff(self, attempt: int) -> None:
         # Exponential backoff with full jitter: [0, base * 2^attempt)
         base = 0.25
-        delay = random.uniform(0, base * (2 ** attempt))
+        delay = random.uniform(0, base * (2**attempt))
         time.sleep(min(delay, 8.0))
 
 
 # ── module-level helpers ─────────────────────────────────────────────────────
-def _parse_error_body(resp: httpx.Response) -> tuple:
+def _parse_error_body(resp: httpx.Response) -> tuple[Dict[str, Any], Any, str, Any]:
     """Best-effort parse of `{ error, code, details }` JSON response body."""
     try:
         body = resp.json()
@@ -314,14 +308,14 @@ def _parse_retry_after(resp: httpx.Response) -> Optional[int]:
         return None
 
 
-def iter_sse_events(resp: httpx.Response) -> Iterator[tuple]:
+def iter_sse_events(resp: httpx.Response) -> Iterator[tuple[str, Any]]:
     """Iterate SSE events from a streaming response.
 
     Yields `(event_name, parsed_json)` tuples. `data:` lines are concatenated
     per event and parsed as JSON. Comment lines (`:`) are skipped.
     """
     event = "message"
-    data_lines: list = []
+    data_lines: List[str] = []
     for line in resp.iter_lines():
         if line == "":
             if data_lines:
@@ -337,9 +331,9 @@ def iter_sse_events(resp: httpx.Response) -> Iterator[tuple]:
         if line.startswith(":"):
             continue
         if line.startswith("event:"):
-            event = line[len("event:"):].strip()
+            event = line[len("event:") :].strip()
         elif line.startswith("data:"):
-            data_lines.append(line[len("data:"):].lstrip(" "))
+            data_lines.append(line[len("data:") :].lstrip(" "))
     # Trailing event without blank line
     if data_lines:
         raw = "\n".join(data_lines)

--- a/clients/python/src/virtualfs/_http.py
+++ b/clients/python/src/virtualfs/_http.py
@@ -88,7 +88,7 @@ class Transport:
         self._max_retries = max_retries
         self._owns_client = http_client is None
         self._http = http_client or httpx.Client(timeout=timeout)
-        self._user_agent = user_agent or f"virtualfs-python/{__version__}"
+        self._user_agent = user_agent or f"virtualfs-sdk/{__version__}"
 
     # ── lifecycle ────────────────────────────────────────────────────────────
     def close(self) -> None:

--- a/clients/python/src/virtualfs/models.py
+++ b/clients/python/src/virtualfs/models.py
@@ -8,7 +8,7 @@ camelCase fields when parsing responses.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, cast
 
 
 @dataclass(frozen=True)
@@ -156,7 +156,11 @@ class StreamEvent:
                 error=payload.get("error"),
             )
         if event_name in ("stdout", "stderr"):
-            return cls(type=event_name, data=payload.get("data", ""), t=payload.get("t"))
+            return cls(
+                type=cast(Literal["stdout", "stderr"], event_name),
+                data=payload.get("data", ""),
+                t=payload.get("t"),
+            )
         raise ValueError(f"unknown SSE event: {event_name!r}")
 
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -125,9 +125,7 @@ def test_get_sandbox_404_raises_notfound():
 
 @respx.mock
 def test_delete_sandbox():
-    route = respx.delete(f"{BASE_URL}/v1/sandboxes/sb-9").mock(
-        return_value=httpx.Response(204)
-    )
+    route = respx.delete(f"{BASE_URL}/v1/sandboxes/sb-9").mock(return_value=httpx.Response(204))
     make_client().sandboxes.delete("sb-9")
     assert route.called
 
@@ -199,9 +197,7 @@ def test_delete_nonempty_dir_raises_conflict():
 
 @respx.mock
 def test_mkdir_with_recursive():
-    route = respx.post(f"{BASE_URL}/v1/sandboxes/sb/mkdir").mock(
-        return_value=httpx.Response(204)
-    )
+    route = respx.post(f"{BASE_URL}/v1/sandboxes/sb/mkdir").mock(return_value=httpx.Response(204))
     sb = make_client().sandboxes.attach("sb")
     sb.fs.mkdir("/a/b/c", recursive=True)
     sent = json.loads(route.calls[0].request.content.decode())
@@ -282,9 +278,7 @@ def test_exec_batch():
         )
     )
     sb = make_client().sandboxes.attach("sb")
-    results = sb.exec_batch(
-        [{"id": "a", "script": "echo 1"}, {"id": "b", "script": "false"}]
-    )
+    results = sb.exec_batch([{"id": "a", "script": "echo 1"}, {"id": "b", "script": "false"}])
     assert [r.id for r in results] == ["a", "b"]
     assert results[0].ok is True
     assert results[1].ok is False
@@ -293,9 +287,9 @@ def test_exec_batch():
 @respx.mock
 def test_exec_stream_yields_events_until_exit():
     sse_body = (
-        "event: stdout\ndata: {\"t\":0.1,\"data\":\"hello\\n\"}\n\n"
-        "event: stderr\ndata: {\"t\":0.2,\"data\":\"warn\\n\"}\n\n"
-        "event: exit\ndata: {\"t\":0.3,\"exitCode\":0,\"durationMs\":42}\n\n"
+        'event: stdout\ndata: {"t":0.1,"data":"hello\\n"}\n\n'
+        'event: stderr\ndata: {"t":0.2,"data":"warn\\n"}\n\n'
+        'event: exit\ndata: {"t":0.3,"exitCode":0,"durationMs":42}\n\n'
     )
     respx.post(f"{BASE_URL}/v1/sandboxes/sb/exec").mock(
         return_value=httpx.Response(
@@ -338,9 +332,7 @@ def test_export_returns_bytes():
 @respx.mock
 def test_400_maps_to_validation_error():
     respx.post(f"{BASE_URL}/v1/sandboxes").mock(
-        return_value=httpx.Response(
-            400, json={"error": "bad", "code": "EINVAL", "details": ["x"]}
-        )
+        return_value=httpx.Response(400, json={"error": "bad", "code": "EINVAL", "details": ["x"]})
     )
     with pytest.raises(ValidationError) as exc:
         make_client().sandboxes.create(name="x")

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+pre-commit:
+  jobs:
+    - name: python-sdk-format
+      glob: "clients/python/**"
+      run: cd clients/python && uvx ruff format --check .
+
+    - name: python-sdk-lint
+      glob: "clients/python/**"
+      run: cd clients/python && uvx ruff check .
+
+    - name: python-sdk-typecheck
+      glob: "clients/python/**/*.py"
+      run: cd clients/python && uvx --with httpx mypy src/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Persistent filesystem backends (Postgres/MySQL/Azure SQL/FileShare) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",
@@ -24,7 +24,8 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:gc": "tsx src/api/cli/gc.ts",
-		"token:create": "tsx src/api/cli/token.ts"
+		"token:create": "tsx src/api/cli/token.ts",
+		"prepare": "lefthook install"
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.14.0",
@@ -49,6 +50,7 @@
 		"@types/node": "^22.0.0",
 		"drizzle-kit": "^0.30.0",
 		"knip": "^6.4.1",
+		"lefthook": "^1.11.0",
 		"tsx": "^4.19.0",
 		"typescript": "^5.7.0",
 		"vitest": "^3.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       knip:
         specifier: ^6.4.1
         version: 6.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      lefthook:
+        specifier: ^1.11.0
+        version: 1.13.6
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -1788,6 +1791,60 @@ packages:
   knip@6.4.1:
     resolution: {integrity: sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  lefthook-darwin-arm64@1.13.6:
+    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.13.6:
+    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.13.6:
+    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.13.6:
+    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.13.6:
+    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.13.6:
+    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.13.6:
+    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.13.6:
+    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.13.6:
+    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.13.6:
+    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.13.6:
+    resolution: {integrity: sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==}
     hasBin: true
 
   lodash.defaults@4.2.0:
@@ -3909,6 +3966,49 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  lefthook-darwin-arm64@1.13.6:
+    optional: true
+
+  lefthook-darwin-x64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-x64@1.13.6:
+    optional: true
+
+  lefthook-linux-arm64@1.13.6:
+    optional: true
+
+  lefthook-linux-x64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-x64@1.13.6:
+    optional: true
+
+  lefthook-windows-arm64@1.13.6:
+    optional: true
+
+  lefthook-windows-x64@1.13.6:
+    optional: true
+
+  lefthook@1.13.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.13.6
+      lefthook-darwin-x64: 1.13.6
+      lefthook-freebsd-arm64: 1.13.6
+      lefthook-freebsd-x64: 1.13.6
+      lefthook-linux-arm64: 1.13.6
+      lefthook-linux-x64: 1.13.6
+      lefthook-openbsd-arm64: 1.13.6
+      lefthook-openbsd-x64: 1.13.6
+      lefthook-windows-arm64: 1.13.6
+      lefthook-windows-x64: 1.13.6
 
   lodash.defaults@4.2.0: {}
 

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.8",
+		version: "0.2.9",
 		description:
 			"Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres, MySQL, Azure SQL, or Azure FileShare.",
 	},


### PR DESCRIPTION
Adds GitHub Actions workflows for the Python SDK: path-filtered CI (lint, typecheck, test matrix on 3.9/3.11/3.13) and a release workflow that publishes to PyPI via OIDC trusted publisher when clients/python/** changes land on main. Adds clients/python/CHANGELOG.md for version tracking. Renames PyPI distribution name from virtualfs to virtualfs-sdk to avoid name collision on PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed Python package to virtualfs-sdk; added CI and automated release workflows, and updated package version.
  * Added pre-commit hooks to enforce formatting and type checks.

* **Documentation**
  * Added Python SDK changelog (initial entry) and updated central release notes for 0.2.9.
  * Updated installation instructions to reference virtualfs-sdk.

* **Examples**
  * Minor output/formatting tweaks in the benchmark script.

* **Tests**
  * Reformatted test fixtures and mocks for compactness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->