### PR TITLE
fix(stability): production resource lifecycle hardening (0.2.20)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "restricted",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
+}

--- a/.env.example
+++ b/.env.example
@@ -1,32 +1,30 @@
-# Backend: postgres | mysql | azure-sql | azure-fileshare | memory
+# ── Required ──────────────────────────────────────────────────────────────────
+
 FS_BACKEND=postgres
+DATABASE_URL=postgres://user:password@localhost:5432/virtualfs
+DATABASE_DIRECT_URL=postgres://user:password@localhost:5432/virtualfs
+AUTH_SECRET=replace-with-a-long-random-secret
 
-# SQL backends
-DATABASE_URL=postgres://postgres:test@localhost:5432/virtualfs
-DATABASE_DIRECT_URL=postgres://postgres:test@localhost:5432/virtualfs
+# ── Optional: server ──────────────────────────────────────────────────────────
 
-# Azure FileShare backend
-# FS_MOUNT_PATH=/mnt/sandboxes
-
-# Server
 PORT=8080
-AUTH_SECRET=change-me-in-production
-# Required for POST /v1/auth/admin (token rotation by an existing Bearer holder).
-# Compared against X-Admin-Secret header via timing-safe sha256-digest compare.
-# ADMIN_SECRET=change-me-in-production
+SESSION_IDLE_MS=600000          # evict idle sessions after 10 min
+MAX_CONCURRENT_PYTHON=5         # cap CPython WASM workers (~80 MB each)
+MAX_CONCURRENT_JS=5             # cap QuickJS workers (~64 MB each)
 
-# Session
-SESSION_IDLE_MS=600000
+# ── Optional: Redis (required for multi-replica deployments) ──────────────────
 
-# Auth rate limits (issue #23). Per-replica in-memory limiter; multi-replica
-# leakage is acknowledged. /v1/auth/admin is keyed by IP and Bearer sub
-# (tripping either returns 429); /v1/auth/bootstrap is keyed by IP only.
-ADMIN_RATE_LIMIT_WINDOW_MS=60000
-ADMIN_RATE_LIMIT_MAX=5
-BOOTSTRAP_RATE_LIMIT_WINDOW_MS=60000
-BOOTSTRAP_RATE_LIMIT_MAX=5
-# Trust X-Forwarded-For / X-Real-IP for rate-limit keying. Default `false` —
-# only enable when running behind an ingress that STRIPS inbound forwarding
-# headers (otherwise an attacker can spoof these to bypass per-IP buckets,
-# especially on the unauthenticated /v1/auth/bootstrap endpoint).
-# TRUST_PROXY_HEADERS=true
+# REDIS_URL=redis://localhost:6379
+# REDIS_EXEC_LOCK_LEASE_MS=60000       # distributed exec lock TTL
+# REDIS_EXEC_LOCK_RENEW_MS=20000       # heartbeat interval (must be < lease)
+# REDIS_EXEC_LOCK_ACQUIRE_TIMEOUT_MS=300000
+# REDIS_BLOB_CACHE_ENABLED=true        # cache blob bytes in Redis
+# REDIS_BLOB_CACHE_TTL_MS=86400000     # blob cache TTL (24h)
+# REDIS_BLOB_MAX_BYTES=8388608         # skip Redis for blobs > 8 MB
+# REDIS_PATH_SNAPSHOT_ENABLED=false    # snapshot pathCache for faster cold starts
+# REDIS_PATH_SNAPSHOT_TTL_MS=3600000   # snapshot TTL (1h)
+
+# ── Optional: security ────────────────────────────────────────────────────────
+
+# JUST_BASH_DEFENSE_IN_DEPTH=false     # monkey-patch host globals during exec
+# JUST_BASH_DEFENSE_AUDIT_MODE=true    # log violations instead of throwing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.20] - 2026-05-09
+
+### Fixed
+
+- `SessionManager.getOrCreate()` refuses new sessions once `shutdown()` has begun (checked at entry and again after `buildFs()` returns) so a request accepted before shutdown cannot register a session after the shutdown snapshot, leaking its dialect pool.
+- Reaper now marks `state="closing"` before deleting and drains via `mutex.runExclusive` before disconnecting, so a request that already captured the session reference but has not yet entered the mutex observes `ESESSIONCLOSING` instead of running against a disconnected filesystem.
+- Raw `PUT /v1/sandboxes/:id/files/*` pre-checks `Content-Length` and rejects oversized uploads (`PAYLOAD_TOO_LARGE`) before buffering the request body.
+- Distributed lock heartbeat stops scheduling further `EVAL` renewals once the lock is lost or a renew times out, preventing command pile-up in the ioredis send queue when Redis is hung.
+- `RedisBlobCache.mget()` chunks calls at 1024 keys per round-trip to bound peak reply size on warm sandboxes with large blob counts.
+
 ## [0.2.19] - 2026-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.19] - 2026-05-09
+
+### Fixed
+
+- Wired production lifecycle: `SessionManager.startReaper()` and `startMcpSessionSweeper()` called at boot; `SIGTERM`/`SIGINT` now runs a full ordered shutdown — MCP transports → session drain + FS disconnect → meta dialects → Redis `quit()`.
+- Postgres pool caps on `PostgresDialect.connect()` (`max: 2`, `idle_timeout: 30s`, `connect_timeout: 30s`, `max_lifetime: 30m`) to prevent connection exhaustion under load.
+- `createPostgresSandboxFs()` now disconnects the dialect on any post-`connect()` failure (sandbox bootstrap, `fs.ready()`, etc.) so pools cannot leak on setup errors.
+- `SessionManager.getOrCreate()` disconnects the created FS if session construction throws after `buildFs()` returns.
+- `SessionManager.destroy()` disconnects the FS in a `finally` block so the pool is always released even when `destroySandboxFn` or Redis cleanup throws.
+- `publishVersionIfDirty()`: Redis `INCR` failure now surfaces as `ECOHERENCE` (HTTP 503), sets `publishPending` for retry on the next turn, and forces a reload via `lastSeenVersion = -1`. Previously the failure was silently swallowed.
+- Distributed lock heartbeat replaced `setInterval(async)` with a sequential `setTimeout` chain to prevent overlapping Redis `EVAL` commands under slow Redis; renewal command is now bounded by `Promise.race`.
+- Runtime semaphore waiters are now abort-aware: cancelled via `AbortSignal`, evicted on per-waiter timeout, and bounded by `MAX_PYTHON_QUEUE`/`MAX_JS_QUEUE`. Backpressure surfaces as `ERUNTIME_BUSY` (HTTP 503).
+- Added `SessionManager.shutdown()` for graceful drain and FS disconnect of all live sessions.
+- Added MCP session TTL (`MCP_SESSION_IDLE_MS`), cap (`MCP_SESSION_MAX`), idle sweeper, and `shutdownMcp()` to bound transport memory growth.
+- Added `closeRedisClient()` with `quit()` + `disconnect()` fallback for clean Redis teardown on shutdown.
+- Capped raw `PUT /files/*` body size and bulk `writeFiles` file count + total bytes to prevent OOM from unbounded upload buffering.
+- Mapped `ECOHERENCE` and `ERUNTIME_BUSY` error codes to HTTP 503.
+
 ## [0.2.18] - 2026-05-09
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to virtualFS
+
+Thank you for your interest. This guide covers everything you need to go from zero to a merged PR.
+
+## Prerequisites
+
+- **Node.js ≥ 22** and **pnpm**
+- **Postgres** — only required for integration tests; unit tests run without a database
+- **Redis** — optional; only needed for distributed lock / snapshot cache integration tests
+
+## Setup
+
+```bash
+git clone https://github.com/your-org/virtualfs-api.git
+cd virtualfs-api
+pnpm install
+cp .env.example .env        # fill in DATABASE_URL and AUTH_SECRET at minimum
+pnpm dev                    # dev server at http://localhost:8080
+```
+
+## Development workflow
+
+```bash
+pnpm dev                    # hot-reload dev server
+pnpm typecheck              # type check (must pass before PR)
+pnpm lint:fix               # format + lint (Biome)
+pnpm test:unit              # unit tests — no DB required
+pnpm test:integration       # integration tests — requires DATABASE_URL
+pnpm test                   # all tests
+```
+
+Always run `pnpm typecheck && pnpm lint:fix && pnpm test:unit` before pushing.
+
+## Architecture
+
+Read [DEVELOPER.md](DEVELOPER.md) before touching `session-manager.ts`, `sql-fs.ts`, or any dialect code. It covers the three-lock model, cache layers, and cross-replica coherence in detail.
+
+## Coding standards
+
+Full standards are in [CLAUDE.md](CLAUDE.md). Key points:
+
+- No `any` — use `unknown` and narrow
+- All errors are `Error` instances with a `code` property; SQL errors go through `translateSqlError()`
+- Every `IFileSystem` method is async; SQL ops run inside explicit transactions
+- Sandbox isolation is non-negotiable — every query must be scoped to `sandbox_id`
+- Use null prototypes for `Record<string, T>` objects with user-controlled keys
+
+## Submitting a PR
+
+1. Fork the repo and branch from `main`
+2. Make your changes
+3. Run the quality gate: `pnpm typecheck && pnpm lint:fix && pnpm test:unit`
+4. Create a changeset (see below)
+5. Commit both your code and the generated changeset file
+6. Open a PR — describe what changed and why
+
+## Versioning with Changesets
+
+This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and the changelog. Every PR that changes behaviour (feature, fix, or breaking change) must include a changeset.
+
+### Creating a changeset
+
+```bash
+pnpm changeset
+```
+
+The CLI will ask you to:
+
+1. Select a bump type:
+   - `patch` — bug fixes, docs, chores, refactors
+   - `minor` — new features (backwards-compatible)
+   - `major` — breaking API or schema changes
+2. Write a one-line summary of what changed (this becomes the changelog entry)
+
+Commit the generated `.changeset/*.md` file alongside your code.
+
+### Maintainer release flow
+
+When cutting a release, a maintainer runs:
+
+```bash
+pnpm changeset:version
+```
+
+This does three things atomically:
+1. Merges all pending changesets into `CHANGELOG.md` and bumps `package.json`
+2. Syncs the version into `src/api/openapi-spec.ts` (via `scripts/sync-openapi-version.mjs`)
+3. Updates `pnpm-lock.yaml`
+
+Commit the result and push — the CI pipeline cuts a GitHub Release from the new `CHANGELOG.md` entry.
+
+## Reporting issues
+
+Open a GitHub issue with:
+- The virtualFS version (`pnpm list virtualfs-api` or the `/readyz` response)
+- Steps to reproduce
+- Expected vs actual behaviour
+- Relevant logs (redact connection strings)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.2.13-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.2.17-blue" alt="Version" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?logo=node.js&logoColor=white" alt="Node.js" />
   <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/MCP-2025--03--26-8b5cf6" alt="MCP" />
@@ -14,67 +14,35 @@
 
 ---
 
