### PR TITLE
feat(sql-fs): defense-in-depth Postgres compatibility + opt-in env flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-06
+
+### Added
+
+- Defense-in-depth security layer for just-bash execution: opt-in via `JUST_BASH_DEFENSE_IN_DEPTH=true`. When enabled, just-bash monkey-patches host globals (`setTimeout`, `eval`, `Function`, dynamic `import`) during `bash.exec` to prevent sandbox escape. All Postgres I/O chokepoints (`#withTx`, `#withReadTx`, `#withBareTx`, `getBlobNoTx`) are wrapped in `DefenseInDepthBox.runTrustedAsync` to keep DB access functional.
+- `JUST_BASH_DEFENSE_AUDIT_MODE` env var (default `true`): controls whether violations throw (`false`) or are logged only (`true`). Recommended rollout: enable with audit mode on, watch for `defense_in_depth_violation` logs, then flip to enforce mode once clean.
+- Structured violation logging: violations emit a JSON line `{ event: "defense_in_depth_violation", sandboxId, ... }` via `onViolation` callback for easy grep/alerting.
+
 ## [0.2.15] - 2026-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-05-06
+## [0.2.16] - 2026-05-06
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ blobs (sha256, data, size)  — content-addressable, global dedup
 - **Auth:** Every `/v1/*` route requires Bearer token. Validate before any DB access.
 - **SQL injection:** Use parameterized queries only. Never interpolate user input into SQL strings. The `postgres` driver's tagged templates and Drizzle's query builder handle this automatically — do not bypass them with raw string concatenation.
 - **Prototype pollution:** Use `Object.create(null)` for objects with user-controlled keys. Use `Map` where possible.
+- **Defense-in-depth:** Opt-in via `JUST_BASH_DEFENSE_IN_DEPTH=true`. When enabled, just-bash monkey-patches host globals (`setTimeout`, `eval`, `Function`, dynamic `import`) during `bash.exec`. All Postgres I/O chokepoints (`#withTx`, `#withReadTx`, `#withBareTx`, `getBlobNoTx`) are wrapped in `DefenseInDepthBox.runTrustedAsync` to bypass the patch. When adding new dialects (MySQL, Azure SQL), this wrapping must be preserved — omitting it will throw `WorkerSecurityViolationError` at runtime.
 
 ### Null Prototype Objects
 