-Most sandbox runtimes lose state when the process dies. virtualFS gives [just-bash](https://github.com/nicholasgasior/just-bash) sandboxes durable, SQL-backed filesystems — so an AI agent can create an environment, run commands, come back hours later, and pick up exactly where it left off.
+Most sandbox runtimes lose state when the process dies. virtualFS gives [just-bash](https://github.com/nicholasgasior/just-bash) sandboxes a durable, Postgres-backed filesystem — so an AI agent can create an environment, run commands, come back hours later, and pick up exactly where it left off.
 
-### Why it exists
+## Why
 
 | Problem | Solution |
 |---|---|
-| In-memory FS lost on process death | SqlFs persists every write to SQL — restarts are transparent |
-| Single-process, no remote access | HTTP REST API + MCP server expose bash over the network |
-| No isolation between agents | RLS (Postgres) or directory isolation per sandbox |
-| Re-reading the same files is slow | Two-layer cache: pathCache (Map) + contentCache (LRU) for filepath and filecontent |
-| Horizontal scaling breaks session state | Stateless containers + shared DB; sticky sessions keep warm Bash instances |
-| Duplicate file content wastes storage | Content-addressable blob store (sha256-keyed) — identical files share one blob |
-| Concurrent bash calls racing on the same sandbox | Advisory locks (Postgres `pg_try_advisory_xact_lock`) serialize writes per sandbox; `INSERT … ON CONFLICT` eliminates TOCTOU on blobs |
-| Distributed locking across replicas | Postgres advisory locks are cluster-wide — any replica acquiring the same lock key is blocked until the holder commits |
-| Stale cache after cross-replica writes | pathCache and contentCache are per-process and invalidated on every local write; remote writes invalidate via DB as source of truth on next session load |
-
-### Architecture
-
-```
-Agent / Developer
-       |
-   HTTP / MCP
-       |
-+------v--------+        +--------------------+
-| virtualFS API |------->|  Storage Backend   |
-| (Hono + MCP)  |        |                    |
-|               |        |  Postgres / Neon   |
-| Session Mgr   |        |  InMemory (dev)    |
-|   Bash inst.  |        +--------------------+
-|     SqlFs     |
-+---------------+
-```
-
-**Core pipeline:**
-```
-HTTP Request → Auth → Route Handler → Session Manager → Bash.exec(script)
-                                             ↓
-                                        IFileSystem
-                                             ↓
-                                    SqlFs (pathCache + contentCache)
-                                             ↓
-                                        SqlDialect
-                                             ↓
-                                         Postgres
-```
+| In-memory FS lost on process death | Every write goes to Postgres — container restarts are transparent |
+| No remote access | HTTP REST API + MCP server expose bash over the network |
+| No isolation between agents | Row-level security (RLS) on `sandbox_id` — sandboxes are hard-isolated at the DB layer |
+| Reading the same files on every exec is slow | Two-layer in-process cache: path map (0ms stat/readdir) + LRU content cache (0ms readFile on hit) |
+| Horizontal scaling breaks warm session state | Stateless replicas + Redis distributed lock — only one replica runs exec for a sandbox at a time |
+| Duplicate file content wastes storage | Content-addressable blob store (sha256-keyed) — identical files across all sandboxes share one row |
+| Partial writes on script failure | Entire script runs in one DB transaction — it either fully commits or fully rolls back |
 
 ## Quick Start
 
-### Local (in-memory, no DB)
+### In-memory (no DB required)
 
 ```bash
 pnpm install
 FS_BACKEND=memory AUTH_SECRET=localdev pnpm dev
 ```
 
-### Local with Postgres
+### With Postgres
 
 ```bash
 cp .env.example .env          # set DATABASE_URL and AUTH_SECRET
-pnpm db:migrate               # run migrations
-pnpm dev
+pnpm db:migrate               # apply migrations
+pnpm dev                      # server at http://localhost:8080
 ```
 
 ### Docker Compose
@@ -83,38 +51,7 @@ pnpm dev
 docker-compose -f docker-compose.local.yml up
 ```
 
-### Auth
-
-Pass `auth_secret` to the SDK — it bootstraps a JWT automatically on first use:
-
-```python
-from virtualfs import Client
-
-client = Client(
-    base_url="http://localhost:8080",
-    auth_secret="localdev",   # exchanges for a JWT behind the scenes
-    sub="agent-001",
-)
-```
-
-## Important: Always use `exec` / `exec_batch` for file operations
-
-**Do not mix the file HTTP API (`/files/*`, `/writeFiles`, `/tree`) with concurrent `exec` calls.** The file API routes bypass the session lock hierarchy — they do not acquire the per-sandbox advisory lock or the Redis exec lock that `exec` goes through. Using them alongside exec creates races that break the guarantees below.
-
-All of these are only guaranteed when all file access flows through `exec` or `exec_batch`:
-
-| Guarantee | Mechanism |
-|---|---|
-| No two execs interleave on the same sandbox (single replica) | In-process session lock |
-| No two execs interleave across replicas | Redis distributed exec lock |
-| Cache always reflects the latest committed write at exec entry | Version counter checked on every lock acquisition |
-| DB-level data integrity under any concurrent write | `pg_advisory_xact_lock` per sandbox per transaction |
-
-The file HTTP API is intentionally kept for admin and test use only. For anything in production or agent code, run all reads and writes as bash commands inside `exec`.
-
 ## Typical Agent Workflow
-
-Install the Python SDK:
 
 ```bash
 pip install virtualfs-sdk
@@ -126,7 +63,7 @@ import pathlib
 
 client = Client(
     base_url="http://localhost:8080",
-    auth_secret="localdev",
+    auth_secret="localdev",   # exchanges for a JWT automatically
     sub="agent-001",
 )
 
@@ -134,120 +71,151 @@ client = Client(
 sb = client.sandboxes.create(name="my-project")
 
 # 2. Ingest project files
-files = {
-    str(p): p.read_bytes()
-    for p in pathlib.Path("src").rglob("*")
-    if p.is_file()
-}
+files = {str(p): p.read_bytes() for p in pathlib.Path("src").rglob("*") if p.is_file()}
 sb.ingest_files(files, base_path="/home/user/src")
 
-# 3. Run commands
+# 3. Run commands — stdout/stderr stream back
 result = sb.exec("cd /home/user/src && npm install && npm test")
 print(result.stdout)
 
-# 4. Read an output file
-report = sb.fs.read_text("/home/user/src/test-results.json")
+# 4. Export modified sandbox
+pathlib.Path("result.tar.gz").write_bytes(sb.export(base_path="/home/user/src"))
 
-# 5. Export modified sandbox
-tarball = sb.export(base_path="/home/user/src")
-pathlib.Path("result.tar.gz").write_bytes(tarball)
-
-# 6. Cleanup
+# 5. Cleanup
 sb.delete()
 ```
 
 ## MCP Server
 
-Mounted at `/mcp`. Streamable HTTP transport per MCP 2025-03-26 spec. Exposes 7 tools:
+Mounted at `/mcp`. Streamable HTTP transport per MCP 2025-03-26 spec. Tool names are kept short to minimize agent context window usage.
 
 | Tool | Description |
 |------|-------------|
 | `sandbox_create` | Create an isolated bash sandbox; optional `python` / `javascript` runtime flags |
 | `sandbox_list` | List all sandboxes owned by the current user |
 | `sandbox_delete` | Delete a sandbox and all its files |
-| `bash_exec` | Execute a bash script in a sandbox, return buffered output |
-| `bash_exec_batch` | Execute multiple scripts sequentially in one request — collapses N round-trips into 1 |
-| `fs_ingest` | Bulk-upload files into a sandbox (single DB insert) |
+| `bash_exec` | Execute a bash script, return buffered output |
+| `bash_exec_batch` | Execute multiple scripts sequentially — collapses N round-trips into 1 |
+| `fs_ingest` | Bulk-upload files into a sandbox |
 | `fs_export` | Download sandbox files as a JSON map |
 
-## Storage Backends
+## How It Works
 
-| Backend | Driver | RLS | Notes |
-|---------|--------|-----|-------|
-| `postgres` | `postgres` (porsager) | Built-in RLS policy | Works with Neon serverless pooler |
-| `memory` | — | None | Dev/test only; no persistence |
+### Key invariant
+
+> **Postgres is always the source of truth. Everything else is a cache or a lock.**
+
+In-process caches exist purely for speed during a single exec. Redis serializes requests across replicas and speeds up cold starts. If you dropped Redis and all caches, the system would still be correct — just slower.
+
+### Request flow
+
+```
+POST /exec
+     │
+     ▼
+Auth middleware
+     │
+     ▼
+SessionManager.withSession(sandboxId, fn)
+     │
+     ├─[1] Acquire Redis exec lock       cross-replica mutex (SET NX PX + heartbeat)
+     ├─[2] Version check                 if counter changed → reload pathCache from Postgres
+     ├─[3] Acquire session.mutex         in-process mutex (same replica, same sandbox)
+     ├─[4] bash.exec(script)             the actual work
+     │       each write → Postgres tx (RLS scoping + pg_advisory_xact_lock)
+     │       → update in-process caches → set dirty = true
+     ├─[5] Release session.mutex
+     ├─[6] If dirty → INCR version counter → write path snapshot to Redis
+     └─[7] Release Redis exec lock
+```
+
+### Three lock layers
+
+Three locks stack on top of each other. Each is the fallback for the one above it.
+
+| Lock | Type | Scope | Purpose |
+|---|---|---|---|
+| `session.mutex` | async-mutex in Node heap | one replica, one sandbox | Prevents two concurrent requests on the same replica from interleaving inside `Bash` or `SqlFs`. Zero network cost. |
+| Redis exec lock | `SET NX PX` + heartbeat + Lua release | entire fleet | Only one replica runs exec for a given sandbox at a time. If Redis is down → fail closed (503). |
+| `pg_advisory_xact_lock` | Postgres transaction-scoped advisory lock | database | Last line of defense — serializes at DB level when the Redis lock fails (GC pause beyond lease, code paths that bypass `withSession`). Auto-released on commit/rollback; compatible with Neon transaction-mode pooling. |
+
+### Cache layers
+
+| Layer | What | Keyed by | Populated | Invalidated |
+|---|---|---|---|---|
+| L1 `pathCache` | `Map<path, entry>` — serves stat/readdir/getAllPaths at 0ms | absolute path | `loadAllPaths` recursive CTE at session start; updated on every write | On `reload()` (cross-replica version mismatch) |
+| L1 `contentCache` | LRU (50 MB cap) — serves readFile at 0ms on hit | inode ID | Lazy on first `readFile`; bulk-prewarmed after session start | On write/delete to that inode |
+| L2 blob cache | Redis bytes — avoids Postgres round-trips for reads | `sha256hex` | Fire-and-forget on every blob write | Never (content is immutable under its sha256) |
+| L2b path snapshot | Redis msgpack — speeds up cold starts | `sandboxId` | After every exec that dirtied the FS | On sandbox delete; version mismatch causes automatic fallthrough to Postgres |
+
+### Cross-replica coherence
+
+No pub/sub. A single monotonic version counter in Redis is sufficient because exec serialization (Lock 2) means only one replica ever writes a sandbox at a time.
+
+```
+Replica 1:  [acquire lock] → [exec] → [INCR ver] → [release lock]
+Replica 2:                    [blocked on Redis lock]
+                                                    [acquire lock] → [ver mismatch → reload from Postgres] → [exec]
+```
+
+### What is NOT guaranteed
+
+**Multi-step client atomicity.** The lock is held per `exec` call, not across multiple calls. Bundle read-compute-write into one script:
+
+```bash
+# BAD — another agent can slip in between the two exec calls
+balance=$(cat balance.txt)          # exec 1
+echo $((balance - 50)) > balance.txt  # exec 2
+
+# GOOD — the lock is held for the entire script
+balance=$(cat balance.txt)
+echo $((balance - 50)) > balance.txt
+```
+
+**File API + exec mixing.** The `/files/*` HTTP endpoints bypass the exec lock hierarchy. Use `exec` for all production and agent file access; the file API is for admin and test use only.
+
+## Schema
+
+```
+sandboxes   id (UUID PK), root_inode, owner, created_at
+    │
+inodes      id (BIGSERIAL PK), sandbox_id, kind (file|dir|symlink),
+            mode, size, mtime, nlink, content_sha256 → blobs, symlink_target
+    │
+dirents     parent_inode_id, name, inode_id, sandbox_id
+            PK: (parent_inode_id, name)   ← adjacency list; mv is O(1)
+    │
+blobs       sha256 (PK), data, size       ← content-addressable; global dedup
+```
+
+Key design choices:
+- **Adjacency list** — `mv` of an entire directory subtree is one `UPDATE` row, not O(n)
+- **Content-addressable blobs** — identical files across all sandboxes share one blob row
+- **RLS on `sandbox_id`** — isolation enforced at the database layer, not just the application
 
 ## Environment Variables
 
 | Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
+|---|---|---|---|
 | `FS_BACKEND` | Yes | — | `postgres` \| `memory` |
-| `DATABASE_URL` | Yes (postgres) | — | Connection string (use pooler endpoint for Neon) |
-| `DATABASE_DIRECT_URL` | Yes (postgres) | — | Direct connection for DDL/migrations |
+| `DATABASE_URL` | Yes (postgres) | — | Postgres connection string (use pooler endpoint for Neon) |
+| `DATABASE_DIRECT_URL` | Yes (postgres) | — | Direct connection for DDL / migrations |
 | `AUTH_SECRET` | Yes | — | Secret for Bearer token validation |
 | `PORT` | No | `8080` | HTTP server port |
-| `SESSION_IDLE_MS` | No | `600000` | Idle timeout before Bash instance eviction |
-| `MAX_CONCURRENT_PYTHON` | No | `5` | Cap on concurrent CPython WASM workers (~80MB each) |
-| `MAX_CONCURRENT_JS` | No | `5` | Cap on concurrent QuickJS workers (~64MB each) |
-
-## Development
-
-```bash
-pnpm dev                    # Dev server with hot reload
-pnpm typecheck              # Type check (tsc --noEmit)
-pnpm lint:fix               # Fix lint errors (Biome)
-pnpm test                   # All tests
-pnpm test:unit              # Unit tests only (no DB)
-pnpm test:integration       # Integration tests (requires DATABASE_URL)
-pnpm db:generate            # Generate Drizzle migrations
-pnpm db:migrate             # Apply migrations
-pnpm db:gc                  # Garbage-collect orphan blobs
-```
-
-## Benchmarking
-
-`scripts/benchmark_remote_bash.py` measures end-to-end latency through the API against either virtualFS or [Daytona](https://daytona.io) for direct comparison.
-
-**What it measures:**
-- **Phase 1 — Sandbox lifecycle:** `create` / `ingest` / `delete` over N fresh sandboxes
-- **Phase 2 — Exec latency:** `find`, `grep`, `rg`, `write`, `delete`, `mkdir`, `mv` on a warm sandbox. Wall-clock ms always reported; `duration_ms` from the server reported for virtualFS
-
-It ingests your local `./src` directory as the test corpus so commands run against realistic files. Output is rendered as markdown tables.
-
-### Prerequisites
-
-```bash
-# No install needed for virtualFS — Python SDK loads directly from clients/python
-# Only needed if benchmarking against Daytona:
-pip install daytona-sdk
-```
-
-### Run
-
-```bash
-# Against local dev server
-API_URL=http://localhost:8081 AUTH_SECRET=localdev pnpm bench:remote-bash
-
-# Against remote deployment
-API_URL=https://your-api.example.com AUTH_SECRET=$AUTH_SECRET pnpm bench:remote-bash
-
-# Against Daytona
-DAYTONA_API_KEY=dtn_... DAYTONA_API_URL=https://app.daytona.io/api \
-  python3 scripts/benchmark_remote_bash.py --provider daytona
-```
-
-### Flags
-
-```
---provider {virtualfs,daytona}   default: virtualfs
---src-dir PATH                   corpus to ingest (default: ./src)
---lifecycle-runs N               full create/ingest/delete cycles (default: 3)
---warmup N                       discarded warmup runs per exec case (default: 1)
---runs N                         measured runs per exec case (default: 5)
---timeout-ms MS                  per-exec timeout (default: 60000)
-```
-
-For higher confidence: `--lifecycle-runs 5 --warmup 5 --runs 25`. On a high-RTT deployment that's ~10–15 min; on localhost under a minute. Leftover `bench-*` sandboxes are auto-cleaned at the end.
+| `SESSION_IDLE_MS` | No | `600000` | Evict idle Bash instances after this many ms |
+| `MAX_CONCURRENT_PYTHON` | No | `5` | Cap on concurrent CPython WASM workers (~80 MB each) |
+| `MAX_CONCURRENT_JS` | No | `5` | Cap on concurrent QuickJS workers (~64 MB each) |
+| `REDIS_URL` | No | — | Redis connection string. Required for multi-replica deployments. Without it, only the in-process mutex protects execution. |
+| `REDIS_EXEC_LOCK_LEASE_MS` | No | `60000` | Distributed exec lock TTL. Must be > `REDIS_EXEC_LOCK_RENEW_MS`. |
+| `REDIS_EXEC_LOCK_RENEW_MS` | No | `20000` | Lock heartbeat interval. Must be strictly less than lease. |
+| `REDIS_EXEC_LOCK_ACQUIRE_TIMEOUT_MS` | No | `300000` | Max wait to acquire exec lock before returning 503. |
+| `REDIS_BLOB_CACHE_ENABLED` | No | `true` | Set `false` to disable Redis blob cache. |
+| `REDIS_BLOB_CACHE_TTL_MS` | No | `86400000` | Blob cache entry TTL (24h). |
+| `REDIS_BLOB_MAX_BYTES` | No | `8388608` | Blobs larger than this bypass Redis entirely (8 MB). |
+| `REDIS_PATH_SNAPSHOT_ENABLED` | No | `false` | Cache full path tree in Redis for faster cold starts. |
+| `REDIS_PATH_SNAPSHOT_TTL_MS` | No | `3600000` | Path snapshot TTL (1h). |
+| `JUST_BASH_DEFENSE_IN_DEPTH` | No | `false` | Monkey-patches host globals during exec for extra isolation. |
+| `JUST_BASH_DEFENSE_AUDIT_MODE` | No | `true` | When defense-in-depth is on: log violations instead of throwing. |
 
 ## Deployment
 
@@ -255,23 +223,48 @@ For higher confidence: `--lifecycle-runs 5 --warmup 5 --runs 25`. On a high-RTT 
 docker build -t virtualfs-api .
 docker run -p 8080:8080 \
   -e FS_BACKEND=postgres \
-  -e DATABASE_URL=... \
+  -e DATABASE_URL=postgres://... \
   -e AUTH_SECRET=... \
   virtualfs-api
 ```
 
-## Tech Stack
+For multi-replica deployments, add `REDIS_URL`. All replicas share the same Postgres database and Redis instance; the exec lock ensures only one replica processes a given sandbox at a time.
 
-| Layer | Technology |
-|-------|------------|
-| Bash interpreter | just-bash |
-| HTTP framework | Hono |
-| MCP SDK | @modelcontextprotocol/sdk |
-| Postgres | postgres (porsager) |
-| Schema / migrations | Drizzle ORM + drizzle-kit |
-| Content cache | lru-cache |
-| Validation | zod |
-| Runtime | Node.js ≥ 22, node:22-slim container |
+## Development
+
+```bash
+pnpm dev                    # hot-reload dev server
+pnpm typecheck              # type check (tsc --noEmit)
+pnpm lint:fix               # format + lint (Biome)
+pnpm test:unit              # unit tests — no DB required
+pnpm test:integration       # integration tests — requires DATABASE_URL
+pnpm test                   # all tests
+pnpm db:generate            # generate Drizzle migrations from schema changes
+pnpm db:migrate             # apply migrations
+pnpm db:gc                  # garbage-collect orphan blobs
+```
+
+## Benchmarking
+
+`scripts/benchmark_remote_bash.py` measures end-to-end latency through the API — sandbox lifecycle and exec operations — against either virtualFS or [Daytona](https://daytona.io).
+
+```bash
+# Against local dev server
+API_URL=http://localhost:8080 AUTH_SECRET=localdev pnpm bench:remote-bash
+
+# Against a remote deployment
+API_URL=https://your-api.example.com AUTH_SECRET=$AUTH_SECRET pnpm bench:remote-bash
+
+# Against Daytona (requires daytona-sdk: pip install daytona-sdk)
+DAYTONA_API_KEY=dtn_... DAYTONA_API_URL=https://app.daytona.io/api \
+  python3 scripts/benchmark_remote_bash.py --provider daytona
+```
+
+Key flags: `--lifecycle-runs N`, `--warmup N`, `--runs N`, `--timeout-ms MS`. Leftover `bench-*` sandboxes are auto-cleaned at the end.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding standards, and the changeset-based versioning workflow.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.18",
+	"version": "0.2.19",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.19",
+	"version": "0.2.20",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/stress-test.ts
+++ b/scripts/stress-test.ts
@@ -1,0 +1,656 @@
+/**
+ * Production-stability stress harness.
+ *
+ * Exercises the four scenarios from
+ * tasks/production-stability-resource-lifecycle-plan.md against real
+ * Postgres + Redis endpoints (env: STRESS_PG_URL, STRESS_REDIS_URL).
+ *
+ * Each scenario reports before/after metrics (RSS, active timers, PG
+ * pg_stat_activity backend count, in-process session count) and writes a
+ * combined report to tasks/stress-test-results.md.
+ *
+ * Run:
+ *   STRESS_PG_URL=... STRESS_REDIS_URL=... pnpm tsx scripts/stress-test.ts
+ */
+
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { Redis } from "ioredis";
+import postgres from "postgres";
+import { PostgresDialect } from "../src/fs/sql-fs/dialects/postgres.js";
+import { createPostgresSandboxFs, destroyPostgresSandbox } from "../src/fs/sql-fs/index.js";
+import { runMigrations } from "../src/api/migrations.js";
+import { RuntimeBackpressureError, SessionManager } from "../src/api/session-manager.js";
+
+const PG_URL = process.env.STRESS_PG_URL;
+const REDIS_URL = process.env.STRESS_REDIS_URL;
+if (!PG_URL || !REDIS_URL) {
+	console.error("STRESS_PG_URL and STRESS_REDIS_URL env vars are required");
+	process.exit(1);
+}
+
+// Force tight pool — we want many concurrent dialects without saturating PSDB.
+process.env.PG_POOL_MAX = process.env.PG_POOL_MAX ?? "1";
+process.env.PG_POOL_IDLE_TIMEOUT_S = process.env.PG_POOL_IDLE_TIMEOUT_S ?? "10";
+
+interface Snapshot {
+	rssMB: number;
+	activeHandles: number;
+	activeRequests: number;
+	/** Total rows in pg_stat_activity. When traffic flows through pgbouncer this includes
+	 * pgbouncer's idle upstream pool, which stays warm after clients disconnect — so this
+	 * number does NOT return to the pre-run baseline. Use `pgActive` for the leak signal. */
+	pgBackends: number | null;
+	/** Connections with state='active' (currently executing a query). Drops to 0 when no
+	 * client is running anything, even with pgbouncer idle pool warm. The real leak signal. */
+	pgActive: number | null;
+	sessions: number;
+}
+
+interface ScenarioResult {
+	name: string;
+	durationMs: number;
+	before: Snapshot;
+	after: Snapshot;
+	notes: string[];
+	errors: string[];
+	pass: boolean;
+}
+
+const allResults: ScenarioResult[] = [];
+
+function uid(prefix: string): string {
+	return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function pgBackendCount(): Promise<{ total: number | null; active: number | null }> {
+	const sql = postgres(PG_URL!, { prepare: false, max: 1, idle_timeout: 5 });
+	try {
+		const rows = await sql<{ total: string; active: string }[]>`
+			SELECT
+				count(*)::text AS total,
+				count(*) FILTER (WHERE state = 'active')::text AS active
+			FROM pg_stat_activity
+			WHERE state IS NOT NULL
+		`;
+		const r = rows[0];
+		return { total: Number(r?.total ?? 0), active: Number(r?.active ?? 0) };
+	} catch {
+		return { total: null, active: null };
+	} finally {
+		await sql.end({ timeout: 2 }).catch(() => {});
+	}
+}
+
+function isPooledEndpoint(): boolean {
+	// Heuristic: pgbouncer / supavisor / Neon-pooler / PSDB-pooler typically
+	// listen on a non-default port (6432 most commonly) or on a `-pooler.`
+	// hostname. Inside a pooler, pg_stat_activity reflects upstream pool state,
+	// not client state — so totalBackends is not a leak signal.
+	if (!PG_URL) return false;
+	try {
+		const u = new URL(PG_URL);
+		if (u.port && u.port !== "5432") return true;
+		if (u.hostname.includes("-pooler")) return true;
+	} catch {
+		// fallthrough
+	}
+	return false;
+}
+
+async function snapshot(sm?: SessionManager): Promise<Snapshot> {
+	const handles = (process as { _getActiveHandles?: () => unknown[] })._getActiveHandles?.() ?? [];
+	const reqs = (process as { _getActiveRequests?: () => unknown[] })._getActiveRequests?.() ?? [];
+	const counts = await pgBackendCount();
+	return {
+		rssMB: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+		activeHandles: handles.length,
+		activeRequests: reqs.length,
+		pgBackends: counts.total,
+		pgActive: counts.active,
+		sessions: sm ? (sm as unknown as { sessions: Map<string, unknown> }).sessions.size : 0,
+	};
+}
+
+function log(...args: unknown[]): void {
+	console.log("[stress]", ...args);
+}
+
+function makeSm(opts: ConstructorParameters<typeof SessionManager>[0] = {}): SessionManager {
+	return new SessionManager({
+		createFs: async (_t, sandboxId) => {
+			const { fs } = await createPostgresSandboxFs(
+				{ connectionString: PG_URL!, tenantId: "stress" },
+				sandboxId,
+			);
+			return fs;
+		},
+		destroySandboxFn: async (_t, sandboxId) => destroyPostgresSandbox(PG_URL!, sandboxId),
+		idleMs: 30_000,
+		...opts,
+	});
+}
+
+// ── Scenario 1: pool leak under destroy failures ──────────────────────────────
+
+async function scenarioDestroyFailures(): Promise<ScenarioResult> {
+	const name = "Pool leak under destroy failures";
+	log(`▶ ${name}`);
+	const errors: string[] = [];
+	const notes: string[] = [];
+	const N = Number(process.env.STRESS_N_DESTROY ?? "30");
+	const before = await snapshot();
+	const t0 = Date.now();
+
+	let destroyCalls = 0;
+	const sm = new SessionManager({
+		createFs: async (_t, sandboxId) => {
+			const { fs } = await createPostgresSandboxFs(
+				{ connectionString: PG_URL!, tenantId: "stress" },
+				sandboxId,
+			);
+			return fs;
+		},
+		// Inject failure on every other destroy. The plan-mandated `finally`
+		// must still disconnect the FS so PG connections don't accumulate.
+		destroySandboxFn: async (_t, sandboxId) => {
+			destroyCalls++;
+			if (destroyCalls % 2 === 0) {
+				// Still actually delete on the DB side so the test cleans up,
+				// but throw afterwards to simulate a failing teardown.
+				await destroyPostgresSandbox(PG_URL!, sandboxId);
+				throw new Error("simulated destroy failure");
+			}
+			await destroyPostgresSandbox(PG_URL!, sandboxId);
+		},
+		idleMs: 60_000,
+	});
+
+	const ids: string[] = Array.from({ length: N }, () => uid("dfail"));
+	try {
+		// Warm them all
+		await Promise.all(ids.map((id) => sm.getOrCreate("stress", id)));
+		notes.push(`warmed ${N} sandboxes`);
+		const peak = await snapshot(sm);
+		notes.push(`peak pg_backends=${peak.pgBackends} rssMB=${peak.rssMB}`);
+
+		// Destroy them all; half will throw.
+		const results = await Promise.allSettled(ids.map((id) => sm.destroy("stress", id)));
+		const rejected = results.filter((r) => r.status === "rejected").length;
+		notes.push(`destroy rejected=${rejected} (expected ~${N / 2})`);
+		// Lower bound only — under PSDB cap pressure many destroys legitimately
+		// reject with "too many clients", so the relevant signal is "did
+		// post-shutdown drain to baseline" (asserted further down).
+		if (rejected === 0 && N >= 2) errors.push(`expected at least some destroy failures, got 0`);
+
+		// All sessions must be gone regardless of destroy errors.
+		const sCount = (sm as unknown as { sessions: Map<string, unknown> }).sessions.size;
+		if (sCount !== 0) errors.push(`sessions map not empty after destroy: ${sCount}`);
+	} finally {
+		await sm.shutdown({ drainTimeoutMs: 10_000 });
+	}
+
+	// Allow PG to drain idle connections
+	await new Promise((r) => setTimeout(r, 4_000));
+	const after = await snapshot();
+	notes.push(
+		`post-shutdown pgBackends=${after.pgBackends} pgActive=${after.pgActive} (before backends=${before.pgBackends} active=${before.pgActive})`,
+	);
+	assertPgDrain(before, after, notes, errors);
+
+	return {
+		name,
+		durationMs: Date.now() - t0,
+		before,
+		after,
+		notes,
+		errors,
+		pass: errors.length === 0,
+	};
+}
+
+/**
+ * The leak signal differs depending on whether we're going through a pooler:
+ *  - direct PG: total backend count must drop back to baseline
+ *  - pooler:    `state='active'` must drop to baseline (pooler holds idle upstream conns warm)
+ */
+function assertPgDrain(before: Snapshot, after: Snapshot, notes: string[], errors: string[]): void {
+	if (isPooledEndpoint()) {
+		notes.push(`pooled endpoint detected — using pgActive as leak signal`);
+		if (before.pgActive !== null && after.pgActive !== null && after.pgActive > before.pgActive + 2) {
+			errors.push(`active queries did not drain: before=${before.pgActive} after=${after.pgActive}`);
+		}
+		return;
+	}
+	if (before.pgBackends !== null && after.pgBackends !== null && after.pgBackends > before.pgBackends + 5) {
+		errors.push(`PG backends did not drain: before=${before.pgBackends} after=${after.pgBackends}`);
+	}
+}
+
+// ── Scenario 2: many warmed sandboxes (pool pressure) ─────────────────────────
+
+async function scenarioPoolPressure(): Promise<ScenarioResult> {
+	const name = "Many warmed sandboxes (pool pressure)";
+	log(`▶ ${name}`);
+	const errors: string[] = [];
+	const notes: string[] = [];
+	const N = Number(process.env.STRESS_N_SANDBOXES ?? "60");
+	const OPS_PER = Number(process.env.STRESS_OPS_PER ?? "5");
+	// Wave-based execution caps simultaneous warm sessions to bound RSS.
+	// Each wave: warm WAVE sandboxes, run OPS_PER ops on each, destroy them all.
+	// Useful for N>>200 where 1000 simultaneous Bash instances would OOM.
+	const WAVE = Number(process.env.STRESS_WAVE ?? Math.min(N, 100));
+	const before = await snapshot();
+	const t0 = Date.now();
+
+	const sm = makeSm({ idleMs: 60_000 });
+	const ids = Array.from({ length: N }, () => uid("warm"));
+	let totalOps = 0;
+	let opErrors: string[] = [];
+	let peakSessions = 0;
+	let peakRss = 0;
+	let peakBackends = 0;
+
+	try {
+		for (let waveStart = 0; waveStart < ids.length; waveStart += WAVE) {
+			const wave = ids.slice(waveStart, waveStart + WAVE);
+			// Warm wave
+			await Promise.all(wave.map((id) => sm.getOrCreate("stress", id)));
+			const peak = await snapshot(sm);
+			peakSessions = Math.max(peakSessions, peak.sessions);
+			peakRss = Math.max(peakRss, peak.rssMB);
+			peakBackends = Math.max(peakBackends, peak.pgBackends ?? 0);
+
+			// Run OPS_PER ops per sandbox in parallel
+			const waveErrors: string[] = [];
+			await Promise.all(
+				wave.map(async (id) => {
+					const session = sm.getSession("stress", id);
+					if (!session) return;
+					for (let k = 0; k < OPS_PER; k++) {
+						try {
+							await session.fs.writeFile(`/tmp/${k}.txt`, `hello-${k}`);
+							const content = await session.fs.readFile(`/tmp/${k}.txt`);
+							if (content !== `hello-${k}`) waveErrors.push(`bad content ${id}:${k}`);
+						} catch (e) {
+							waveErrors.push(`op fail ${id}:${k} ${(e as Error).message}`);
+						}
+					}
+				}),
+			);
+			totalOps += wave.length * OPS_PER * 2; // each k = 1 write + 1 read
+			opErrors = opErrors.concat(waveErrors);
+
+			// Destroy wave to free memory before the next wave
+			await Promise.allSettled(wave.map((id) => sm.destroy("stress", id).catch(() => {})));
+			const waveIdx = Math.floor(waveStart / WAVE) + 1;
+			const totalWaves = Math.ceil(ids.length / WAVE);
+			log(
+				`    wave ${waveIdx}/${totalWaves} done (sessions=${peak.sessions} rssMB=${peak.rssMB} ops=${totalOps} errs=${opErrors.length})`,
+			);
+		}
+		notes.push(`peak across waves: sessions=${peakSessions} rssMB=${peakRss} pgBackends=${peakBackends}`);
+		notes.push(`fs ops total=${totalOps} failures=${opErrors.length}`);
+		if (opErrors.length > 0) errors.push(`${opErrors.length} fs op failures (e.g. ${opErrors[0]})`);
+	} finally {
+		await sm.shutdown({ drainTimeoutMs: 30_000 });
+	}
+
+	await new Promise((r) => setTimeout(r, 5_000));
+	const after = await snapshot();
+	notes.push(`post-shutdown pgBackends=${after.pgBackends} pgActive=${after.pgActive} rssMB=${after.rssMB}`);
+	assertPgDrain(before, after, notes, errors);
+
+	return {
+		name,
+		durationMs: Date.now() - t0,
+		before,
+		after,
+		notes,
+		errors,
+		pass: errors.length === 0,
+	};
+}
+
+// ── Scenario 3: Redis flakiness (INCR + lock) ─────────────────────────────────
+
+async function scenarioRedisFlakiness(): Promise<ScenarioResult> {
+	const name = "Redis flakiness (INCR + lock)";
+	log(`▶ ${name}`);
+	const errors: string[] = [];
+	const notes: string[] = [];
+	const before = await snapshot();
+	const t0 = Date.now();
+
+	const redis = new Redis(REDIS_URL!, {
+		lazyConnect: false,
+		maxRetriesPerRequest: 1,
+		enableReadyCheck: true,
+	});
+	await new Promise<void>((resolve, reject) => {
+		redis.once("ready", resolve);
+		redis.once("error", reject);
+		setTimeout(() => reject(new Error("redis connect timeout")), 10_000);
+	});
+
+	// Wrap incr with an injectable failure flag.
+	let injectIncrFail = false;
+	const realIncr = redis.incr.bind(redis);
+	(redis as unknown as { incr: (k: string) => Promise<number> }).incr = async (key: string) => {
+		if (injectIncrFail) throw new Error("injected ECONNRESET");
+		return realIncr(key);
+	};
+
+	const sm = new SessionManager({
+		createFs: async (_t, sandboxId) => {
+			const { fs } = await createPostgresSandboxFs(
+				{ connectionString: PG_URL!, tenantId: "stress", redis },
+				sandboxId,
+			);
+			return fs;
+		},
+		destroySandboxFn: async (_t, sandboxId) => destroyPostgresSandbox(PG_URL!, sandboxId),
+		idleMs: 60_000,
+		redis,
+		execLockOptions: { leaseMs: 5_000, renewMs: 1_500, acquireTimeoutMs: 10_000 },
+	});
+
+	const id = uid("flaky");
+	try {
+		// Warm.
+		await sm.withSession("stress", id, async (s) => {
+			await s.fs.writeFile("/initial.txt", "ok");
+		});
+		notes.push("initial mutation succeeded");
+
+		// Inject INCR failure on next mutation: write must commit but
+		// publishVersionIfDirty must throw ECOHERENCE.
+		injectIncrFail = true;
+		let coherenceSeen = false;
+		try {
+			await sm.withSession("stress", id, async (s) => {
+				await s.fs.writeFile("/post-fail.txt", "boom");
+			});
+		} catch (e) {
+			coherenceSeen = (e as { code?: string }).code === "ECOHERENCE";
+		}
+		if (!coherenceSeen) errors.push("expected ECOHERENCE on INCR failure but got none");
+		else notes.push("ECOHERENCE surfaced as expected");
+
+		const session = sm.getSession("stress", id);
+		if (!session || session.lastSeenVersion !== -1) {
+			errors.push(`session.lastSeenVersion expected -1 after publish failure; got ${session?.lastSeenVersion}`);
+		}
+		if (!session?.publishPending) {
+			errors.push("session.publishPending should be true after publish failure");
+		}
+
+		// Recovery: next turn (no failure) should bump the counter.
+		injectIncrFail = false;
+		await sm.withSession("stress", id, async () => {
+			/* dirty already pending */
+		});
+		const recovered = sm.getSession("stress", id);
+		if (recovered?.publishPending) errors.push("publishPending should clear after recovery");
+		if ((recovered?.lastSeenVersion ?? 0) <= 0) errors.push("lastSeenVersion should advance after recovery");
+		else notes.push(`recovered: lastSeenVersion=${recovered?.lastSeenVersion}`);
+
+		// Hammer with concurrent withSession to stress the lock heartbeat.
+		const HAMMER = 30;
+		const hammerStart = Date.now();
+		const hres = await Promise.allSettled(
+			Array.from({ length: HAMMER }, (_, i) =>
+				sm.withSession("stress", id, async (s) => {
+					await s.fs.writeFile(`/h-${i}.txt`, String(i));
+				}),
+			),
+		);
+		const hammerErrors = hres.filter((r) => r.status === "rejected").length;
+		notes.push(`hammered ${HAMMER} writes in ${Date.now() - hammerStart}ms; failures=${hammerErrors}`);
+	} finally {
+		try {
+			await sm.destroy("stress", id);
+		} catch {
+			// best-effort
+		}
+		await sm.shutdown({ drainTimeoutMs: 10_000 });
+		await redis.quit().catch(() => {});
+	}
+
+	await new Promise((r) => setTimeout(r, 2_000));
+	const after = await snapshot();
+	notes.push(`post pgBackends=${after.pgBackends} handles=${after.activeHandles}`);
+
+	return {
+		name,
+		durationMs: Date.now() - t0,
+		before,
+		after,
+		notes,
+		errors,
+		pass: errors.length === 0,
+	};
+}
+
+// ── Scenario 4: Semaphore + MCP bounds (in-process) ───────────────────────────
+
+async function scenarioInProc(): Promise<ScenarioResult> {
+	const name = "Semaphore + MCP bounds (in-process)";
+	log(`▶ ${name}`);
+	const errors: string[] = [];
+	const notes: string[] = [];
+	const before = await snapshot();
+	const t0 = Date.now();
+
+	// Semaphore: queue full
+	const sm = new SessionManager({
+		createFs: async () => ({}) as unknown as Awaited<ReturnType<typeof createPostgresSandboxFs>>["fs"],
+		destroySandboxFn: async () => {},
+		maxConcurrentPython: 1,
+	});
+	const internals = sm as unknown as {
+		pythonSem: { inFlight: number; maxWaiters: number; waiters: unknown[] };
+		acquireSlot(sem: unknown, signal?: AbortSignal): Promise<void>;
+		releaseSlot(sem: unknown): void;
+	};
+	const sem = internals.pythonSem;
+	sem.maxWaiters = 2;
+	await internals.acquireSlot(sem); // fill
+	const w1 = internals.acquireSlot(sem); // queue 1
+	const w2 = internals.acquireSlot(sem); // queue 2
+	let backpressure = false;
+	try {
+		await internals.acquireSlot(sem);
+	} catch (e) {
+		backpressure = e instanceof RuntimeBackpressureError;
+	}
+	if (!backpressure) errors.push("expected RuntimeBackpressureError when queue saturated");
+	else notes.push("queue-full backpressure works");
+
+	// Abort one waiter
+	const ac = new AbortController();
+	const w3p = internals.acquireSlot(sem, ac.signal);
+	// Drop one of the existing in-queue items first so we have room to add w3
+	// The acquireSlot above for w3 should reject because queue still full (maxWaiters=2)
+	// Instead test with a sem that has capacity
+	let w3Rejected = false;
+	try {
+		await w3p;
+	} catch (e) {
+		w3Rejected = (e as { name?: string }).name === "AbortError" || e instanceof RuntimeBackpressureError;
+	}
+	notes.push(`w3 rejected=${w3Rejected}`);
+
+	// Drain
+	internals.releaseSlot(sem);
+	await w1;
+	internals.releaseSlot(sem);
+	await w2;
+	internals.releaseSlot(sem);
+
+	if (sem.waiters.length !== 0) errors.push(`semaphore waiters not drained: ${sem.waiters.length}`);
+	else notes.push("waiters drained cleanly");
+
+	// MCP TTL: dynamic import so we don't disturb the global MCP map until needed.
+	const mcpMod = await import("../src/api/mcp/server.js");
+	notes.push(`mcp module loaded (startMcpSessionSweeper=${typeof mcpMod.startMcpSessionSweeper})`);
+
+	await sm.shutdown();
+	const after = await snapshot();
+	notes.push(`handles before=${before.activeHandles} after=${after.activeHandles}`);
+
+	return {
+		name,
+		durationMs: Date.now() - t0,
+		before,
+		after,
+		notes,
+		errors,
+		pass: errors.length === 0,
+	};
+}
+
+// ── Migration bootstrap ───────────────────────────────────────────────────────
+
+/**
+ * Wipe every sandbox + every blob. Use only on a database dedicated to stress
+ * testing — this is a destructive operation. CASCADE through dirents/inodes
+ * via FK; blobs are content-addressed and deleted unconditionally.
+ */
+async function cleanupAll(): Promise<void> {
+	log("⚠ cleaning up ALL sandboxes + blobs in stress DB…");
+	const sql = postgres(PG_URL!, { prepare: false, max: 2, idle_timeout: 5 });
+	try {
+		const sandboxesBefore = await sql<{ n: string }[]>`SELECT count(*)::text AS n FROM sandboxes`;
+		const blobsBefore = await sql<{ n: string }[]>`SELECT count(*)::text AS n FROM blobs`;
+		log(`  before: sandboxes=${sandboxesBefore[0]?.n} blobs=${blobsBefore[0]?.n}`);
+
+		// `sandboxes` cascades to inodes/dirents via FK ON DELETE CASCADE.
+		await sql`DELETE FROM sandboxes`;
+		// Blobs are global / content-addressed; not FK'd to sandboxes.
+		await sql`DELETE FROM blobs`;
+
+		const sandboxesAfter = await sql<{ n: string }[]>`SELECT count(*)::text AS n FROM sandboxes`;
+		const blobsAfter = await sql<{ n: string }[]>`SELECT count(*)::text AS n FROM blobs`;
+		log(`  after:  sandboxes=${sandboxesAfter[0]?.n} blobs=${blobsAfter[0]?.n}`);
+	} finally {
+		await sql.end({ timeout: 5 }).catch(() => {});
+	}
+}
+
+async function ensureMigrations(): Promise<void> {
+	log("running migrations against stress PG…");
+	const tenantConfig = {
+		tenantIds: ["stress"],
+		getConnectionString: () => PG_URL!,
+	} as Parameters<typeof runMigrations>[0];
+	await runMigrations(tenantConfig);
+	log("migrations OK");
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const overallStart = Date.now();
+	log(`starting stress run: PG=${PG_URL!.split("@")[1]?.split("?")[0]} REDIS=${REDIS_URL!.split("@")[1]}`);
+
+	await ensureMigrations();
+	if (process.env.STRESS_CLEANUP === "true") {
+		await cleanupAll();
+	}
+
+	const scenarios = [scenarioDestroyFailures, scenarioPoolPressure, scenarioRedisFlakiness, scenarioInProc];
+	for (const fn of scenarios) {
+		try {
+			const r = await fn();
+			allResults.push(r);
+			log(`  ${r.pass ? "✓" : "✗"} ${r.name} (${r.durationMs}ms)`);
+			for (const n of r.notes) log(`    · ${n}`);
+			for (const e of r.errors) log(`    ! ${e}`);
+		} catch (err) {
+			allResults.push({
+				name: fn.name,
+				durationMs: 0,
+				before: await snapshot(),
+				after: await snapshot(),
+				notes: [],
+				errors: [`scenario crashed: ${(err as Error).message}`],
+				pass: false,
+			});
+			log(`  ✗ ${fn.name} crashed: ${(err as Error).message}`);
+		}
+	}
+
+	// Report
+	const totalDuration = Date.now() - overallStart;
+	const passCount = allResults.filter((r) => r.pass).length;
+	const reportPath = path.resolve("tasks/stress-test-results.md");
+	const jsonPath = path.resolve("tasks/stress-test-results.json");
+
+	const md = renderMarkdown(allResults, totalDuration, passCount);
+	writeFileSync(reportPath, md, "utf8");
+	writeFileSync(
+		jsonPath,
+		JSON.stringify(
+			{ ranAt: new Date().toISOString(), totalDurationMs: totalDuration, results: allResults },
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	log(`\nDone. ${passCount}/${allResults.length} scenarios passed.`);
+	log(`Report: ${reportPath}`);
+	log(`JSON:   ${jsonPath}`);
+	process.exit(passCount === allResults.length ? 0 : 1);
+}
+
+function renderMarkdown(results: ScenarioResult[], totalMs: number, passCount: number): string {
+	const lines: string[] = [];
+	lines.push("# Production Stability Stress Test Results");
+	lines.push("");
+	lines.push(`Ran: ${new Date().toISOString()}`);
+	lines.push(`Total duration: ${totalMs}ms`);
+	lines.push(`Pass rate: **${passCount}/${results.length}**`);
+	lines.push("");
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Scenario | Result | Duration | Notes |");
+	lines.push("|---|---|---|---|");
+	for (const r of results) {
+		const status = r.pass ? "✅" : "❌";
+		lines.push(`| ${r.name} | ${status} | ${r.durationMs}ms | ${r.notes.length} notes, ${r.errors.length} errors |`);
+	}
+	lines.push("");
+	for (const r of results) {
+		lines.push(`## ${r.pass ? "✅" : "❌"} ${r.name}`);
+		lines.push("");
+		lines.push("### Snapshots");
+		lines.push("");
+		lines.push("| Metric | Before | After |");
+		lines.push("|---|---|---|");
+		lines.push(`| RSS (MB) | ${r.before.rssMB} | ${r.after.rssMB} |`);
+		lines.push(`| Active handles | ${r.before.activeHandles} | ${r.after.activeHandles} |`);
+		lines.push(`| Active requests | ${r.before.activeRequests} | ${r.after.activeRequests} |`);
+		lines.push(`| PG backends (total) | ${r.before.pgBackends ?? "n/a"} | ${r.after.pgBackends ?? "n/a"} |`);
+		lines.push(`| PG active queries | ${r.before.pgActive ?? "n/a"} | ${r.after.pgActive ?? "n/a"} |`);
+		lines.push(`| Sessions | ${r.before.sessions} | ${r.after.sessions} |`);
+		lines.push("");
+		if (r.notes.length > 0) {
+			lines.push("### Notes");
+			for (const n of r.notes) lines.push(`- ${n}`);
+			lines.push("");
+		}
+		if (r.errors.length > 0) {
+			lines.push("### Errors");
+			for (const e of r.errors) lines.push(`- ${e}`);
+			lines.push("");
+		}
+	}
+	return lines.join("\n");
+}
+
+main().catch((err) => {
+	console.error("[stress] fatal:", err);
+	process.exit(2);
+});

--- a/scripts/sync-openapi-version.mjs
+++ b/scripts/sync-openapi-version.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Keeps openapi-spec.ts and README.md version badge in sync with package.json after `pnpm changeset:version`.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+
+const specPath = join(root, "src", "api", "openapi-spec.ts");
+writeFileSync(
+	specPath,
+	readFileSync(specPath, "utf8").replace(
+		/version: "\d+\.\d+\.\d+"/,
+		`version: "${pkg.version}"`,
+	),
+);
+console.log(`openapi-spec.ts → ${pkg.version}`);
+
+const readmePath = join(root, "README.md");
+writeFileSync(
+	readmePath,
+	readFileSync(readmePath, "utf8").replace(
+		/badge\/version-[\d.]+/,
+		`badge/version-${pkg.version}`,
+	),
+);
+console.log(`README.md badge → ${pkg.version}`);

--- a/src/api/distributed-lock.ts
+++ b/src/api/distributed-lock.ts
@@ -147,7 +147,11 @@ export async function withDistributedLock<T>(
 			} catch {
 				lost = true;
 			}
-			if (!stopped) scheduleRenew();
+			// Once the lock is lost (or a renew has timed out), stop scheduling
+			// further renewals. Otherwise on a hung Redis we'd keep enqueuing
+			// EVAL commands every renewMs that pile up in the ioredis send queue
+			// while their predecessors are still in-flight.
+			if (!stopped && !lost) scheduleRenew();
 		}, renewMs);
 	};
 	scheduleRenew();

--- a/src/api/distributed-lock.ts
+++ b/src/api/distributed-lock.ts
@@ -121,15 +121,36 @@ export async function withDistributedLock<T>(
 	}
 
 	// ── Heartbeat ──
+	// Non-overlapping renewal: schedule the next renewal only after the
+	// previous Redis call settles. `setInterval(async ...)` would let slow
+	// Redis commands stack — every `renewMs` we'd queue another EVAL even if
+	// the previous one hasn't returned yet, eventually overwhelming the
+	// connection. Sequential scheduling keeps at most one renewal in flight
+	// and bounds command latency naturally.
 	let lost = false;
-	const renewer = setInterval(async () => {
-		try {
-			const res = await redis.eval(RENEW_SCRIPT, 1, key, token, String(leaseMs));
-			if (res !== 1) lost = true;
-		} catch {
-			lost = true;
-		}
-	}, renewMs);
+	let stopped = false;
+	let renewTimer: ReturnType<typeof setTimeout> | undefined;
+	const scheduleRenew = (): void => {
+		if (stopped) return;
+		renewTimer = setTimeout(async () => {
+			if (stopped) return;
+			// Cap renewal command wait so a stalled Redis can't block release.
+			// We use a generous bound (renewMs) — any longer and the lease has
+			// already expired anyway.
+			try {
+				const renewPromise = redis.eval(RENEW_SCRIPT, 1, key, token, String(leaseMs));
+				const timeoutPromise = new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error("renew_timeout")), renewMs),
+				);
+				const res = await Promise.race([renewPromise, timeoutPromise]);
+				if (res !== 1) lost = true;
+			} catch {
+				lost = true;
+			}
+			if (!stopped) scheduleRenew();
+		}, renewMs);
+	};
+	scheduleRenew();
 
 	// ── Critical section ──
 	try {
@@ -137,7 +158,8 @@ export async function withDistributedLock<T>(
 		if (lost) throw new LockLostError(key);
 		return result;
 	} finally {
-		clearInterval(renewer);
+		stopped = true;
+		if (renewTimer !== undefined) clearTimeout(renewTimer);
 		try {
 			await redis.eval(RELEASE_SCRIPT, 1, key, token);
 		} catch (err) {

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -47,6 +47,10 @@ export function mapFsErrorToStatus(err: Error): number {
 			return 503;
 		case "ELOCKLOST":
 			return 500;
+		case "ECOHERENCE":
+			return 503;
+		case "ERUNTIME_BUSY":
+			return 503;
 		default:
 			return 500;
 	}

--- a/src/api/mcp/server.ts
+++ b/src/api/mcp/server.ts
@@ -18,8 +18,69 @@ interface SessionEntry {
 	readonly transport: WebStandardStreamableHTTPServerTransport;
 	readonly owner: string;
 	readonly tenant: string;
+	lastSeen: number;
 }
 const sessions = new Map<string, SessionEntry>();
+
+const MCP_SESSION_IDLE_MS = Number(process.env.MCP_SESSION_IDLE_MS ?? "1800000"); // 30 min
+const MCP_SESSION_MAX = Number(process.env.MCP_SESSION_MAX ?? "1000");
+const MCP_SWEEP_INTERVAL_MS = Number(process.env.MCP_SWEEP_INTERVAL_MS ?? "60000");
+
+let sweeperTimer: ReturnType<typeof setInterval> | undefined;
+
+function closeTransport(entry: SessionEntry): void {
+	const t = entry.transport as { close?: () => void | Promise<void> };
+	try {
+		if (typeof t.close === "function") void t.close();
+	} catch {
+		// best-effort
+	}
+}
+
+/** Evict the oldest (by lastSeen) session to keep the map under MCP_SESSION_MAX. */
+function evictOldest(): void {
+	let oldestId: string | undefined;
+	let oldestSeen = Number.POSITIVE_INFINITY;
+	for (const [id, entry] of sessions) {
+		if (entry.lastSeen < oldestSeen) {
+			oldestSeen = entry.lastSeen;
+			oldestId = id;
+		}
+	}
+	if (oldestId !== undefined) {
+		const entry = sessions.get(oldestId);
+		sessions.delete(oldestId);
+		if (entry !== undefined) closeTransport(entry);
+	}
+}
+
+function sweepIdleMcpSessions(): void {
+	const now = Date.now();
+	for (const [id, entry] of sessions) {
+		if (now - entry.lastSeen > MCP_SESSION_IDLE_MS) {
+			sessions.delete(id);
+			closeTransport(entry);
+		}
+	}
+}
+
+/** Start the idle sweeper. Idempotent; safe to call once at server startup. */
+export function startMcpSessionSweeper(intervalMs: number = MCP_SWEEP_INTERVAL_MS): void {
+	if (sweeperTimer !== undefined) return;
+	sweeperTimer = setInterval(sweepIdleMcpSessions, intervalMs);
+	if (typeof sweeperTimer.unref === "function") sweeperTimer.unref();
+}
+
+/** Stop the sweeper and close every active MCP transport. Used during shutdown. */
+export async function shutdownMcp(): Promise<void> {
+	if (sweeperTimer !== undefined) {
+		clearInterval(sweeperTimer);
+		sweeperTimer = undefined;
+	}
+	const entries = [...sessions.values()];
+	sessions.clear();
+	for (const entry of entries) closeTransport(entry);
+}
 
 /**
  * Creates a new MCP server instance with virtualfs server info.
@@ -55,8 +116,16 @@ export async function handleMcpRequest(
 					headers: { "Content-Type": "application/json" },
 				});
 			}
+			existing.lastSeen = Date.now();
 			return existing.transport.handleRequest(req);
 		}
+	}
+
+	// Cap total live MCP sessions: each session holds an MCP server + transport
+	// in memory, so unbounded growth from short-lived clients can leak.
+	if (sessions.size >= MCP_SESSION_MAX) {
+		sweepIdleMcpSessions();
+		if (sessions.size >= MCP_SESSION_MAX) evictOldest();
 	}
 
 	const server = createMcpServer();
@@ -64,7 +133,7 @@ export async function handleMcpRequest(
 	const transport = new WebStandardStreamableHTTPServerTransport({
 		sessionIdGenerator: () => randomUUID(),
 		onsessioninitialized: (id) => {
-			sessions.set(id, { transport, owner, tenant });
+			sessions.set(id, { transport, owner, tenant, lastSeen: Date.now() });
 		},
 		onsessionclosed: (id) => {
 			sessions.delete(id);

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.19",
+		version: "0.2.20",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.18",
+		version: "0.2.19",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/routes/files.ts
+++ b/src/api/routes/files.ts
@@ -77,6 +77,10 @@ function parentDir(filePath: string): string {
 	return lastSlash <= 0 ? "/" : filePath.slice(0, lastSlash);
 }
 
+const MAX_RAW_FILE_WRITE_BYTES = Number(process.env.MAX_FILE_WRITE_BYTES ?? `${64 * 1024 * 1024}`);
+const MAX_BULK_WRITE_FILES = Number(process.env.MAX_BULK_WRITE_FILES ?? "1000");
+const MAX_BULK_WRITE_BYTES = Number(process.env.MAX_BULK_WRITE_BYTES ?? `${128 * 1024 * 1024}`);
+
 export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: AuthVariables }> {
 	const router = new Hono<{ Variables: AuthVariables }>();
 
@@ -163,6 +167,16 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		const buffer = await c.req.raw.arrayBuffer();
 		const content = new Uint8Array(buffer);
+		if (content.byteLength > MAX_RAW_FILE_WRITE_BYTES) {
+			return c.json(
+				{
+					error: "payload_too_large",
+					code: "PAYLOAD_TOO_LARGE",
+					details: [`File body exceeds limit (${MAX_RAW_FILE_WRITE_BYTES} bytes)`],
+				},
+				413 as ContentfulStatusCode,
+			);
+		}
 
 		try {
 			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
@@ -254,10 +268,35 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		}
 
 		const { files } = body;
+		const fileEntries = Object.entries(files);
+		if (fileEntries.length > MAX_BULK_WRITE_FILES) {
+			return c.json(
+				{
+					error: "payload_too_large",
+					code: "PAYLOAD_TOO_LARGE",
+					details: [`Bulk write exceeds file count limit (${MAX_BULK_WRITE_FILES})`],
+				},
+				413 as ContentfulStatusCode,
+			);
+		}
+		let totalBytes = 0;
+		for (const [, content] of fileEntries) {
+			totalBytes += Buffer.byteLength(content, "utf8");
+			if (totalBytes > MAX_BULK_WRITE_BYTES) {
+				return c.json(
+					{
+						error: "payload_too_large",
+						code: "PAYLOAD_TOO_LARGE",
+						details: [`Bulk write exceeds total byte limit (${MAX_BULK_WRITE_BYTES})`],
+					},
+					413 as ContentfulStatusCode,
+				);
+			}
+		}
 
 		try {
 			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
-				for (const [filePath, content] of Object.entries(files)) {
+				for (const [filePath, content] of fileEntries) {
 					const parent = parentDir(filePath);
 					if (parent !== "/") {
 						try {

--- a/src/api/routes/files.ts
+++ b/src/api/routes/files.ts
@@ -165,6 +165,23 @@ export function fileRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		const wildcard = c.req.param("path");
 		const filePath = `/${wildcard}`;
 
+		// Reject oversized uploads up-front via Content-Length so we never buffer
+		// a too-large body into memory.
+		const contentLength = c.req.header("content-length");
+		if (contentLength !== undefined) {
+			const declared = Number(contentLength);
+			if (Number.isFinite(declared) && declared > MAX_RAW_FILE_WRITE_BYTES) {
+				return c.json(
+					{
+						error: "payload_too_large",
+						code: "PAYLOAD_TOO_LARGE",
+						details: [`File body exceeds limit (${MAX_RAW_FILE_WRITE_BYTES} bytes)`],
+					},
+					413 as ContentfulStatusCode,
+				);
+			}
+		}
+
 		const buffer = await c.req.raw.arrayBuffer();
 		const content = new Uint8Array(buffer);
 		if (content.byteLength > MAX_RAW_FILE_WRITE_BYTES) {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -12,12 +12,12 @@ import { translateSqlError } from "../fs/sql-fs/errors.js";
 import { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { RedisPathSnapshot } from "../fs/sql-fs/redis-path-snapshot.js";
 import type { SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
-import { getRedisClient } from "../redis/client.js";
+import { closeRedisClient, getRedisClient } from "../redis/client.js";
 import { parseNonNegativeInt } from "../redis/config.js";
 import { type AuthVariables, createAuthMiddleware } from "./auth.js";
 import { mapFsErrorToStatus } from "./errors.js";
 import { mcpOptionsResponse, withMcpCors } from "./mcp-cors.js";
-import { handleMcpRequest } from "./mcp/server.js";
+import { handleMcpRequest, shutdownMcp, startMcpSessionSweeper } from "./mcp/server.js";
 import { runMigrations } from "./migrations.js";
 import { openapiSpec } from "./openapi-spec.js";
 import { authRoutes } from "./routes/auth.js";
@@ -223,6 +223,8 @@ app.onError((err, c) => {
 		"EINVAL",
 		"ELOCKTIMEOUT",
 		"ELOCKLOST",
+		"ECOHERENCE",
+		"ERUNTIME_BUSY",
 	];
 	const message = knownFsCodes.includes(code) ? err.message : "Internal server error";
 
@@ -248,16 +250,46 @@ if (isMain) {
 			console.log(JSON.stringify({ event: "server_start", port, tenantCount: tenantConfig.tenantIds.length }));
 		});
 
+		// Wire production lifecycle: reaper sweeps idle warm sessions; MCP
+		// sweeper evicts idle MCP transports.
+		sessionManager.startReaper();
+		startMcpSessionSweeper();
+
 		let shuttingDown = false;
 		const shutdown = (): void => {
 			if (shuttingDown) return;
 			shuttingDown = true;
+			console.log(JSON.stringify({ event: "shutdown_begin" }));
+			// Force-exit guard so a hung Postgres or Redis cleanup cannot keep
+			// the process alive past the orchestrator's grace period.
+			const forceExit = setTimeout(() => {
+				console.error(JSON.stringify({ event: "shutdown_force_exit" }));
+				process.exit(1);
+			}, 60_000);
+			if (typeof forceExit.unref === "function") forceExit.unref();
 			server.close(async () => {
 				try {
-					await closeMetaFns();
-				} finally {
-					process.exit(0);
+					await shutdownMcp();
+				} catch (err) {
+					console.error(JSON.stringify({ event: "shutdown_mcp_error", error: (err as Error).message }));
 				}
+				try {
+					await sessionManager.shutdown();
+				} catch (err) {
+					console.error(JSON.stringify({ event: "shutdown_session_manager_error", error: (err as Error).message }));
+				}
+				try {
+					await closeMetaFns();
+				} catch (err) {
+					console.error(JSON.stringify({ event: "shutdown_close_meta_error", error: (err as Error).message }));
+				}
+				try {
+					await closeRedisClient();
+				} catch (err) {
+					console.error(JSON.stringify({ event: "shutdown_redis_error", error: (err as Error).message }));
+				}
+				console.log(JSON.stringify({ event: "shutdown_complete" }));
+				process.exit(0);
 			});
 		};
 		process.once("SIGINT", shutdown);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -335,6 +335,9 @@ export class SessionManager {
 		runtimeOptions?: RuntimeOptions,
 		owner = "",
 	): Promise<Session> {
+		if (this.shuttingDown) {
+			throw Object.assign(new Error("ESHUTTINGDOWN: server is shutting down"), { code: "ESHUTTINGDOWN" });
+		}
 		const key = this.sessionKey(tenantId, sandboxId);
 		const existing = this.sessions.get(key);
 		if (existing !== undefined) {
@@ -381,6 +384,12 @@ export class SessionManager {
 					}
 				}
 
+				// Shutdown may have begun while buildFs() was running. If so, refuse
+				// to register the session — shutdown's snapshot has already been
+				// taken and would never see this fs, leaking its dialect pool.
+				if (this.shuttingDown) {
+					throw Object.assign(new Error("ESHUTTINGDOWN: server is shutting down"), { code: "ESHUTTINGDOWN" });
+				}
 				const session: Session = {
 					fs,
 					bash,
@@ -805,8 +814,20 @@ export class SessionManager {
 			if (session.state === "closing") continue;
 			if (session.inFlight !== 0) continue;
 			if (session.overBudget || now - session.lastUsed > this.idleMs) {
+				// Mark closing FIRST so any request that already captured this
+				// session reference but hasn't yet entered the mutex will
+				// observe ESESSIONCLOSING in withSessionEntry instead of running
+				// against a disconnected filesystem.
+				session.state = "closing";
 				this.sessions.delete(key);
-				void this.disconnectFs(session.fs);
+				void session.mutex
+					.runExclusive(async () => {
+						/* drain queued waiters; they will throw ESESSIONCLOSING */
+					})
+					.catch(() => {})
+					.finally(() => {
+						void this.disconnectFs(session.fs);
+					});
 			}
 		}
 	}

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -99,6 +99,16 @@ export interface Session {
 	overBudget: boolean;
 	destroyPromise?: Promise<void>;
 	lastSeenVersion: number;
+	/**
+	 * Set to true when a previous turn's `publishVersionIfDirty` call failed
+	 * (the write committed to Postgres but the Redis INCR errored). The next
+	 * successful turn must publish a version bump even if no new mutations
+	 * occurred on the FS — this is what guarantees other replicas eventually
+	 * see the prior write.
+	 *
+	 * Cleared after a successful publish.
+	 */
+	publishPending: boolean;
 }
 
 /** Per-tenant lazy Postgres backend state. */
@@ -156,10 +166,29 @@ export interface SessionManagerOptions {
 	readonly defenseAuditMode?: boolean;
 }
 
+interface SemaphoreWaiter {
+	readonly resolve: () => void;
+	readonly reject: (err: Error) => void;
+	readonly timer: ReturnType<typeof setTimeout> | undefined;
+	readonly onAbort: (() => void) | undefined;
+	readonly signal: AbortSignal | undefined;
+	settled: boolean;
+}
+
 interface Semaphore {
 	readonly limit: number;
+	readonly maxWaiters: number;
+	readonly waitTimeoutMs: number;
 	inFlight: number;
-	readonly waiters: Array<() => void>;
+	readonly waiters: SemaphoreWaiter[];
+}
+
+export class RuntimeBackpressureError extends Error {
+	readonly code = "ERUNTIME_BUSY";
+	constructor(runtime: string) {
+		super(`ERUNTIME_BUSY: ${runtime} runtime queue is full or wait timed out`);
+		this.name = "RuntimeBackpressureError";
+	}
 }
 
 export class SessionManager {
@@ -185,6 +214,7 @@ export class SessionManager {
 	private readonly jsSem: Semaphore;
 	private readonly defenseInDepth: boolean;
 	private readonly defenseAuditMode: boolean;
+	private shuttingDown = false;
 
 	constructor({
 		tenantConfig,
@@ -222,13 +252,21 @@ export class SessionManager {
 		this.getSandboxMetaFn = getSandboxMetaFn;
 		this.persistSandboxMetaFn = persistSandboxMetaFn;
 		this.listSandboxesFn = listSandboxesFn;
+		const maxPyWaiters = Number(process.env.MAX_PYTHON_QUEUE ?? "100");
+		const maxJsWaiters = Number(process.env.MAX_JS_QUEUE ?? "100");
+		const pyTimeout = Number(process.env.PYTHON_QUEUE_TIMEOUT_MS ?? "60000");
+		const jsTimeout = Number(process.env.JS_QUEUE_TIMEOUT_MS ?? "60000");
 		this.pythonSem = {
 			limit: maxConcurrentPython ?? Number(process.env.MAX_CONCURRENT_PYTHON ?? "5"),
+			maxWaiters: maxPyWaiters,
+			waitTimeoutMs: pyTimeout,
 			inFlight: 0,
 			waiters: [],
 		};
 		this.jsSem = {
 			limit: maxConcurrentJs ?? Number(process.env.MAX_CONCURRENT_JS ?? "5"),
+			maxWaiters: maxJsWaiters,
+			waitTimeoutMs: jsTimeout,
 			inFlight: 0,
 			waiters: [],
 		};
@@ -312,8 +350,10 @@ export class SessionManager {
 		const resolvedRuntime: RuntimeOptions = runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS;
 
 		const creationPromise = (async (): Promise<Session> => {
+			let createdFs: IFileSystem | undefined;
 			try {
 				const { fs, resolvedOwner } = await this.buildFs(tenantId, sandboxId, owner);
+				createdFs = fs;
 				const defenseInDepthConfig: DefenseInDepthConfig | false = this.defenseInDepth
 					? {
 							enabled: true,
@@ -357,9 +397,23 @@ export class SessionManager {
 					pathCacheBytes,
 					overBudget: pathCacheBytes > this.pathCacheMaxBytes,
 					lastSeenVersion: initialVersion,
+					publishPending: false,
 				};
 				this.sessions.set(key, session);
+				createdFs = undefined; // ownership transferred to session
 				return session;
+			} catch (err) {
+				// Disconnect any FS we built before the failure so the dialect
+				// pool doesn't leak when session construction throws
+				// post-buildFs() (e.g., new Bash(), Redis version probe, etc.).
+				if (createdFs !== undefined) {
+					try {
+						await this.disconnectFs(createdFs);
+					} catch {
+						// best-effort
+					}
+				}
+				throw err;
 			} finally {
 				this.pending.delete(key);
 			}
@@ -397,28 +451,42 @@ export class SessionManager {
 			}
 			session.inFlight++;
 			session.lastUsed = Date.now();
+			let primaryError: unknown;
+			let result: T | undefined;
+			let succeeded = false;
 			try {
-				return await fn(session);
-			} finally {
-				const coherent = asCoherentFs(session.fs);
-				const shouldRefreshPathBudget = coherent === undefined || coherent.wasDirty();
-				try {
-					await this.publishVersionIfDirty(tenantId, sandboxId, session);
-				} catch (err) {
-					console.error(
-						JSON.stringify({
-							event: "publish_version_finally_error",
-							sandboxId,
-							error: (err as Error).message,
-						}),
-					);
-				}
-				session.inFlight--;
-				if (shouldRefreshPathBudget) {
-					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
-					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
-				}
+				result = await fn(session);
+				succeeded = true;
+			} catch (err) {
+				primaryError = err;
 			}
+			const coherent = asCoherentFs(session.fs);
+			const shouldRefreshPathBudget = coherent === undefined || coherent.wasDirty();
+			let publishError: unknown;
+			try {
+				await this.publishVersionIfDirty(tenantId, sandboxId, session);
+			} catch (err) {
+				publishError = err;
+				console.error(
+					JSON.stringify({
+						event: "publish_version_finally_error",
+						sandboxId,
+						error: (err as Error).message,
+					}),
+				);
+			}
+			session.inFlight--;
+			if (shouldRefreshPathBudget) {
+				session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
+				session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+			}
+			// Order of precedence:
+			// 1. The handler's own error (most specific) takes priority.
+			// 2. Otherwise, surface the publish failure so the client knows the
+			//    write committed but cross-replica coherence did not (503).
+			if (primaryError !== undefined) throw primaryError;
+			if (publishError !== undefined && succeeded) throw publishError;
+			return result as T;
 		});
 	}
 
@@ -451,15 +519,26 @@ export class SessionManager {
 		if (this.redis === undefined) return;
 		const coherent = asCoherentFs(session.fs);
 		if (coherent === undefined) return;
-		if (!coherent.wasDirty()) return;
+		const dirty = coherent.wasDirty();
+		if (!dirty && !session.publishPending) return;
 
 		const key = versionKey(tenantId, sandboxId);
 		let newVersion: number;
 		try {
 			newVersion = Number(await this.redis.incr(key));
 		} catch (err) {
+			// The local write committed to Postgres but we could not publish a
+			// new version to Redis — other replicas will continue to serve
+			// stale reads from their local pathCache. Preserve the dirty flag
+			// (do NOT clearDirty), force the next exec on this replica to
+			// reload from Postgres, and surface a caller-visible 503 so the
+			// client knows cross-replica coherence is broken.
 			console.error(JSON.stringify({ event: "version_incr_error", sandboxId, error: (err as Error).message }));
-			return;
+			session.lastSeenVersion = -1;
+			session.publishPending = true;
+			throw Object.assign(new Error("ECOHERENCE: write committed but version publish failed; client should retry"), {
+				code: "ECOHERENCE",
+			});
 		}
 		try {
 			await this.redis.expire(key, VERSION_KEY_TTL_SECONDS);
@@ -469,10 +548,18 @@ export class SessionManager {
 		if (this.pathSnapshot !== undefined) {
 			const writer = asSnapshotWriter(coherent);
 			if (writer !== undefined) {
-				await this.pathSnapshot.write(tenantId, sandboxId, newVersion, writer._getPathCache());
+				try {
+					await this.pathSnapshot.write(tenantId, sandboxId, newVersion, writer._getPathCache());
+				} catch (err) {
+					// snapshot write is a perf optimization — losing it is fine
+					console.error(
+						JSON.stringify({ event: "path_snapshot_write_error", sandboxId, error: (err as Error).message }),
+					);
+				}
 			}
 		}
 		session.lastSeenVersion = newVersion;
+		session.publishPending = false;
 		coherent.clearDirty();
 	}
 
@@ -585,12 +672,41 @@ export class SessionManager {
 
 			const p = session.mutex.runExclusive(async () => {
 				this.sessions.delete(key);
-				await this.destroySandboxFn(tenantId, sandboxId);
-				await this.deleteVersionKey(tenantId, sandboxId);
-				if (this.pathSnapshot !== undefined) {
-					await this.pathSnapshot.delete(tenantId, sandboxId);
+				// Disconnect the FS unconditionally — even if destroySandboxFn,
+				// version-key deletion, or path-snapshot cleanup throws — so the
+				// per-session Postgres pool can never leak. Errors from the
+				// individual cleanup steps are surfaced to the caller via
+				// rethrow at the end.
+				let cleanupError: unknown;
+				try {
+					try {
+						await this.destroySandboxFn(tenantId, sandboxId);
+					} catch (e) {
+						cleanupError ??= e;
+						console.error(
+							JSON.stringify({
+								event: "destroy_sandbox_error",
+								sandboxId,
+								error: (e as Error).message,
+							}),
+						);
+					}
+					try {
+						await this.deleteVersionKey(tenantId, sandboxId);
+					} catch (e) {
+						cleanupError ??= e;
+					}
+					if (this.pathSnapshot !== undefined) {
+						try {
+							await this.pathSnapshot.delete(tenantId, sandboxId);
+						} catch (e) {
+							cleanupError ??= e;
+						}
+					}
+				} finally {
+					await this.disconnectFs(session.fs);
 				}
-				await this.disconnectFs(session.fs);
+				if (cleanupError !== undefined) throw cleanupError;
 			});
 			session.destroyPromise = p;
 
@@ -611,6 +727,69 @@ export class SessionManager {
 	startReaper(intervalMs = 60_000): void {
 		if (this.reaperTimer !== undefined) return;
 		this.reaperTimer = setInterval(() => this.runReaper(), intervalMs);
+		// Reaper should never block process exit — a Node timer with `unref()`
+		// lets graceful shutdown proceed even if the reaper interval is mid-tick.
+		if (typeof this.reaperTimer.unref === "function") this.reaperTimer.unref();
+	}
+
+	/**
+	 * Graceful shutdown: stops the reaper, marks every session as closing,
+	 * waits (up to a bound) for in-flight work, and disconnects every live
+	 * filesystem so dialect connection pools don't leak.
+	 *
+	 * Safe to call multiple times.
+	 */
+	async shutdown(opts: { drainTimeoutMs?: number } = {}): Promise<void> {
+		if (this.shuttingDown) return;
+		this.shuttingDown = true;
+		this.stopReaper();
+
+		const drainTimeoutMs = opts.drainTimeoutMs ?? 30_000;
+
+		// Mark every session closing so new entries reject early.
+		for (const session of this.sessions.values()) {
+			session.state = "closing";
+		}
+
+		// Reject any queued runtime semaphore waiters: they would otherwise
+		// hold their request closures alive past shutdown.
+		for (const sem of [this.pythonSem, this.jsSem]) {
+			while (sem.waiters.length > 0) {
+				const w = sem.waiters.shift();
+				if (w === undefined) break;
+				w.reject(new RuntimeBackpressureError("shutting_down"));
+			}
+		}
+
+		const deadline = Date.now() + drainTimeoutMs;
+		const sessionsSnapshot = [...this.sessions.entries()];
+		await Promise.allSettled(
+			sessionsSnapshot.map(async ([key, session]) => {
+				const remaining = Math.max(0, deadline - Date.now());
+				try {
+					await Promise.race([
+						session.mutex.runExclusive(async () => {
+							/* drain */
+						}),
+						new Promise<void>((resolve) => setTimeout(resolve, remaining)),
+					]);
+				} catch {
+					// best-effort
+				}
+				this.sessions.delete(key);
+				try {
+					await this.disconnectFs(session.fs);
+				} catch {
+					// best-effort
+				}
+			}),
+		);
+		this.sessions.clear();
+	}
+
+	/** Alias for shutdown() — matches the plan's `closeAll()` naming. */
+	async closeAll(opts?: { drainTimeoutMs?: number }): Promise<void> {
+		return this.shutdown(opts);
 	}
 
 	stopReaper(): void {
@@ -643,20 +822,67 @@ export class SessionManager {
 		}
 	}
 
-	private acquireSlot(sem: Semaphore): Promise<void> {
+	private acquireSlot(sem: Semaphore, signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) {
+			return Promise.reject(Object.assign(new Error("ABORTED"), { code: "ABORTED", name: "AbortError" }));
+		}
 		if (sem.inFlight < sem.limit) {
 			sem.inFlight++;
 			return Promise.resolve();
 		}
-		return new Promise<void>((resolve) => {
-			sem.waiters.push(resolve);
+		if (sem.waiters.length >= sem.maxWaiters) {
+			return Promise.reject(new RuntimeBackpressureError("queue_full"));
+		}
+		return new Promise<void>((resolve, reject) => {
+			const waiter: SemaphoreWaiter = {
+				resolve: () => {
+					if (waiter.settled) return;
+					waiter.settled = true;
+					if (waiter.timer !== undefined) clearTimeout(waiter.timer);
+					if (waiter.onAbort !== undefined && waiter.signal !== undefined) {
+						waiter.signal.removeEventListener("abort", waiter.onAbort);
+					}
+					resolve();
+				},
+				reject: (err: Error) => {
+					if (waiter.settled) return;
+					waiter.settled = true;
+					if (waiter.timer !== undefined) clearTimeout(waiter.timer);
+					if (waiter.onAbort !== undefined && waiter.signal !== undefined) {
+						waiter.signal.removeEventListener("abort", waiter.onAbort);
+					}
+					// Remove from queue so the closure doesn't outlive the request.
+					const idx = sem.waiters.indexOf(waiter);
+					if (idx >= 0) sem.waiters.splice(idx, 1);
+					reject(err);
+				},
+				timer: undefined,
+				onAbort: undefined,
+				signal,
+				settled: false,
+			};
+			(waiter as { timer: ReturnType<typeof setTimeout> }).timer = setTimeout(
+				() => waiter.reject(new RuntimeBackpressureError("wait_timeout")),
+				sem.waitTimeoutMs,
+			);
+			if (signal !== undefined) {
+				const onAbort = (): void =>
+					waiter.reject(Object.assign(new Error("ABORTED"), { code: "ABORTED", name: "AbortError" }));
+				(waiter as { onAbort: () => void }).onAbort = onAbort;
+				signal.addEventListener("abort", onAbort, { once: true });
+			}
+			sem.waiters.push(waiter);
 		});
 	}
 
 	private releaseSlot(sem: Semaphore): void {
-		const next = sem.waiters.shift();
-		if (next !== undefined) {
-			next();
+		// Skip waiters that already settled (aborted/timed out) but haven't
+		// been spliced — defensive belt-and-braces.
+		while (sem.waiters.length > 0) {
+			const next = sem.waiters.shift();
+			if (next === undefined) break;
+			if (next.settled) continue;
+			next.resolve();
 			return;
 		}
 		sem.inFlight--;
@@ -685,10 +911,11 @@ export class SessionManager {
 			return execFn();
 		}
 
-		if (usesPython) await this.acquireSlot(this.pythonSem);
+		const signal = opts?.signal;
+		if (usesPython) await this.acquireSlot(this.pythonSem, signal);
 		if (usesJs) {
 			try {
-				await this.acquireSlot(this.jsSem);
+				await this.acquireSlot(this.jsSem, signal);
 			} catch (e) {
 				if (usesPython) this.releaseSlot(this.pythonSem);
 				throw e;

--- a/src/api/tests/unit/session-manager.lifecycle.test.ts
+++ b/src/api/tests/unit/session-manager.lifecycle.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for production-stability lifecycle behaviors:
+ *  - shutdown() disconnects every live FS
+ *  - destroy() disconnects FS even when destroySandboxFn throws
+ *  - getOrCreate() disconnects FS when post-build session construction fails
+ *  - runtime semaphore waiters are removed on abort
+ */
+
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it, vi } from "vitest";
+import { RuntimeBackpressureError, SessionManager } from "../../session-manager.js";
+
+const T = "tenantA";
+
+interface FakeFs extends IFileSystem {
+	disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeFs(): FakeFs {
+	const fs = new InMemoryFs() as unknown as FakeFs;
+	fs.disconnect = vi.fn(() => Promise.resolve());
+	return fs;
+}
+
+describe("SessionManager.shutdown", () => {
+	it("stops the reaper, marks sessions closing, and disconnects every FS", async () => {
+		const fs1 = makeFakeFs();
+		const fs2 = makeFakeFs();
+		const created: FakeFs[] = [];
+		const createFs = vi.fn((_t: string, _s: string) => {
+			const next = created.length === 0 ? fs1 : fs2;
+			created.push(next);
+			return Promise.resolve(next as IFileSystem);
+		});
+		const sm = new SessionManager({ createFs });
+		sm.startReaper(60_000);
+
+		await sm.getOrCreate(T, "sbx-1");
+		await sm.getOrCreate(T, "sbx-2");
+
+		await sm.shutdown({ drainTimeoutMs: 1_000 });
+
+		expect(fs1.disconnect).toHaveBeenCalledTimes(1);
+		expect(fs2.disconnect).toHaveBeenCalledTimes(1);
+		expect(sm.getSession(T, "sbx-1")).toBeUndefined();
+		expect(sm.getSession(T, "sbx-2")).toBeUndefined();
+	});
+
+	it("is idempotent", async () => {
+		const fs1 = makeFakeFs();
+		const sm = new SessionManager({ createFs: vi.fn(() => Promise.resolve(fs1 as IFileSystem)) });
+		await sm.getOrCreate(T, "sbx-1");
+		await sm.shutdown();
+		await sm.shutdown();
+		expect(fs1.disconnect).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("SessionManager.destroy resilience", () => {
+	it("disconnects FS even when destroySandboxFn throws", async () => {
+		const fs1 = makeFakeFs();
+		const sm = new SessionManager({
+			createFs: vi.fn(() => Promise.resolve(fs1 as IFileSystem)),
+			destroySandboxFn: vi.fn(() => Promise.reject(new Error("boom"))),
+		});
+		await sm.getOrCreate(T, "sbx");
+
+		await expect(sm.destroy(T, "sbx")).rejects.toThrow("boom");
+		// FS must still be disconnected — pool leak prevention is the point.
+		expect(fs1.disconnect).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("SessionManager.getOrCreate cleanup", () => {
+	it("disconnects FS when session construction fails after buildFs", async () => {
+		const fs1 = makeFakeFs();
+		const sm = new SessionManager({
+			createFs: vi.fn(() => Promise.resolve(fs1 as IFileSystem)),
+		});
+		// Force estimatePathCacheBytes to blow up by replacing fs.getAllPaths.
+		(fs1 as unknown as { getAllPaths: () => string[] }).getAllPaths = () => {
+			throw new Error("getAllPaths failed");
+		};
+		await expect(sm.getOrCreate(T, "sbx")).rejects.toThrow("getAllPaths failed");
+		expect(fs1.disconnect).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("Runtime semaphore abort + queue limits", () => {
+	// Direct internal-API tests: we exercise the semaphore primitives
+	// (acquireSlot/releaseSlot) rather than going through bash.exec, which
+	// would require a runtime that actually blocks. The semaphore semantics
+	// are independent of the runtime that runs after the slot is acquired.
+	type SmInternals = {
+		pythonSem: { inFlight: number; maxWaiters: number; waiters: unknown[] };
+		acquireSlot(sem: unknown, signal?: AbortSignal): Promise<void>;
+		releaseSlot(sem: unknown): void;
+	};
+
+	it("removes a queued waiter when the AbortSignal fires", async () => {
+		const sm = new SessionManager({
+			createFs: vi.fn(() => Promise.resolve(makeFakeFs() as IFileSystem)),
+			maxConcurrentPython: 1,
+		});
+		const internals = sm as unknown as SmInternals;
+		const sem = internals.pythonSem;
+
+		await internals.acquireSlot(sem); // fill the only slot
+
+		const ac = new AbortController();
+		const queued = internals.acquireSlot(sem, ac.signal);
+		expect(sem.waiters.length).toBe(1);
+
+		ac.abort();
+		await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+		// Waiter must be removed from the queue, not retained in memory.
+		expect(sem.waiters.length).toBe(0);
+	});
+
+	it("rejects with ERUNTIME_BUSY when queue is full", async () => {
+		const sm = new SessionManager({
+			createFs: vi.fn(() => Promise.resolve(makeFakeFs() as IFileSystem)),
+			maxConcurrentPython: 1,
+		});
+		const internals = sm as unknown as SmInternals;
+		const sem = internals.pythonSem;
+		sem.maxWaiters = 1;
+
+		await internals.acquireSlot(sem); // fill slot
+		const queued = internals.acquireSlot(sem); // fill queue
+		await expect(internals.acquireSlot(sem)).rejects.toBeInstanceOf(RuntimeBackpressureError);
+
+		// Drain so the test doesn't leak unhandled rejections.
+		internals.releaseSlot(sem);
+		await queued;
+	});
+});

--- a/src/api/tests/unit/session-manager.version-counter.test.ts
+++ b/src/api/tests/unit/session-manager.version-counter.test.ts
@@ -301,7 +301,7 @@ describe("SessionManager version counter (Phase D)", () => {
 		expect(stub.reloadCount).toBe(0);
 	});
 
-	it("swallows transient INCR error, preserves dirty flag for next-turn retry", async () => {
+	it("surfaces ECOHERENCE on transient INCR error, preserves dirty flag, forces stale lastSeenVersion", async () => {
 		const redis = new FakeRedis();
 		const stub = new StubCoherentFs();
 		const sm = new SessionManager({
@@ -315,16 +315,21 @@ describe("SessionManager version counter (Phase D)", () => {
 		// Next turn: mutation happens, but INCR throws once.
 		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValueOnce(new Error("ECONNRESET"));
 
+		// The write committed but cross-replica coherence did not — caller must
+		// see ECOHERENCE so they can retry instead of falsely thinking the write
+		// fully succeeded.
 		await expect(
 			sm.withSession("default", "sbx", async () => {
 				stub.dirty = true;
 			}),
-		).resolves.toBeUndefined();
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
 
 		// Dirty flag must survive — the publish failed and the next turn needs
 		// to retry the bump.
 		expect(stub.dirty).toBe(true);
-		expect(sm.getSession("default", "sbx")?.lastSeenVersion).toBe(0);
+		// lastSeenVersion is forced to -1 so the next ensureFreshCache reloads
+		// from Postgres before serving any read.
+		expect(sm.getSession("default", "sbx")?.lastSeenVersion).toBe(-1);
 		expect(redis.store.has("vfs:default:ver:sbx")).toBe(false);
 
 		// Next turn: INCR works, the pending bump flushes.

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -26,6 +26,17 @@ import {
 /** Transaction handle type used throughout this dialect. */
 type PgTx = postgres.TransactionSql;
 
+/**
+ * Reads a positive integer env var, returns the fallback when unset / malformed.
+ * Used for pool tuning so deploys can override without code changes.
+ */
+function envInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (raw === undefined || raw === "") return fallback;
+	const n = Number(raw);
+	return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
 export class PostgresDialect implements SqlDialect<PgTx> {
 	private pool: postgres.Sql | null = null;
 	private readonly connectionString: string;
@@ -39,8 +50,24 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	// ── Connection ────────────────────────────────────────────────────────────────
 
 	async connect(): Promise<void> {
+		// Bound the pool: each PostgresDialect instance is owned by one warm
+		// session, so a tiny `max` is sufficient. Without these caps a runaway
+		// session could exhaust the upstream Postgres connection limit
+		// (especially Neon, where pooler endpoints have small per-tenant caps).
+		const max = envInt("PG_POOL_MAX", 2);
+		const idleTimeout = envInt("PG_POOL_IDLE_TIMEOUT_S", 30);
+		const connectTimeout = envInt("PG_POOL_CONNECT_TIMEOUT_S", 30);
+		const maxLifetime = envInt("PG_POOL_MAX_LIFETIME_S", 60 * 30);
 		this.pool = await DefenseInDepthBox.runTrustedAsync(() =>
-			Promise.resolve(postgres(this.connectionString, { prepare: false })),
+			Promise.resolve(
+				postgres(this.connectionString, {
+					prepare: false,
+					max,
+					idle_timeout: idleTimeout,
+					connect_timeout: connectTimeout,
+					max_lifetime: maxLifetime,
+				}),
+			),
 		);
 	}
 

--- a/src/fs/sql-fs/index.ts
+++ b/src/fs/sql-fs/index.ts
@@ -54,29 +54,45 @@ export async function createPostgresSandboxFs(
 ): Promise<{ fs: IFileSystem; resolvedOwner: string }> {
 	const dialect = new PostgresDialect(opts.connectionString, opts.blobCache);
 	await dialect.connect();
-	// Initialize the sandbox in the DB (creates root inode structure).
-	// On unique violation (23505) the sandbox already exists — read its owner back.
-	let resolvedOwner = owner;
+	// All post-connect work runs inside try/catch so a failure (sandbox bootstrap,
+	// metadata lookup, SqlFs construction, or fs.ready) cannot leak the dialect's
+	// connection pool. The pg pool stays alive until disconnect() is awaited.
 	try {
-		await dialect.transaction(async (tx) => {
-			await dialect.createSandbox(tx, sandboxId, owner);
+		let resolvedOwner = owner;
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.createSandbox(tx, sandboxId, owner);
+			});
+		} catch (e) {
+			const sqlErr = e as { code?: string };
+			if (sqlErr.code !== "23505") throw e;
+			const meta = await dialect.transaction(async (tx) => dialect.getSandboxMeta(tx, sandboxId));
+			resolvedOwner = meta?.owner ?? "";
+		}
+		const fs = new SqlFs({
+			dialect,
+			sandboxId,
+			tenantId: opts.tenantId,
+			redis: opts.redis,
+			pathSnapshot: opts.pathSnapshot,
+			blobCache: opts.blobCache,
 		});
-	} catch (e) {
-		const sqlErr = e as { code?: string };
-		if (sqlErr.code !== "23505") throw e;
-		const meta = await dialect.transaction(async (tx) => dialect.getSandboxMeta(tx, sandboxId));
-		resolvedOwner = meta?.owner ?? "";
+		await fs.ready();
+		return { fs, resolvedOwner };
+	} catch (err) {
+		try {
+			await dialect.disconnect();
+		} catch (cleanupErr) {
+			console.error(
+				JSON.stringify({
+					event: "postgres_dialect_cleanup_failed",
+					sandboxId,
+					error: (cleanupErr as Error).message,
+				}),
+			);
+		}
+		throw err;
 	}
-	const fs = new SqlFs({
-		dialect,
-		sandboxId,
-		tenantId: opts.tenantId,
-		redis: opts.redis,
-		pathSnapshot: opts.pathSnapshot,
-		blobCache: opts.blobCache,
-	});
-	await fs.ready();
-	return { fs, resolvedOwner };
 }
 
 /**

--- a/src/fs/sql-fs/redis-blob-cache.ts
+++ b/src/fs/sql-fs/redis-blob-cache.ts
@@ -53,13 +53,26 @@ export class RedisBlobCache {
 	 */
 	async mget(sha256s: ReadonlyArray<Uint8Array>): Promise<Array<Uint8Array | null>> {
 		if (!this.#enabled || sha256s.length === 0) return sha256s.map(() => null);
+		// Chunk MGET to bound a single round-trip's keyspace and response size.
+		// A 50k-blob warm sandbox would otherwise issue one MGET that requires
+		// Redis to assemble the entire response array before returning, spiking
+		// memory on both client and server.
+		const CHUNK = 1024;
+		const out: Array<Uint8Array | null> = new Array(sha256s.length);
 		try {
-			const keys = sha256s.map((s) => this.#key(s));
-			// ioredis exposes mgetBuffer for binary-safe pipelined gets.
-			const bufs = await (
+			const mgetBuffer = (
 				this.#client as unknown as { mgetBuffer(...keys: string[]): Promise<Array<Buffer | null>> }
-			).mgetBuffer(...keys);
-			return bufs.map((b) => (b ? new Uint8Array(b) : null));
+			).mgetBuffer.bind(this.#client);
+			for (let i = 0; i < sha256s.length; i += CHUNK) {
+				const slice = sha256s.slice(i, i + CHUNK);
+				const keys = slice.map((s) => this.#key(s));
+				const bufs = await mgetBuffer(...keys);
+				for (let j = 0; j < bufs.length; j++) {
+					const b = bufs[j];
+					out[i + j] = b ? new Uint8Array(b) : null;
+				}
+			}
+			return out;
 		} catch (err) {
 			console.error(JSON.stringify({ event: "redis_blob_mget_error", error: (err as Error).message }));
 			return sha256s.map(() => null); // fail open

--- a/src/redis/client.ts
+++ b/src/redis/client.ts
@@ -43,3 +43,34 @@ export function getRedisClient(): Redis | undefined {
 	});
 	return client;
 }
+
+/**
+ * Gracefully close the shared Redis client. Issues `quit()` (drains pending
+ * commands), and falls back to `disconnect()` on timeout or failure so a
+ * misbehaving Redis cannot block process shutdown.
+ *
+ * Safe to call multiple times. After the first successful close, subsequent
+ * calls are no-ops. Once closed, `getRedisClient()` will not reinitialize.
+ */
+export async function closeRedisClient(timeoutMs = 5_000): Promise<void> {
+	const c = client;
+	if (c === undefined) {
+		// Mark as initialized so future getRedisClient() calls don't construct a new client during shutdown.
+		initialized = true;
+		return;
+	}
+	client = undefined;
+	try {
+		await Promise.race([
+			c.quit(),
+			new Promise<void>((_, reject) => setTimeout(() => reject(new Error("redis_quit_timeout")), timeoutMs)),
+		]);
+	} catch (err) {
+		console.error(JSON.stringify({ event: "redis_quit_error", error: (err as Error).message }));
+		try {
+			c.disconnect();
+		} catch {
+			// best-effort
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two-stage hardening of VirtualFS resource lifecycles, closing leaks and races identified by the production-stability plan and a follow-up review.

**Stage 1 (`dd37e29`)** — implemented `tasks/production-stability-resource-lifecycle-plan.md`:
- Wired `startReaper()` / MCP sweeper at boot; ordered `SIGTERM`/`SIGINT` shutdown (MCP → session drain → meta dialects → Redis `quit()`).
- Capped Postgres pool (`max: 2`, `idle_timeout: 30s`, `connect_timeout: 30s`, `max_lifetime: 30m`).
- Guaranteed FS disconnect on `SessionManager.destroy()` failure paths and on `createPostgresSandboxFs()` setup failure.
- Surfaced Redis `INCR` failure as `ECOHERENCE` (HTTP 503), preserving dirty state and forcing reload.
- Replaced `setInterval(async)` lock heartbeat with sequential `setTimeout` chain; added bounded renewal `Promise.race`.
- Abort-aware runtime semaphore waiters with queue caps; `ERUNTIME_BUSY` (HTTP 503) backpressure.
- MCP session TTL/cap/sweeper, `closeRedisClient()`, raw PUT + `writeFiles` size caps, error-code → 503 mapping.

**Stage 2 (`dcb8c9a`)** — closes review-identified gaps:
- `getOrCreate()` refuses on `shuttingDown` at entry and again after `buildFs()` so a request accepted just before shutdown cannot register a session after the shutdown snapshot (would leak its dialect pool).
- Reaper marks `state="closing"` before deleting, drains via `mutex.runExclusive`, then disconnects — fixes the race where a queued waiter could run on a disconnected fs.
- Raw `PUT /files/*` pre-checks `Content-Length` to reject oversized uploads before buffering.
- Distributed lock stops scheduling `EVAL` renewals once `lost` or after a renew timeout, preventing command pile-up in the ioredis queue when Redis is hung.
- `RedisBlobCache.mget()` chunks at 1024 keys per round-trip to bound peak reply size on warm sandboxes with many blobs.

Out of scope (deferred to a future change): streaming JSON ingest / streaming export buffers, path-snapshot byte/entry caps, fire-and-forget blob backfill bound. These are larger refactors than the surgical lifecycle fixes here.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `pnpm test:unit`
- [x] Postgres + Redis integration tests (where env vars available)
- [x] Smoke: SIGTERM during in-flight exec — verify ordered shutdown, no orphaned pools
- [x] Smoke: large `PUT /files/*` body with oversized `Content-Length` returns 413 without buffering
- [x] Smoke: warm sandbox with many blobs — confirm chunked MGET round-trips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upload size limits for enhanced security and reliability.
  * Introduced MCP session idle tracking with configurable eviction policies.

* **Bug Fixes**
  * Fixed session lifecycle issues during shutdown and creation boundaries.
  * Corrected distributed lock renewal to prevent queue buildup.
  * Enhanced Redis version coherence error handling.
  * Improved database pool management to prevent resource leaks.
  * Added Content-Length validation for file uploads.

* **Documentation**
  * Added comprehensive contribution guide with setup, workflow, and coding standards.
  * Updated README with typical workflows and deployment guidance.

* **Chores**
  * Updated environment configuration template with security improvements.
  * Version bumped to 0.2.20.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/59)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->