@@ -213,6 +214,8 @@ const TABLE = Object.assign(Object.create(null) as Record<string, string>, {
 | `REDIS_BLOB_MAX_BYTES` | No (default: 8388608) | Max blob size cached in Redis (bytes, default 8 MB). Blobs larger than this bypass Redis entirely. |
 | `REDIS_PATH_SNAPSHOT_ENABLED` | No (default: false) | Set to `true` to enable the Redis path snapshot cache. When enabled, cold-start pathCache is loaded from Redis instead of a full Postgres `loadAllPaths` scan. Requires `REDIS_URL`. |
 | `REDIS_PATH_SNAPSHOT_TTL_MS` | No (default: 3600000) | TTL for path snapshot entries (ms, default 1h). |
+| `JUST_BASH_DEFENSE_IN_DEPTH` | No (default: `false`) | Enables just-bash's defense-in-depth security layer (monkey-patches `setTimeout`, `eval`, `Function`, dynamic `import`, etc. for the duration of `bash.exec`). All Postgres I/O is wrapped in `DefenseInDepthBox.runTrustedAsync` to remain compatible. |
+| `JUST_BASH_DEFENSE_AUDIT_MODE` | No (default: `true`) | When `JUST_BASH_DEFENSE_IN_DEPTH=true`, controls whether violations throw (`false`) or are logged only (`true`). Recommended `true` for initial rollout, then flip to `false` once logs are clean. |
 
 ## File Layout
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.15",
+	"version": "0.3.0",
 	"description": "Persistent filesystem backends (Postgres/MySQL/Azure SQL/FileShare) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.0",
+	"version": "0.2.16",
 	"description": "Persistent filesystem backends (Postgres/MySQL/Azure SQL/FileShare) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.15",
+		version: "0.3.0",
 		description:
 			"Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres, MySQL, Azure SQL, or Azure FileShare.",
 	},

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.0",
+		version: "0.2.16",
 		description:
 			"Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres, MySQL, Azure SQL, or Azure FileShare.",
 	},

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -314,14 +314,14 @@ export class SessionManager {
 		const creationPromise = (async (): Promise<Session> => {
 			try {
 				const { fs, resolvedOwner } = await this.buildFs(tenantId, sandboxId, owner);
-				const defenseInDepthConfig: DefenseInDepthConfig | undefined = this.defenseInDepth
+				const defenseInDepthConfig: DefenseInDepthConfig | false = this.defenseInDepth
 					? {
 							enabled: true,
 							auditMode: this.defenseAuditMode,
 							onViolation: (v: SecurityViolation) =>
 								console.log(JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v })),
 						}
-					: undefined;
+					: false;
 				const bash = new Bash({
 					fs,
 					python: resolvedRuntime.python || undefined,

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -15,7 +15,7 @@
 import { Mutex } from "async-mutex";
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
-import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem } from "just-bash";
+import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
 import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/index.js";
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
@@ -315,7 +315,14 @@ export class SessionManager {
 			try {
 				const { fs, resolvedOwner } = await this.buildFs(tenantId, sandboxId, owner);
 				const defenseInDepthConfig: DefenseInDepthConfig | undefined = this.defenseInDepth
-					? { enabled: true, auditMode: this.defenseAuditMode }
+					? {
+							enabled: true,
+							auditMode: this.defenseAuditMode,
+							onViolation: (v: SecurityViolation) =>
+								console.log(
+									JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v }),
+								),
+						}
 					: undefined;
 				const bash = new Bash({
 					fs,

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -15,8 +15,7 @@
 import { Mutex } from "async-mutex";
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
-import type { ExecOptions, IFileSystem } from "just-bash";
-import type { BashExecResult } from "just-bash";
+import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem } from "just-bash";
 import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/index.js";
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
@@ -142,6 +141,19 @@ export interface SessionManagerOptions {
 	 * optionally filtered by owner.
 	 */
 	readonly listSandboxesFn?: (tenantId: string, owner?: string) => Promise<SandboxListEntry[]>;
+	/**
+	 * Override for `JUST_BASH_DEFENSE_IN_DEPTH` env var — used by tests and
+	 * non-default configurations. When `true`, enables just-bash's defense-in-depth
+	 * security layer on each `Bash` instance. Requires all DB calls to be wrapped
+	 * in `DefenseInDepthBox.runTrustedAsync` (Phase 1).
+	 */
+	readonly defenseInDepth?: boolean;
+	/**
+	 * Override for `JUST_BASH_DEFENSE_AUDIT_MODE` env var. When `true` (default),
+	 * violations are logged but not thrown — safe for initial rollout observation.
+	 * Flip to `false` once logs are clean to enforce the security boundary.
+	 */
+	readonly defenseAuditMode?: boolean;
 }
 
 interface Semaphore {
@@ -171,6 +183,8 @@ export class SessionManager {
 
 	private readonly pythonSem: Semaphore;
 	private readonly jsSem: Semaphore;
+	private readonly defenseInDepth: boolean;
+	private readonly defenseAuditMode: boolean;
 
 	constructor({
 		tenantConfig,
@@ -187,6 +201,8 @@ export class SessionManager {
 		getSandboxMetaFn,
 		persistSandboxMetaFn,
 		listSandboxesFn,
+		defenseInDepth,
+		defenseAuditMode,
 	}: SessionManagerOptions) {
 		this.tenantConfig = tenantConfig;
 		this.createFsOverride = createFs;
@@ -216,6 +232,8 @@ export class SessionManager {
 			inFlight: 0,
 			waiters: [],
 		};
+		this.defenseInDepth = defenseInDepth ?? process.env.JUST_BASH_DEFENSE_IN_DEPTH === "true";
+		this.defenseAuditMode = defenseAuditMode ?? process.env.JUST_BASH_DEFENSE_AUDIT_MODE !== "false";
 	}
 
 	private sessionKey(tenantId: string, sandboxId: string): string {
@@ -296,10 +314,14 @@ export class SessionManager {
 		const creationPromise = (async (): Promise<Session> => {
 			try {
 				const { fs, resolvedOwner } = await this.buildFs(tenantId, sandboxId, owner);
+				const defenseInDepthConfig: DefenseInDepthConfig | undefined = this.defenseInDepth
+					? { enabled: true, auditMode: this.defenseAuditMode }
+					: undefined;
 				const bash = new Bash({
 					fs,
 					python: resolvedRuntime.python || undefined,
 					javascript: resolvedRuntime.javascript || undefined,
+					defenseInDepth: defenseInDepthConfig,
 				});
 				const pathCacheBytes = this.estimatePathCacheBytes(fs);
 				const scriptTxFs = asScriptTxFs(fs);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -319,9 +319,7 @@ export class SessionManager {
 							enabled: true,
 							auditMode: this.defenseAuditMode,
 							onViolation: (v: SecurityViolation) =>
-								console.log(
-									JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v }),
-								),
+								console.log(JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v })),
 						}
 					: undefined;
 				const bash = new Bash({

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -23,6 +23,7 @@ import { SessionScopedFs } from "../fs/sql-fs/session-scoped-fs.js";
 import type { ICoherentFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
+import { logAudit } from "./lib/audit.js";
 import type { TenantConfig } from "./tenants.js";
 
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
@@ -144,8 +145,7 @@ export interface SessionManagerOptions {
 	/**
 	 * Override for `JUST_BASH_DEFENSE_IN_DEPTH` env var — used by tests and
 	 * non-default configurations. When `true`, enables just-bash's defense-in-depth
-	 * security layer on each `Bash` instance. Requires all DB calls to be wrapped
-	 * in `DefenseInDepthBox.runTrustedAsync` (Phase 1).
+	 * security layer on each `Bash` instance.
 	 */
 	readonly defenseInDepth?: boolean;
 	/**
@@ -318,8 +318,7 @@ export class SessionManager {
 					? {
 							enabled: true,
 							auditMode: this.defenseAuditMode,
-							onViolation: (v: SecurityViolation) =>
-								console.log(JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v })),
+							onViolation: (v: SecurityViolation) => logAudit("defense_in_depth_violation", { sandboxId, ...v }),
 						}
 					: false;
 				const bash = new Bash({

--- a/src/api/tests/unit/session-manager.defense-in-depth.test.ts
+++ b/src/api/tests/unit/session-manager.defense-in-depth.test.ts
@@ -30,7 +30,7 @@ describe("SessionManager defense-in-depth wiring", () => {
 
 	it("default (no env var, no override) is disabled and passes false", async () => {
 		const prev = process.env.JUST_BASH_DEFENSE_IN_DEPTH;
-		delete process.env.JUST_BASH_DEFENSE_IN_DEPTH;
+		process.env.JUST_BASH_DEFENSE_IN_DEPTH = undefined;
 		try {
 			const sm = new SessionManager({
 				createFs: async () => new InMemoryFs(),

--- a/src/api/tests/unit/session-manager.defense-in-depth.test.ts
+++ b/src/api/tests/unit/session-manager.defense-in-depth.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression tests: SessionManager must pass `false` (not `undefined`) to the
+ * `Bash` constructor when defense-in-depth is disabled.
+ *
+ * just-bash's `Bash` constructor does `t.defenseInDepth ?? true`, so omitting
+ * the option enables defense-in-depth with default config — silently flipping
+ * the rollout flag and changing production behavior.
+ */
+
+import { InMemoryFs } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+const T = "default";
+
+describe("SessionManager defense-in-depth wiring", () => {
+	it("disabled flag passes false to Bash so just-bash does not default to true", async () => {
+		const sm = new SessionManager({
+			createFs: async () => new InMemoryFs(),
+			defenseInDepth: false,
+		});
+
+		const session = await sm.getOrCreate(T, "sandbox-defense-off");
+
+		// just-bash stores the option as `t.defenseInDepth ?? true`. Reading it
+		// back as `false` proves the SessionManager passed `false` explicitly
+		// rather than `undefined` (which would have nullish-coalesced to `true`).
+		expect((session.bash as unknown as { defenseInDepthConfig: unknown }).defenseInDepthConfig).toBe(false);
+	});
+
+	it("default (no env var, no override) is disabled and passes false", async () => {
+		const prev = process.env.JUST_BASH_DEFENSE_IN_DEPTH;
+		delete process.env.JUST_BASH_DEFENSE_IN_DEPTH;
+		try {
+			const sm = new SessionManager({
+				createFs: async () => new InMemoryFs(),
+			});
+
+			const session = await sm.getOrCreate(T, "sandbox-defense-default");
+
+			expect((session.bash as unknown as { defenseInDepthConfig: unknown }).defenseInDepthConfig).toBe(false);
+		} finally {
+			if (prev !== undefined) process.env.JUST_BASH_DEFENSE_IN_DEPTH = prev;
+		}
+	});
+
+	it("enabled flag passes a config object with auditMode honored", async () => {
+		const sm = new SessionManager({
+			createFs: async () => new InMemoryFs(),
+			defenseInDepth: true,
+			defenseAuditMode: false,
+		});
+
+		const session = await sm.getOrCreate(T, "sandbox-defense-on");
+
+		const cfg = (session.bash as unknown as { defenseInDepthConfig: unknown }).defenseInDepthConfig;
+		expect(cfg).toMatchObject({ enabled: true, auditMode: false });
+	});
+});

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -5,6 +5,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { DefenseInDepthBox } from "just-bash";
 import postgres from "postgres";
 import { createEisdir, createEnoent, createEnotdir, translateSqlError } from "../errors.js";
 import type { RedisBlobCache } from "../redis-blob-cache.js";
@@ -38,11 +39,13 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	// ── Connection ────────────────────────────────────────────────────────────────
 
 	async connect(): Promise<void> {
-		this.pool = postgres(this.connectionString, { prepare: false });
+		this.pool = await DefenseInDepthBox.runTrustedAsync(() =>
+			Promise.resolve(postgres(this.connectionString, { prepare: false })),
+		);
 	}
 
 	async disconnect(): Promise<void> {
-		await this.pool?.end();
+		await DefenseInDepthBox.runTrustedAsync(() => this.pool?.end() ?? Promise.resolve());
 		this.pool = null;
 	}
 
@@ -569,9 +572,9 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 			const cached = await this.#blobCache.get(sha256);
 			if (cached !== null) return cached;
 		}
-		const rows = await this.db()<{ data: Buffer }[]>`
-			SELECT data FROM blobs WHERE sha256 = ${sha256}
-		`;
+		const rows = await DefenseInDepthBox.runTrustedAsync(
+			() => this.db()<{ data: Buffer }[]>`SELECT data FROM blobs WHERE sha256 = ${sha256}`,
+		);
 		const data = rows[0]?.data;
 		if (!data) return null;
 		const bytes = new Uint8Array(data);
@@ -586,23 +589,26 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 
 		// If RLS is later added to `inodes` requiring app.sandbox_id, this query
 		// will need to set that context first; today the WHERE filter suffices.
-		const metaRows = await this.db()<{ inode_id: string; content_sha256: Buffer; size: string }[]>`
-			WITH ranked AS (
-				SELECT
-					i.id              AS inode_id,
-					i.content_sha256  AS content_sha256,
-					i.size            AS size,
-					SUM(i.size) OVER (ORDER BY i.size ASC, i.id ASC) AS running_total
-				FROM inodes i
-				WHERE i.sandbox_id = ${sandboxId}
-					AND i.kind = ${INODE_KIND.FILE}
-					AND i.content_sha256 IS NOT NULL
-			)
-			SELECT inode_id, content_sha256, size
-			FROM ranked
-			WHERE running_total <= ${maxBytes}
-			ORDER BY size ASC, inode_id ASC
-		`;
+		const metaRows: { inode_id: string; content_sha256: Buffer; size: string }[] =
+			await DefenseInDepthBox.runTrustedAsync(
+				() => this.db()<{ inode_id: string; content_sha256: Buffer; size: string }[]>`
+				WITH ranked AS (
+					SELECT
+						i.id              AS inode_id,
+						i.content_sha256  AS content_sha256,
+						i.size            AS size,
+						SUM(i.size) OVER (ORDER BY i.size ASC, i.id ASC) AS running_total
+					FROM inodes i
+					WHERE i.sandbox_id = ${sandboxId}
+						AND i.kind = ${INODE_KIND.FILE}
+						AND i.content_sha256 IS NOT NULL
+				)
+				SELECT inode_id, content_sha256, size
+				FROM ranked
+				WHERE running_total <= ${maxBytes}
+				ORDER BY size ASC, inode_id ASC
+			`,
+			);
 
 		if (metaRows.length === 0) return [];
 
@@ -622,12 +628,14 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		const pgHits = new Map<string, Uint8Array>();
 		if (missByHex.size > 0) {
 			const missHexes = [...missByHex.keys()];
-			const pgRows = await this.db()<{ sha256: Buffer; data: Buffer }[]>`
-				SELECT b.sha256, b.data
-				FROM blobs b
-				JOIN unnest(${missHexes}::text[]) AS v(sha256_hex)
-					ON b.sha256 = decode(v.sha256_hex, 'hex')
-			`;
+			const pgRows = await DefenseInDepthBox.runTrustedAsync(
+				() => this.db()<{ sha256: Buffer; data: Buffer }[]>`
+					SELECT b.sha256, b.data
+					FROM blobs b
+					JOIN unnest(${missHexes}::text[]) AS v(sha256_hex)
+						ON b.sha256 = decode(v.sha256_hex, 'hex')
+				`,
+			);
 			for (const r of pgRows) {
 				const hex = Buffer.from(r.sha256).toString("hex");
 				const bytes = new Uint8Array(r.data);

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -572,9 +572,9 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 			const cached = await this.#blobCache.get(sha256);
 			if (cached !== null) return cached;
 		}
-		const rows = await DefenseInDepthBox.runTrustedAsync(
-			() => this.db()<{ data: Buffer }[]>`SELECT data FROM blobs WHERE sha256 = ${sha256}`,
-		);
+		const rows = await this.db()<{ data: Buffer }[]>`
+			SELECT data FROM blobs WHERE sha256 = ${sha256}
+		`;
 		const data = rows[0]?.data;
 		if (!data) return null;
 		const bytes = new Uint8Array(data);
@@ -589,26 +589,23 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 
 		// If RLS is later added to `inodes` requiring app.sandbox_id, this query
 		// will need to set that context first; today the WHERE filter suffices.
-		const metaRows: { inode_id: string; content_sha256: Buffer; size: string }[] =
-			await DefenseInDepthBox.runTrustedAsync(
-				() => this.db()<{ inode_id: string; content_sha256: Buffer; size: string }[]>`
-				WITH ranked AS (
-					SELECT
-						i.id              AS inode_id,
-						i.content_sha256  AS content_sha256,
-						i.size            AS size,
-						SUM(i.size) OVER (ORDER BY i.size ASC, i.id ASC) AS running_total
-					FROM inodes i
-					WHERE i.sandbox_id = ${sandboxId}
-						AND i.kind = ${INODE_KIND.FILE}
-						AND i.content_sha256 IS NOT NULL
-				)
-				SELECT inode_id, content_sha256, size
-				FROM ranked
-				WHERE running_total <= ${maxBytes}
-				ORDER BY size ASC, inode_id ASC
-			`,
-			);
+		const metaRows = await this.db()<{ inode_id: string; content_sha256: Buffer; size: string }[]>`
+			WITH ranked AS (
+				SELECT
+					i.id              AS inode_id,
+					i.content_sha256  AS content_sha256,
+					i.size            AS size,
+					SUM(i.size) OVER (ORDER BY i.size ASC, i.id ASC) AS running_total
+				FROM inodes i
+				WHERE i.sandbox_id = ${sandboxId}
+					AND i.kind = ${INODE_KIND.FILE}
+					AND i.content_sha256 IS NOT NULL
+			)
+			SELECT inode_id, content_sha256, size
+			FROM ranked
+			WHERE running_total <= ${maxBytes}
+			ORDER BY size ASC, inode_id ASC
+		`;
 
 		if (metaRows.length === 0) return [];
 
@@ -628,14 +625,12 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		const pgHits = new Map<string, Uint8Array>();
 		if (missByHex.size > 0) {
 			const missHexes = [...missByHex.keys()];
-			const pgRows = await DefenseInDepthBox.runTrustedAsync(
-				() => this.db()<{ sha256: Buffer; data: Buffer }[]>`
-					SELECT b.sha256, b.data
-					FROM blobs b
-					JOIN unnest(${missHexes}::text[]) AS v(sha256_hex)
-						ON b.sha256 = decode(v.sha256_hex, 'hex')
-				`,
-			);
+			const pgRows = await this.db()<{ sha256: Buffer; data: Buffer }[]>`
+				SELECT b.sha256, b.data
+				FROM blobs b
+				JOIN unnest(${missHexes}::text[]) AS v(sha256_hex)
+					ON b.sha256 = decode(v.sha256_hex, 'hex')
+			`;
 			for (const r of pgRows) {
 				const hex = Buffer.from(r.sha256).toString("hex");
 				const bytes = new Uint8Array(r.data);

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -10,6 +10,7 @@
 import { createHash } from "node:crypto";
 import type { Redis } from "ioredis";
 import type { CpOptions, FileContent, FsStat, IFileSystem, MkdirOptions, RmOptions } from "just-bash";
+import { DefenseInDepthBox } from "just-bash";
 import { LRUCache } from "lru-cache";
 
 import {
@@ -179,12 +180,14 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 			if (this.#scriptTx === undefined) {
 				await this.#openScriptTx();
 			}
-			return fn(this.#scriptTx!);
+			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
 		}
-		return this.#dialect.transaction(async (tx) => {
-			await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
-			return await fn(tx);
-		});
+		return DefenseInDepthBox.runTrustedAsync(() =>
+			this.#dialect.transaction(async (tx) => {
+				await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
+				return await fn(tx);
+			}),
+		);
 	}
 
 	/**
@@ -194,12 +197,14 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	 */
 	async #withReadTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
 		if (this.#scriptScope && this.#scriptTx !== undefined) {
-			return fn(this.#scriptTx);
+			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
 		}
-		return this.#dialect.transaction(async (tx) => {
-			await this.#dialect.setSandboxContext(tx, this.#sandboxId);
-			return await fn(tx);
-		});
+		return DefenseInDepthBox.runTrustedAsync(() =>
+			this.#dialect.transaction(async (tx) => {
+				await this.#dialect.setSandboxContext(tx, this.#sandboxId);
+				return await fn(tx);
+			}),
+		);
 	}
 
 	async #openScriptTx(): Promise<void> {
@@ -217,16 +222,19 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		this.#scriptTxEnd = resolveEnd;
 		this.#scriptTxAbort = rejectEnd;
 
-		this.#scriptTxPromise = this.#dialect.transaction(async (tx) => {
-			await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
-			this.#scriptTx = tx;
-			resolveTxReady();
-			await endPromise;
-		});
+		const scriptTxPromise = DefenseInDepthBox.runTrustedAsync(() =>
+			this.#dialect.transaction(async (tx) => {
+				await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
+				this.#scriptTx = tx;
+				resolveTxReady();
+				await endPromise;
+			}),
+		);
+		this.#scriptTxPromise = scriptTxPromise;
 		// Guard against unhandled rejection if the connection closes before endScriptScope/abortScriptScope.
 		// endScriptScope still sees the rejection via `await this.#scriptTxPromise` because .catch() creates
 		// a new derived chain without affecting the original promise's rejected state.
-		this.#scriptTxPromise.catch(() => {});
+		scriptTxPromise.catch(() => {});
 
 		// Race txReady against #scriptTxPromise so that a connection failure before
 		// setSandboxContextWithLock completes (i.e. before resolveTxReady fires) propagates
@@ -240,9 +248,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		// here would deadlock trying to acquire the same lock. Route through the existing script-tx.
 		// When no script-tx is open yet, use a fresh transaction (original behavior, no extra RTT).
 		if (this.#scriptTx !== undefined) {
-			return fn(this.#scriptTx);
+			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
 		}
-		return this.#dialect.transaction(fn);
+		return DefenseInDepthBox.runTrustedAsync(() => this.#dialect.transaction(fn));
 	}
 
 	// ── Path helpers ──────────────────────────────────────────────────────────────
@@ -382,7 +390,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		const cap = this.#contentCache.maxSize;
 		const task = (async (): Promise<void> => {
 			try {
-				const blobs = await this.#dialect.getBlobsForSandbox(this.#sandboxId, cap);
+				const blobs = await DefenseInDepthBox.runTrustedAsync(() =>
+					this.#dialect.getBlobsForSandbox(this.#sandboxId, cap),
+				);
 				for (const { inodeId, data } of blobs) {
 					if (data.byteLength > 0) this.#contentCache.set(inodeId, data);
 				}
@@ -867,7 +877,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		}
 
 		// `blobs` is global (no RLS), so a transaction wrapper is unnecessary.
-		const data = await this.#dialect.getBlobNoTx(entry.contentSha256!);
+		const data = await DefenseInDepthBox.runTrustedAsync(() => this.#dialect.getBlobNoTx(entry.contentSha256!));
 		const bytes = data ?? new Uint8Array(0);
 		if (bytes.byteLength > 0) this.#contentCache.set(entry.inodeId, bytes);
 		return bytes;

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -180,7 +180,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 			if (this.#scriptTx === undefined) {
 				await this.#openScriptTx();
 			}
-			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+			const tx = this.#scriptTx as Tx;
+			return DefenseInDepthBox.runTrustedAsync(() => fn(tx));
 		}
 		return DefenseInDepthBox.runTrustedAsync(() =>
 			this.#dialect.transaction(async (tx) => {
@@ -196,8 +197,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	 * same sandbox. Use for getBlob / resolvePath paths that only serve reads.
 	 */
 	async #withReadTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
-		if (this.#scriptScope && this.#scriptTx !== undefined) {
-			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+		const scriptTx = this.#scriptTx;
+		if (this.#scriptScope && scriptTx !== undefined) {
+			return DefenseInDepthBox.runTrustedAsync(() => fn(scriptTx));
 		}
 		return DefenseInDepthBox.runTrustedAsync(() =>
 			this.#dialect.transaction(async (tx) => {
@@ -247,8 +249,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		// When the script-tx is already open it holds the advisory lock — starting a new transaction
 		// here would deadlock trying to acquire the same lock. Route through the existing script-tx.
 		// When no script-tx is open yet, use a fresh transaction (original behavior, no extra RTT).
-		if (this.#scriptTx !== undefined) {
-			return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+		const scriptTx = this.#scriptTx;
+		if (scriptTx !== undefined) {
+			return DefenseInDepthBox.runTrustedAsync(() => fn(scriptTx));
 		}
 		return DefenseInDepthBox.runTrustedAsync(() => this.#dialect.transaction(fn));
 	}

--- a/src/fs/sql-fs/tests/integration/defense-in-depth.integration.test.ts
+++ b/src/fs/sql-fs/tests/integration/defense-in-depth.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Integration tests: DefenseInDepth + Postgres SqlFs.
+ *
+ * Proves that the DefenseInDepthBox.runTrustedAsync wrappers applied in Phase 1
+ * prevent WorkerSecurityViolationError for common filesystem operations when
+ * defenseInDepth is enabled and auditMode is false.
+ *
+ * Skipped when DATABASE_URL is not set so CI without a DB still passes.
+ */
+
+import { Bash } from "just-bash";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPostgresSandboxFs, destroyPostgresSandbox } from "../../index.js";
+
+const SKIP = !process.env.DATABASE_URL;
+
+describe.skipIf(SKIP)("defenseInDepth + Postgres SqlFs", () => {
+	const url = process.env.DATABASE_URL!;
+	const createdSandboxIds: string[] = [];
+
+	function makeSandboxId(): string {
+		return `test-did-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	}
+
+	afterEach(async () => {
+		for (const id of createdSandboxIds.splice(0)) {
+			await destroyPostgresSandbox(url, id).catch(() => {});
+		}
+	});
+
+	// Helper: creates a fresh SqlFs + Bash with defenseInDepth enabled.
+	async function createBash(sandboxId: string): Promise<Bash> {
+		const { fs } = await createPostgresSandboxFs({ connectionString: url }, sandboxId);
+		return new Bash({ fs, defenseInDepth: { enabled: true, auditMode: false } });
+	}
+
+	it("echo-write-read does not throw WorkerSecurityViolationError", async () => {
+		const sandboxId = makeSandboxId();
+		createdSandboxIds.push(sandboxId);
+
+		const bash = await createBash(sandboxId);
+		const result = await bash.exec("echo hi > /tmp/x && cat /tmp/x");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("hi");
+	});
+
+	it("mkdir -p and ls succeed", async () => {
+		const sandboxId = makeSandboxId();
+		createdSandboxIds.push(sandboxId);
+
+		const bash = await createBash(sandboxId);
+		const result = await bash.exec("mkdir -p /a/b/c && ls /a/b");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("c");
+	});
+
+	it("rm -rf directory succeeds", async () => {
+		const sandboxId = makeSandboxId();
+		createdSandboxIds.push(sandboxId);
+
+		const bash = await createBash(sandboxId);
+		// Create then remove so rm has something to delete.
+		const result = await bash.exec("mkdir -p /tmp/rmme && rm -rf /tmp/rmme && echo done");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("done");
+	});
+
+	it("multiple writes in one exec (script-tx flow) commit cleanly", async () => {
+		const sandboxId = makeSandboxId();
+		createdSandboxIds.push(sandboxId);
+
+		const bash = await createBash(sandboxId);
+		const result = await bash.exec("echo a > /tmp/a && echo b > /tmp/b && echo c > /tmp/c && cat /tmp/a /tmp/b /tmp/c");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("a\nb\nc");
+	});
+
+	it("cold-start prewarm: fresh SqlFs reads file written by previous Bash", async () => {
+		const sandboxId = makeSandboxId();
+		createdSandboxIds.push(sandboxId);
+
+		// First Bash writes a file.
+		const bash1 = await createBash(sandboxId);
+		await bash1.exec("echo persisted > /tmp/persist");
+
+		// Second Bash (fresh SqlFs, same sandboxId) reads it back.
+		const bash2 = await createBash(sandboxId);
+		const result = await bash2.exec("cat /tmp/persist");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("persisted");
+	});
+});

--- a/src/fs/sql-fs/tests/integration/defense-in-depth.integration.test.ts
+++ b/src/fs/sql-fs/tests/integration/defense-in-depth.integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * Integration tests: DefenseInDepth + Postgres SqlFs.
  *
- * Proves that the DefenseInDepthBox.runTrustedAsync wrappers applied in Phase 1
- * prevent WorkerSecurityViolationError for common filesystem operations when
+ * Proves that the DefenseInDepthBox.runTrustedAsync wrappers prevent
+ * WorkerSecurityViolationError for common filesystem operations when
  * defenseInDepth is enabled and auditMode is false.
  *
  * Skipped when DATABASE_URL is not set so CI without a DB still passes.

--- a/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
+++ b/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
@@ -339,7 +339,7 @@ Document the two new env vars and the rollout posture.
 ### Phase 4: Success Criteria
 
 #### Phase 4: Automated Verification
-- [ ] No automated check.
+- [x] No automated check.
 
 #### Phase 4: Manual Verification
 - [ ] CLAUDE.md renders cleanly; the two new rows are in the env table; the security note matches the actual implementation.

--- a/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
+++ b/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
@@ -1,0 +1,383 @@
+---
+date: 2026-05-05T23:03:22+09:30
+researcher: Harry Nguyen
+git_commit: effe298e8b608097b637c8dac82c7db1bc637e33
+branch: main
+repository: virtualFS
+task: "Enable just-bash defenseInDepth without breaking Postgres calls"
+tags: [implementation-plan, just-bash, defense-in-depth, sql-fs, postgres, security]
+status: draft
+last_updated: 2026-05-05
+last_updated_by: Harry Nguyen
+---
+
+# Defense-in-Depth + Postgres Implementation Plan
+
+## Overview
+
+Make virtualfs-api compatible with just-bash's `defenseInDepth` security layer by routing every Postgres call through `DefenseInDepthBox.runTrustedAsync(...)`, then wire an opt-in env flag (`JUST_BASH_DEFENSE_IN_DEPTH`) into our `Bash` constructor with `auditMode` enabled by default for safe rollout.
+
+## Current State Analysis
+
+- `defenseInDepth` is never enabled — `src/api/session-manager.ts:299` constructs `new Bash({ fs, python, javascript })` with no security field.
+- The `postgres` driver (porsager v3) uses `setTimeout`/`clearTimeout` for connect / idle / lifetime timers and `setImmediate(nextWrite)` for batched writes. With `defenseInDepth: true`, these globals are monkey-patched and any DB call from inside `bash.exec(...)` throws `WorkerSecurityViolationError`.
+- `SqlFs` funnels all DB I/O through three helpers: `#withTx`, `#withReadTx`, `#withBareTx` (`src/fs/sql-fs/sql-fs.ts:177–246`) plus the lock-free `getBlobNoTx` path used by reads (`sql-fs.ts:870`) and prewarm/`getBlobsForSandbox` (`sql-fs.ts:385`). Wrapping at these chokepoints covers every dialect for free.
+- `just-bash` exports `DefenseInDepthBox` from its main entry (`node_modules/just-bash/dist/index.d.ts:19`) with `runTrustedAsync(fn)` — an async no-op when no box is installed, otherwise it exits the patched scope for the duration of `fn`.
+
+## Desired End State
+
+- A new env flag `JUST_BASH_DEFENSE_IN_DEPTH` (default `false`) enables `defenseInDepth` on the per-sandbox `Bash`. A second flag `JUST_BASH_DEFENSE_AUDIT_MODE` (default `true`) routes violations to a logger instead of throwing during initial rollout.
+- With both flags on, scripts that touch the filesystem (`cat`, `ls`, `echo > file`, etc.) succeed against a real Postgres without `WorkerSecurityViolationError`.
+- All Postgres I/O in `SqlFs` is wrapped in `DefenseInDepthBox.runTrustedAsync(...)` regardless of whether the flag is on (always-wrap; cheap when no box is installed).
+- Verification: an integration test that constructs `new Bash({ fs: sqlFs, defenseInDepth: true })` against the real Postgres dev DB and runs `echo hi > /tmp/x && cat /tmp/x` returns `"hi"` with no violation thrown.
+
+### Key Discoveries
+
+- `SqlFs` already centralizes every DB call through `#withTx` / `#withReadTx` / `#withBareTx` (`src/fs/sql-fs/sql-fs.ts:177–246`) — wrapping these covers all 20+ IFileSystem methods plus `bulkIngest`.
+- The `getBlobNoTx` and `getBlobsForSandbox` paths bypass the tx helpers and call `this.db()` directly (`src/fs/sql-fs/dialects/postgres.ts:567–650`) — they need their own wrapper.
+- Pool construction (`postgres(connectionString, { prepare: false })` at `src/fs/sql-fs/dialects/postgres.ts:41`) is lazy: connections open on first query, so the wrapper at the tx layer is sufficient — no need to wrap `connect()`.
+- The `loadAllPaths` cold-start runs in `buildFs` *before* `new Bash(...)` (`src/api/session-manager.ts:298`), so cold-start path-cache hydration is outside the patched scope and needs no wrapping.
+- `RedisBlobCache` and `RedisPathSnapshot` calls also use timers (ioredis), but they happen via the same SqlFs/dialect chokepoints, so the `#withTx` wrapping covers them.
+- The script-tx (`#openScriptTx`) holds a long-lived transaction across `bash.exec` — the awaited `endPromise` lives inside the patched scope. Its single `dialect.transaction(...)` call needs the wrapper too.
+
+## What We're NOT Doing
+
+- MySQL (`mysql2`) and Azure SQL (`mssql`/tedious) dialects — same issue, but out of scope for this PR. Tracked separately.
+- The `js-exec` / `python3` worker FS bridge — the workers have their own `WorkerSecurityViolationError` rule list and may need a parallel fix; investigated as a follow-up.
+- Defaulting `defenseInDepth: true` for all production traffic. Initial release ships behind the env flag, off by default.
+- Replacing the porsager `postgres` driver. The fix wraps the call sites, not the driver.
+- Re-architecting `SqlFs` to remove its dependency on just-bash's security primitive. We accept the soft coupling.
+
+## Implementation Approach
+
+Five small phases:
+
+1. **Wrap DB chokepoints** in `SqlFs` and `PostgresDialect` so DB calls always run inside `DefenseInDepthBox.runTrustedAsync(...)`. Always-on; cheap no-op when no box is installed.
+2. **Add the env flags** and plumb `defenseInDepth` + `auditMode` into `new Bash(...)` at `session-manager.ts:299`.
+3. **Integration test** with `defenseInDepth: true` against real Postgres covering reads, writes, mkdir, rm, and a script-tx flow.
+4. **Docs**: env vars in CLAUDE.md + a short note in DEVELOPER.md (if present) on the coupling.
+5. **CHANGELOG + version bump** per repo convention.
+
+Phase 1 is the core fix. Phase 2 is the user-visible toggle. Phase 3 proves it. Phases 4–5 are bookkeeping.
+
+---
+
+## Phase 1: Wrap DB chokepoints in runTrustedAsync
+
+### Phase 1: Overview
+
+Make every Postgres I/O path in `SqlFs` and `PostgresDialect` execute inside `DefenseInDepthBox.runTrustedAsync(...)`. This is unconditional — when no defense box is installed, `runTrustedAsync` simply invokes the function. The cost is one extra async frame per DB call.
+
+### Phase 1: Changes Required
+
+#### 1. SqlFs tx helpers — wrap all three
+
+**File**: `src/fs/sql-fs/sql-fs.ts` (around lines 177–246)
+**Changes**: Import `DefenseInDepthBox` from `just-bash`. Wrap the body of `#withTx`, `#withReadTx`, `#withBareTx`, and `#openScriptTx`'s `dialect.transaction` call in `DefenseInDepthBox.runTrustedAsync(() => ...)`.
+
+```typescript
+import { DefenseInDepthBox } from "just-bash";
+
+async #withTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
+    if (this.#scriptScope) {
+        if (this.#scriptTx === undefined) {
+            await this.#openScriptTx();
+        }
+        return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+    }
+    return DefenseInDepthBox.runTrustedAsync(() =>
+        this.#dialect.transaction(async (tx) => {
+            await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
+            return await fn(tx);
+        }),
+    );
+}
+
+async #withReadTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
+    if (this.#scriptScope && this.#scriptTx !== undefined) {
+        return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+    }
+    return DefenseInDepthBox.runTrustedAsync(() =>
+        this.#dialect.transaction(async (tx) => {
+            await this.#dialect.setSandboxContext(tx, this.#sandboxId);
+            return await fn(tx);
+        }),
+    );
+}
+
+async #withBareTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
+    if (this.#scriptTx !== undefined) {
+        return DefenseInDepthBox.runTrustedAsync(() => fn(this.#scriptTx!));
+    }
+    return DefenseInDepthBox.runTrustedAsync(() => this.#dialect.transaction(fn));
+}
+```
+
+For `#openScriptTx` (lines 205–235): wrap the `this.#dialect.transaction(async (tx) => {...})` call in `runTrustedAsync` so the long-lived script-tx is opened inside the trusted scope. The `await endPromise` inside the callback continues to live in trusted scope, which is what we want — `endScriptScope` and `abortScriptScope` then resolve/reject from their own (potentially patched) scope, but the timer-using bits are inside.
+
+#### 2. SqlFs prewarm + `#readBytes` lock-free read
+
+**File**: `src/fs/sql-fs/sql-fs.ts` (lines 383–408 and 853–874)
+**Changes**: Wrap the `getBlobsForSandbox` call inside `#startPrewarm` and the `getBlobNoTx` call inside `#readBytes`.
+
+```typescript
+// inside #startPrewarm task:
+const blobs = await DefenseInDepthBox.runTrustedAsync(() =>
+    this.#dialect.getBlobsForSandbox(this.#sandboxId, cap),
+);
+
+// inside #readBytes:
+const data = await DefenseInDepthBox.runTrustedAsync(() =>
+    this.#dialect.getBlobNoTx(entry.contentSha256!),
+);
+```
+
+#### 3. PostgresDialect — wrap the lock-free pool calls
+
+**File**: `src/fs/sql-fs/dialects/postgres.ts` (lines 567–582 for `getBlobNoTx`, 584–650 for `getBlobsForSandbox`)
+**Changes**: These are public API methods on `SqlDialect` — defense-in-depth must apply here too even if a future caller doesn't go through SqlFs. Wrap each `this.db()<...>...` template call in `DefenseInDepthBox.runTrustedAsync`.
+
+```typescript
+import { DefenseInDepthBox } from "just-bash";
+
+async getBlobNoTx(sha256: Uint8Array): Promise<Uint8Array | null> {
+    if (this.#blobCache !== undefined) {
+        const cached = await this.#blobCache.get(sha256);
+        if (cached !== null) return cached;
+    }
+    const rows = await DefenseInDepthBox.runTrustedAsync(
+        () => this.db()<{ data: Buffer }[]>`SELECT data FROM blobs WHERE sha256 = ${sha256}`,
+    );
+    // ...rest unchanged
+}
+```
+
+Apply the same pattern to the two `this.db()<...>` calls in `getBlobsForSandbox` (the meta-rows query at line 589 and the missing-blobs query at line 625).
+
+Also wrap `this.pool = postgres(connectionString, { prepare: false })` in `connect()` and `await this.pool?.end()` in `disconnect()` — both run during sandbox lifecycle and `connect()` is currently called outside the patched scope, but wrapping is cheap insurance for any future caller invoking them inside `bash.exec`.
+
+#### 4. Re-export DefenseInDepthBox usage
+
+**File**: `src/fs/sql-fs/sql-fs.ts` and `src/fs/sql-fs/dialects/postgres.ts`
+**Changes**: Verify `DefenseInDepthBox` is importable from `just-bash` main entry (it is — `node_modules/just-bash/dist/index.d.ts:19`). No re-export needed.
+
+### Phase 1: Success Criteria
+
+#### Phase 1: Automated Verification
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` produces no diff (or only the expected import additions)
+- [x] `pnpm test:unit` passes — existing SqlFs unit tests should be unaffected (mocks bypass the dialect entirely)
+
+#### Phase 1: Manual Verification
+- [ ] Boot the dev server with the existing config (no env flags set), run a sandbox `cat /etc/version` style script, confirm latency is unchanged within noise.
+
+### Phase 1: Discoveries and Notable Information
+
+**Technical Discoveries:**
+- `just-bash/dist` has no `security/` directory, but `DefenseInDepthBox` is still resolvable at runtime and TypeScript resolves the export without error. The security module is compiled into the bundle chunks.
+- `DefenseInDepthBox.runTrustedAsync` does not propagate TypeScript's generic type inference correctly when the callback returns a postgres tagged-template `PendingQuery<T[]>`. TypeScript infers `any` for the awaited result, causing downstream implicit-`any` errors (TS7006) in `.map()` callbacks. Fix: add an explicit type annotation on the `const metaRows:` declaration (`postgres.ts:592`).
+- TypeScript does not narrow private class fields (`#scriptTxPromise`) after assignment when the RHS involves a call whose return type includes `any` or is non-trivially inferred. Fix: store the result in a local `const` first, assign to the field second, then call `.catch()` on the const (`sql-fs.ts:225–236`).
+
+**Implementation Adaptations:**
+- `connect()` / `disconnect()` in `postgres.ts`: the plan says to wrap `postgres(...)` with `runTrustedAsync`. Since `postgres(...)` is synchronous (no TCP yet), it was wrapped as `Promise.resolve(postgres(...))` to satisfy the `() => Promise<T>` signature.
+- `#openScriptTx`: used a local `const scriptTxPromise` to avoid the TypeScript narrowing issue before assigning to `this.#scriptTxPromise` and chaining `.catch()`.
+
+---
+
+## Phase 2: Plumb env flags into Bash construction
+
+### Phase 2: Overview
+
+Wire two new env vars — `JUST_BASH_DEFENSE_IN_DEPTH` (default `false`) and `JUST_BASH_DEFENSE_AUDIT_MODE` (default `true`) — through `SessionManager` into `new Bash(...)`. Audit mode means violations are logged but not thrown, so the first production rollout is observation-only.
+
+### Phase 2: Changes Required
+
+#### 1. Read flags at SessionManager construction
+
+**File**: `src/api/session-manager.ts`
+**Changes**: Add two `readonly` fields to `SessionManager` populated from env in the constructor (around line 175–219). Pass them to `new Bash(...)` at line 299.
+
+```typescript
+// new fields on SessionManager
+private readonly defenseInDepth: boolean;
+private readonly defenseAuditMode: boolean;
+
+// in the constructor:
+this.defenseInDepth = process.env.JUST_BASH_DEFENSE_IN_DEPTH === "true";
+this.defenseAuditMode = process.env.JUST_BASH_DEFENSE_AUDIT_MODE !== "false"; // default true
+
+// at line 299:
+const bash = new Bash({
+    fs,
+    python: resolvedRuntime.python || undefined,
+    javascript: resolvedRuntime.javascript || undefined,
+    defenseInDepth: this.defenseInDepth
+        ? { auditMode: this.defenseAuditMode }
+        : undefined,
+});
+```
+
+The exact shape of `DefenseInDepthConfig` is described in `node_modules/just-bash/dist/Bash.d.ts:121–147` — verify `auditMode` is a top-level field on the config object during implementation. If just-bash exposes a violation callback, wire it to a structured `console.log` so audit-mode entries are greppable as `event: "defense_in_depth_violation"`.
+
+#### 2. SessionManagerOptions override (for tests)
+
+**File**: `src/api/session-manager.ts` (around line 110–145)
+**Changes**: Add optional `defenseInDepth?: boolean` and `defenseAuditMode?: boolean` to `SessionManagerOptions` so tests can override env. Plumb through the constructor.
+
+### Phase 2: Success Criteria
+
+#### Phase 2: Automated Verification
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test:unit` passes
+- [ ] Existing API e2e tests in `src/api/tests/` pass with no env flag set (default-off path)
+
+#### Phase 2: Manual Verification
+- [ ] With `JUST_BASH_DEFENSE_IN_DEPTH=true JUST_BASH_DEFENSE_AUDIT_MODE=true pnpm dev`, run a script that does `echo hi > /tmp/x && cat /tmp/x` against the dev Postgres — output is `hi` and any violations appear as warnings in logs without breaking the request.
+- [ ] With `JUST_BASH_DEFENSE_IN_DEPTH=true JUST_BASH_DEFENSE_AUDIT_MODE=false`, the same script succeeds with no violations logged. (This is the post-rollout target state.)
+
+### Phase 2: Discoveries and Notable Information
+
+[Filled by implementing agent.]
+
+---
+
+## Phase 3: Integration test
+
+### Phase 3: Overview
+
+A skip-if-no-DB integration test that exercises the previously-broken path: `new Bash({ fs: sqlFs, defenseInDepth: true })` running real bash against real Postgres.
+
+### Phase 3: Changes Required
+
+#### 1. New test file
+
+**File**: `src/fs/sql-fs/integration/defense-in-depth.integration.test.ts` (new)
+**Changes**: One `describe.skipIf(!process.env.DATABASE_URL)` block with cases:
+- `bash.exec("echo hi > /tmp/x && cat /tmp/x")` returns `"hi"` and no violation thrown (auditMode off).
+- `bash.exec("mkdir -p /a/b/c && ls /a/b")` succeeds.
+- `bash.exec("rm -rf /tmp")` succeeds.
+- A script-tx flow (multiple writes in one exec) commits cleanly.
+- Cold-start prewarm path: read a previously-written file from a fresh `SqlFs` instance attached to the same sandbox.
+
+```typescript
+import { describe, it, expect, afterEach } from "vitest";
+import { Bash } from "just-bash";
+import { createPostgresSandboxFs, destroyPostgresSandbox } from "../index.js";
+
+describe.skipIf(!process.env.DATABASE_URL)("defenseInDepth + Postgres", () => {
+    const sandboxId = `test-defense-${Date.now()}`;
+    const url = process.env.DATABASE_URL!;
+
+    afterEach(async () => {
+        await destroyPostgresSandbox(url, sandboxId).catch(() => {});
+    });
+
+    it("does not throw WorkerSecurityViolationError on read/write", async () => {
+        const { fs } = await createPostgresSandboxFs({ connectionString: url }, sandboxId);
+        const bash = new Bash({ fs, defenseInDepth: { auditMode: false } });
+        const result = await bash.exec("echo hi > /tmp/x && cat /tmp/x");
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe("hi");
+    });
+
+    // ...further cases
+});
+```
+
+### Phase 3: Success Criteria
+
+#### Phase 3: Automated Verification
+- [ ] `DATABASE_URL=... pnpm test:integration` runs the new test green.
+- [ ] Without `DATABASE_URL`, the test is skipped (not failed).
+
+#### Phase 3: Manual Verification
+- [ ] Temporarily revert Phase 1 wrappers — confirm the new test fails with `WorkerSecurityViolationError`. Re-apply Phase 1 — green again.
+
+### Phase 3: Discoveries and Notable Information
+
+[Filled by implementing agent.]
+
+---
+
+## Phase 4: Documentation
+
+### Phase 4: Overview
+
+Document the two new env vars and the rollout posture.
+
+### Phase 4: Changes Required
+
+#### 1. CLAUDE.md env vars table
+
+**File**: `CLAUDE.md`
+**Changes**: Append two rows to the env vars table:
+
+| Variable | Required | Description |
+|---|---|---|
+| `JUST_BASH_DEFENSE_IN_DEPTH` | No (default: `false`) | Enables just-bash's defense-in-depth security layer (monkey-patches `setTimeout`, `eval`, `Function`, dynamic `import`, etc. for the duration of `bash.exec`). All Postgres I/O is wrapped in `DefenseInDepthBox.runTrustedAsync` to remain compatible. |
+| `JUST_BASH_DEFENSE_AUDIT_MODE` | No (default: `true`) | When `JUST_BASH_DEFENSE_IN_DEPTH=true`, controls whether violations throw (`false`) or are logged only (`true`). Recommended `true` for initial rollout, then flip to `false` once logs are clean. |
+
+#### 2. Security section note (optional)
+
+**File**: `CLAUDE.md` (Security subsection)
+**Changes**: One short paragraph noting that defense-in-depth is opt-in and requires the wrapping in SqlFs to be preserved when adding new dialects.
+
+### Phase 4: Success Criteria
+
+#### Phase 4: Automated Verification
+- [ ] No automated check.
+
+#### Phase 4: Manual Verification
+- [ ] CLAUDE.md renders cleanly; the two new rows are in the env table; the security note matches the actual implementation.
+
+---
+
+## Phase 5: CHANGELOG + version bump
+
+Per `CLAUDE.md` "Changelog & Version Bump Requirement": minor bump (new feature), update `package.json`, `pnpm-lock.yaml`, `src/api/openapi-spec.ts`, add a dated `CHANGELOG.md` section.
+
+### Phase 5: Success Criteria
+
+#### Phase 5: Automated Verification
+- [ ] `pnpm install --lockfile-only` produces only the version diff.
+- [ ] All four version sites match.
+
+#### Phase 5: Manual Verification
+- [ ] CHANGELOG entry under `Added` reads clearly to a future reader.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- No new unit tests required. Existing SqlFs unit tests use a mock dialect and don't observe the wrapper. Adding a unit test that asserts `runTrustedAsync` is called would over-couple to the implementation.
+
+### Integration Tests
+- Phase 3's `defense-in-depth.integration.test.ts` is the load-bearing verification. It must run against a real Postgres because the bug only reproduces when porsager actually opens a TCP connection and arms its timers.
+
+### Manual Testing Steps
+1. `JUST_BASH_DEFENSE_IN_DEPTH=true JUST_BASH_DEFENSE_AUDIT_MODE=true pnpm dev` — boot, hit `/v1/sandboxes`, run `echo hi > /tmp/x && cat /tmp/x` via `/v1/exec`, confirm 200 + correct stdout, observe any violation logs.
+2. Flip `JUST_BASH_DEFENSE_AUDIT_MODE=false` — same script must still succeed and produce no violation logs. If it doesn't, find the unwrapped call site.
+3. Run a `bulkIngest` flow (POST to `/v1/ingest`) under both modes — exercises `bulkIngest` → `#withTx` → composite SQL.
+4. Long-running script-tx: `for i in $(seq 1 10); do echo $i >> /a; done` — exercises `#openScriptTx` and the held tx.
+
+## Performance Considerations
+
+- One extra async frame per DB call. Negligible (sub-µs).
+- No measurable impact on cold-start (prewarm wrapper is on the background task, not the request path).
+- When `defenseInDepth: false`, `runTrustedAsync` short-circuits to `await fn()` — observable cost is one promise hop.
+
+## Migration Notes
+
+- No data migration. No schema change.
+- Existing deployments are unaffected until they set `JUST_BASH_DEFENSE_IN_DEPTH=true`.
+- Recommended rollout: deploy with both flags off → flip `JUST_BASH_DEFENSE_IN_DEPTH=true` (audit mode on by default) → watch logs for `defense_in_depth_violation` for ~1 week → flip `JUST_BASH_DEFENSE_AUDIT_MODE=false` once clean.
+
+## References
+
+- Original research: `thoughts/shared/research/2026-05-05_22-26-54_defense-in-depth-postgres-interaction.md`
+- Bash defense-in-depth API: `node_modules/just-bash/dist/Bash.d.ts:121–147`
+- DefenseInDepthBox export: `node_modules/just-bash/dist/index.d.ts:19`
+- SqlFs tx chokepoints: `src/fs/sql-fs/sql-fs.ts:177–246`
+- Postgres lock-free reads: `src/fs/sql-fs/dialects/postgres.ts:567–650`
+- Bash construction site: `src/api/session-manager.ts:298–303`

--- a/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
+++ b/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
@@ -293,15 +293,23 @@ describe.skipIf(!process.env.DATABASE_URL)("defenseInDepth + Postgres", () => {
 ### Phase 3: Success Criteria
 
 #### Phase 3: Automated Verification
-- [ ] `DATABASE_URL=... pnpm test:integration` runs the new test green.
-- [ ] Without `DATABASE_URL`, the test is skipped (not failed).
+- [x] `DATABASE_URL=... pnpm test:integration` runs the new test green.
+- [x] Without `DATABASE_URL`, the test is skipped (not failed).
 
 #### Phase 3: Manual Verification
 - [ ] Temporarily revert Phase 1 wrappers — confirm the new test fails with `WorkerSecurityViolationError`. Re-apply Phase 1 — green again.
 
 ### Phase 3: Discoveries and Notable Information
 
-[Filled by implementing agent.]
+**Technical Discoveries:**
+- The `integration/` directory under `src/fs/sql-fs/` does not exist as a top-level sibling — the plan's stated file path (`src/fs/sql-fs/integration/`) is wrong. Existing integration tests live under `src/fs/sql-fs/tests/integration/`. Placed new file there for consistency.
+- `Bash` from `just-bash` accepts `defenseInDepth: { enabled: true, auditMode: false }` — the `enabled` field is required alongside `auditMode`; the plan scaffold omitted it.
+- `createdSandboxIds` array pattern (push + splice in `afterEach`) is cleaner than a single shared `sandboxId` because each test creates its own sandbox; the plan scaffold reused one id across all tests which would cause `EEXIST` on the second `createPostgresSandboxFs` call for the same sandbox.
+
+**Implementation Adaptations:**
+- Used `{ enabled: true, auditMode: false }` on `defenseInDepth` config to match just-bash's `DefenseInDepthConfig` interface.
+- Each test creates its own sandbox via a helper `makeSandboxId()` to avoid cross-test collisions.
+- Biome auto-organised the `vitest` import to follow `just-bash` alphabetically (import reorder).
 
 ---
 

--- a/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
+++ b/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
@@ -227,9 +227,9 @@ The exact shape of `DefenseInDepthConfig` is described in `node_modules/just-bas
 ### Phase 2: Success Criteria
 
 #### Phase 2: Automated Verification
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm test:unit` passes
-- [ ] Existing API e2e tests in `src/api/tests/` pass with no env flag set (default-off path)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm test:unit` passes
+- [x] Existing API e2e tests in `src/api/tests/` pass with no env flag set (default-off path)
 
 #### Phase 2: Manual Verification
 - [ ] With `JUST_BASH_DEFENSE_IN_DEPTH=true JUST_BASH_DEFENSE_AUDIT_MODE=true pnpm dev`, run a script that does `echo hi > /tmp/x && cat /tmp/x` against the dev Postgres — output is `hi` and any violations appear as warnings in logs without breaking the request.
@@ -237,7 +237,13 @@ The exact shape of `DefenseInDepthConfig` is described in `node_modules/just-bas
 
 ### Phase 2: Discoveries and Notable Information
 
-[Filled by implementing agent.]
+**Technical Discoveries:**
+- `createConsoleViolationCallback()` from `just-bash` uses `console.warn` and plain multi-line text, not structured JSON — not suitable for machine-greppable logs.
+- `SecurityViolation` type is importable directly from `"just-bash"` alongside `DefenseInDepthConfig`.
+
+**Implementation Adaptations:**
+- Used a custom inline `onViolation` callback (`console.log(JSON.stringify({ event: "defense_in_depth_violation", sandboxId, ...v }))`) instead of `createConsoleViolationCallback` to emit structured, greppable log lines. The `sandboxId` is included for correlation.
+- All Phase 2 code was already committed (commit `b9219ec`) before this session; only the `onViolation` wiring was missing.
 
 ---
 

--- a/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
+++ b/thoughts/shared/plans/2026-05-05_23-03-22_defense-in-depth-postgres-fix.md
@@ -353,8 +353,8 @@ Per `CLAUDE.md` "Changelog & Version Bump Requirement": minor bump (new feature)
 ### Phase 5: Success Criteria
 
 #### Phase 5: Automated Verification
-- [ ] `pnpm install --lockfile-only` produces only the version diff.
-- [ ] All four version sites match.
+- [x] `pnpm install --lockfile-only` produces only the version diff.
+- [x] All four version sites match.
 
 #### Phase 5: Manual Verification
 - [ ] CHANGELOG entry under `Added` reads clearly to a future reader.

--- a/thoughts/shared/research/2026-05-05_22-26-54_defense-in-depth-postgres-interaction.md
+++ b/thoughts/shared/research/2026-05-05_22-26-54_defense-in-depth-postgres-interaction.md
@@ -1,0 +1,117 @@
+---
+date: 2026-05-05T22:26:54+09:30
+researcher: Harry Nguyen
+git_commit: effe298e8b608097b637c8dac82c7db1bc637e33
+branch: main
+repository: virtualFS
+topic: "How just-bash defenseInDepth interacts with SqlFs/Postgres calls"
+tags: [research, codebase, just-bash, defense-in-depth, sql-fs, postgres, security]
+status: complete
+last_updated: 2026-05-05
+last_updated_by: Harry Nguyen
+---
+
+# Research: How just-bash defenseInDepth interacts with SqlFs/Postgres calls
+
+**Date**: 2026-05-05 22:26:54 ACST
+**Researcher**: Harry Nguyen
+**Git Commit**: effe298e8b608097b637c8dac82c7db1bc637e33
+**Branch**: main
+**Repository**: virtualFS
+
+## Research Question
+
+A user reports that when testing `SqlFs` plugged into `just-bash`, they had to disable `defenseInDepth`; otherwise calls into Postgres throw errors. Hypothesis: `defenseInDepth` blocks the `setTimeout`/`setImmediate` globals that the `postgres` driver relies on. Trace through the codebase to:
+
+1. Where (and whether) `defenseInDepth` is configured when we create Bash sandboxes.
+2. The execution flow `Bash.exec → IFileSystem → SqlFs → postgres`.
+3. Whether Postgres operations actually run inside the `defenseInDepth`-restricted context.
+4. How the bug manifests in production.
+
+## Summary
+
+**The bug is real, but it does not manifest in the `virtualfs-api` service today** because `defenseInDepth` is never enabled at the only `new Bash(...)` call site (`src/api/session-manager.ts:299`). It manifests only for downstream consumers (or local tests) that compose `just-bash` with `defenseInDepth: true` and pass our `SqlFs` as the filesystem.
+
+The hypothesis is correct. `defenseInDepth` monkey-patches `setTimeout`, `setImmediate`, `Function`, `eval`, `process`, and dynamic `import` during script execution (just-bash `Bash.d.ts:121–146`). The `postgres` driver (porsager/postgres v3) uses `setTimeout`/`clearTimeout` for connect / idle / lifetime timers and `setImmediate`/`clearImmediate` for batched writes (see `node_modules/postgres/src/connection.js:1042–1062`, `node_modules/postgres/src/index.js:372`, `node_modules/postgres/src/connection.js:250, 256, 427, 440`). Because there is **no worker / thread boundary between the bash script execution context and the SqlFs → postgres call** — the `IFileSystem` runs in the same JS event loop as the interpreter — postgres timer calls happen while the globals are patched, and `defenseInDepth` raises `WorkerSecurityViolationError`.
+
+just-bash exposes the intended escape hatch via `requireDefenseContext` / `runInDefenseBox` (`node_modules/just-bash/dist/types.d.ts:174–178, 189`) and `DefenseInDepthBox.runTrustedAsync(...)`, plus `createDefenseAwareCommandContext` (`dist/interpreter/defense-aware-command-context.d.ts`). `SqlFs` does not currently wrap its `postgres` calls in those helpers, so any caller that turns `defenseInDepth` on will hit the violation.
+
+## Detailed Findings
+
+### 1. Where `defenseInDepth` is configured in our codebase
+
+It isn't. The only place we instantiate `Bash` is:
+
+- `src/api/session-manager.ts:299–303` — constructs the per-sandbox Bash with `{ fs, python, javascript }` only. No `defenseInDepth` field is passed, so the option is `undefined` and the protection layer stays off.
+
+There are zero other references to `defenseInDepth`, `SecurityViolation`, `DefenseInDepthBox`, or `requireDefenseContext` anywhere under `src/`.
+
+The type is declared in just-bash:
+
+- `node_modules/just-bash/dist/Bash.d.ts:121–147` — `defenseInDepth?: DefenseInDepthConfig | boolean` with JSDoc explicitly noting it monkey-patches `Function`, `eval`, `setTimeout`, `process`, etc.
+- `node_modules/just-bash/dist/sandbox/Sandbox.d.ts:32–35` — `SandboxOptions.defenseInDepth` defaults to `true` for the higher-level `Sandbox` wrapper. We use `Bash` directly, not `Sandbox`, so we don't inherit that default — but anyone wrapping our `SqlFs` via `Sandbox` would.
+
+### 2. Execution flow Bash → SqlFs → postgres
+
+1. HTTP request arrives at `src/api/routes/exec.ts`. The handler resolves a session and calls `session.bash.exec(script)` via `execWithRuntimeThrottle` (`session-manager.ts:626–665`). The exec timeout uses host `setTimeout` (`exec.ts:160, 248`) — that one is fine because it runs outside the interpreter.
+2. `Bash.exec` runs the parsed script in the same Node event loop. Builtins / commands invoke methods on the `fs` we passed in.
+3. `fs` is a `SqlFs` constructed in `src/fs/sql-fs/index.ts → createPostgresSandboxFs` (called from `session-manager.buildFs`, `session-manager.ts:245–265`).
+4. `SqlFs.readFile` / `writeFile` / etc. (`src/fs/sql-fs/sql-fs.ts`) call `dialect.transaction(...)` or `dialect.getBlobNoTx(...)`.
+5. `PostgresDialect` (`src/fs/sql-fs/dialects/postgres.ts:40–52`) uses `postgres(connectionString, { prepare: false })` — the porsager/postgres client. `transaction()` calls `db.begin(fn)`.
+6. The driver internally schedules timers and immediates as part of normal operation.
+
+There is **no worker_threads boundary, no `vm` context, no separate isolate** between steps 2 and 6. They share globals.
+
+### 3. Does Postgres run inside the restricted context?
+
+Yes — when `defenseInDepth` is on. The interpreter installs the monkey patches around the script's async execution (the violation logic is compiled into `node_modules/just-bash/dist/bin/chunks/worker.js:58–82, 519–1456` and the `js-exec-worker.js` mirror). Anything called synchronously or via awaited promises from a builtin is inside that scope, including:
+
+- The first connection from our pool (lazy connect in `postgres` triggers `setTimeout` for `connectTimer`).
+- Any `idle_timeout` / `max_lifetime` rearm during query execution.
+- `setImmediate(nextWrite)` used to batch writes for prepared messages.
+
+The driver uses **module-scope references to the timer globals**, not `globalThis.setTimeout`, but `defenseInDepth` patches the globals before module evaluation occurs in the protected scope, so the captured references are already the patched ones (or, more importantly, when the driver does `setTimeout(...)` from within the patched async context, the lookup resolves to the patched function). Either way, the violation handler fires.
+
+just-bash itself acknowledges this: commands that legitimately need real timers can opt out via `Command.runInDefenseBox` / `CommandContext.requireDefenseContext` (`node_modules/just-bash/dist/types.d.ts:174–189`) and `DefenseInDepthBox.runTrustedAsync(...)`. `SqlFs` is not a "command"; it's the `IFileSystem` plumbing, so those flags don't directly apply to fs methods — but the same `runTrustedAsync` API is what we'd need to wrap our DB calls in.
+
+### 4. How the bug manifests
+
+Scenarios:
+
+- **Production virtualfs-api today:** Not affected. `session-manager.ts:299` passes no `defenseInDepth`, so the patches never run, and the `postgres` driver uses unpatched timers happily.
+- **Downstream consumer enables it:** If anyone instantiates `new Bash({ fs: sqlFs, defenseInDepth: true })` (the JSDoc example at `Bash.d.ts:135`), the first SqlFs operation that triggers postgres I/O — typically the first `cat`/`ls` after sandbox boot, or our own `loadAllPaths` path-snapshot warmup — throws `WorkerSecurityViolationError` complaining about `setTimeout` (or `setImmediate` for write batching). The user reports exactly this.
+- **Wrapping with `Sandbox` instead of `Bash`:** `SandboxOptions.defenseInDepth` defaults to `true` (`Sandbox.d.ts:32–35`). A consumer who picks the higher-level wrapper gets the bug by default and has to opt out explicitly.
+- **Tests that mimic that setup:** Same as above. The user's repro path.
+
+What blows up first: `PostgresDialect.connect()` does `postgres(connectionString, ...)` — but porsager's client lazily opens connections on first query. So the violation typically fires on the first `dialect.transaction(...)` call from `SqlFs.loadAllPaths` (eager pathCache hydration during `createSandboxFs`) **before** any user script runs… *unless* our factory is called outside the interpreter scope. Looking at `session-manager.ts:245–265`, `buildFs` is awaited **before** `new Bash(...)`, so pathCache hydration runs in the host context and would succeed even with `defenseInDepth` later. The first failure surface is therefore the first DB-touching fs call **during** `bash.exec` — e.g. a write that flushes through `writeFileTx`, or a `readFile` for a blob not yet in `contentCache`.
+
+## Code References
+
+- `src/api/session-manager.ts:299–303` — `new Bash({ fs, python, javascript })` — the sole construction site, no `defenseInDepth`.
+- `src/api/session-manager.ts:245–265` — `buildFs` → `createPostgresSandboxFs`; runs in host context before Bash exec.
+- `src/api/routes/exec.ts:160, 248` — host-side exec timeout `setTimeout` (unaffected).
+- `src/fs/sql-fs/dialects/postgres.ts:40–52` — `postgres(connectionString, { prepare: false })` and `transaction` via `db.begin`.
+- `src/fs/sql-fs/sql-fs.ts` — every IFS method funnels into `dialect.transaction`, hence into postgres timers.
+- `node_modules/just-bash/dist/Bash.d.ts:121–147` — `defenseInDepth` config + JSDoc listing patched globals.
+- `node_modules/just-bash/dist/sandbox/Sandbox.d.ts:32–35` — `SandboxOptions.defenseInDepth` defaults to `true`.
+- `node_modules/just-bash/dist/types.d.ts:174–189` — `CommandContext.requireDefenseContext`, `Command.runInDefenseBox`.
+- `node_modules/just-bash/dist/interpreter/defense-aware-command-context.d.ts:1–6` — `createDefenseAwareCommandContext` helper.
+- `node_modules/just-bash/dist/bin/chunks/worker.js:58–82, 519–1456` — compiled `WorkerSecurityViolationError` and rule list (covers `setTimeout`, `setImmediate`, dynamic import, `process.mainModule/execPath/connected`).
+- `node_modules/postgres/src/connection.js:250, 256, 427, 440` — `setImmediate(nextWrite)` / `clearImmediate` for batched writes.
+- `node_modules/postgres/src/connection.js:1042–1062` — `timer()` helper using `setTimeout`/`clearTimeout` for `idleTimer`, `lifeTimer`, `connectTimer`.
+- `node_modules/postgres/src/index.js:372` — query/connection destruction `setTimeout`.
+
+## Architecture Insights
+
+- **Single shared event loop.** Our design relies on running `IFileSystem` calls in the same JS context as the bash interpreter. This is fine for performance (no IPC), but it means **any global-tampering security layer the interpreter installs will affect our DB driver too.** This is a non-obvious coupling between just-bash's secondary security layer and our DB choice.
+- **`postgres` (porsager) is timer-heavy.** `pg` (node-postgres) uses sockets directly and would also use timers, so swapping drivers wouldn't help. Any TCP-based driver will trip the same patches.
+- **just-bash's intended escape hatch (`runTrustedAsync`) targets commands, not fs methods.** Adopting it inside `SqlFs` would mean importing `DefenseInDepthBox` from just-bash and wrapping every dialect call — viable, but creates a circular concern (the fs has to know about the interpreter that will run on top of it). A cleaner fix is to detect that `defenseInDepth` is active at construction time and route DB calls through `runTrustedAsync` only then, leaving consumers who don't enable it untouched.
+- **Production has been getting away with it.** Because we don't enable `defenseInDepth` ourselves, this has been a latent bug for any consumer following just-bash's own JSDoc example. The CLAUDE.md "Security" guidance focuses on RLS / sandbox isolation / null prototypes — it doesn't mention defense-in-depth, which matches the fact that we never wired it up.
+
+## Open Questions
+
+- Do we want to enable `defenseInDepth` ourselves at `session-manager.ts:299`? If yes, we have to fix the timer-blocking issue first.
+- Should `SqlFs` defensively wrap its dialect calls in `DefenseInDepthBox.runTrustedAsync(...)` when available, so consumers can opt in safely without modifying our code? That introduces a soft dependency on `DefenseInDepthBox` being exported from `just-bash`.
+- Does the same issue affect MySQL (`mysql2`) and Azure SQL (`mssql`/tedious) dialects? Both libraries also use sockets+timers; almost certainly yes — worth verifying before publishing a fix only for postgres.
+- Does `auditMode: true` (`Bash.d.ts:141`) silence the throw and just log? If so, it's a viable workaround for the user pending a real fix.
+- Is `js-exec` / `python3` worker FS access (which goes back to the parent through a bridge) subject to the same patches? Those workers have their own copies of `WorkerSecurityViolationError` (`worker.js:519–1456`, `js-exec-worker.js:496–1433`) — needs a follow-up if FS calls cross that boundary.


### PR DESCRIPTION
## Summary

- Wraps all Postgres I/O chokepoints (`#withTx`, `#withReadTx`, `#withBareTx`, `getBlobNoTx`) in `DefenseInDepthBox.runTrustedAsync` so the just-bash defense-in-depth security layer (which monkey-patches `setTimeout`, `eval`, `Function`, and dynamic `import` during `bash.exec`) does not block DB access when enabled.
- Adds two opt-in env vars: `JUST_BASH_DEFENSE_IN_DEPTH` (default `false`) and `JUST_BASH_DEFENSE_AUDIT_MODE` (default `true`); wires them into `SessionManager` → `Bash` constructor with a structured `onViolation` logger emitting `{ event: "defense_in_depth_violation", sandboxId, ... }`.
- Adds an integration test (`defense-in-depth.integration.test.ts`) that boots a real `Bash` instance with `defenseInDepth: { enabled: true, auditMode: false }` against Postgres and asserts that a simple file write/read script completes without `WorkerSecurityViolationError`.
- Bumps to `0.3.0` (minor — new opt-in feature) and documents env vars + security guidance in `CLAUDE.md`.

## Testing

```bash
# Unit tests (no DB required)
pnpm test:unit

# Integration test (requires DATABASE_URL)
DATABASE_URL=... pnpm test -- src/fs/sql-fs/tests/integration/defense-in-depth.integration.test.ts

# Type check + lint
pnpm typecheck && pnpm lint:fix
```

All automated checks passed. Manual rollout recommendation: deploy with `JUST_BASH_DEFENSE_IN_DEPTH=false` (default), then enable with `JUST_BASH_DEFENSE_AUDIT_MODE=true` to observe violation logs before flipping to enforce mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional defense-in-depth security layer for bash execution via JUST_BASH_DEFENSE_IN_DEPTH.
  * Introduced JUST_BASH_DEFENSE_AUDIT_MODE to log violations (audit) before switching to enforce.
  * Added structured JSON violation logging for easier monitoring and alerting.

* **Documentation**
  * Updated docs and changelog with the new security options and environment variables.

* **Tests**
  * Added unit and integration tests covering the new defense-in-depth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->