### PR TITLE
Add parallel readOnly bash exec with RWLock and read-only scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Parallel readOnly bash exec on the same sandbox (single-replica). Callers opt in by passing `readOnly: true` on `/v1/sandboxes/:id/exec`, `/exec-sync`, `/exec-sync-batch`, and the MCP `bash_exec` / `bash_exec_batch` tools. ReadOnly execs route through the new `SessionManager.withSessionRead`: they take a per-session async readers-writer lock in *shared* mode (multiple readers run concurrently), skip the distributed exec lock, and share one single-flighted `ensureFreshCache` probe + reload across the cohort. Writes still take the lock exclusively and are writer-priority — a queued writer blocks new readers, preventing reader starvation.
-- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work, and the FS records the violation. After the script returns, the session manager surfaces a structured `EREADONLY_VIOLATION` error mapped to HTTP **422** so a lying readOnly script never silently succeeds. Violations are emitted via `logAudit("read_only_violation", ...)`.
+- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work. The scope is **reference-counted** so multiple concurrent readers share a single FS instance safely. Violation attribution uses an `AsyncLocalStorage`-based `readOnlyContext` so a lying script in one reader never falsely flags innocent concurrent readers — only the originating call's context is marked, and the session manager surfaces `EREADONLY_VIOLATION` (HTTP **422**) on that one call. Violations are emitted via `logAudit("read_only_violation", ...)`.
 - New async readers-writer lock primitive `RWLock` (`src/api/rw-lock.ts`) replaces `async-mutex`'s `Mutex` on `Session`. Drop-in `runExclusive` for existing call sites plus a new `runShared`. AbortSignal support cancels pending acquisitions cleanly.
+- OpenAPI spec documents the new `readOnly` request field on `/exec-sync`, `/exec`, and `/exec-sync-batch`, and the corresponding 422 response.
 
 ### Changed
 
 - `Session.mutex: Mutex` is now `Session.lock: RWLock`. The `async-mutex` runtime dependency is no longer used by `SessionManager`. All exclusive-mode call sites (`withSessionEntry`, `destroy`, reaper, shutdown) are unchanged in semantics.
+- `execWithRuntimeThrottle` skips the per-script `scriptTx.beginScope/endScope` wrapper when the call is inside a `readOnlyContext` (no writes can occur, and the shared `SessionScopedFs` would race across concurrent readers).
+- `withSessionReadEntry` is now wrapped in `try/finally` so `session.inFlight` and `endReadOnlyScope` always run even when `fn` throws — fixes a counter leak that pinned sessions and prevented idle eviction.
 
 ## [0.2.20] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-10
+
+### Added
+
+- Parallel readOnly bash exec on the same sandbox (single-replica). Callers opt in by passing `readOnly: true` on `/v1/sandboxes/:id/exec`, `/exec-sync`, `/exec-sync-batch`, and the MCP `bash_exec` / `bash_exec_batch` tools. ReadOnly execs route through the new `SessionManager.withSessionRead`: they take a per-session async readers-writer lock in *shared* mode (multiple readers run concurrently), skip the distributed exec lock, and share one single-flighted `ensureFreshCache` probe + reload across the cohort. Writes still take the lock exclusively and are writer-priority — a queued writer blocks new readers, preventing reader starvation.
+- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work, and the FS records the violation. After the script returns, the session manager surfaces a structured `EREADONLY_VIOLATION` error mapped to HTTP **422** so a lying readOnly script never silently succeeds. Violations are emitted via `logAudit("read_only_violation", ...)`.
+- New async readers-writer lock primitive `RWLock` (`src/api/rw-lock.ts`) replaces `async-mutex`'s `Mutex` on `Session`. Drop-in `runExclusive` for existing call sites plus a new `runShared`. AbortSignal support cancels pending acquisitions cleanly.
+
+### Changed
+
+- `Session.mutex: Mutex` is now `Session.lock: RWLock`. The `async-mutex` runtime dependency is no longer used by `SessionManager`. All exclusive-mode call sites (`withSessionEntry`, `destroy`, reaper, shutdown) are unchanged in semantics.
+
 ## [0.2.20] - 2026-05-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.20",
+	"version": "0.3.0",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -14,7 +14,7 @@ import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
 import { executeBatch } from "../lib/batch-exec.js";
-import { withOwnedSessionOrRehydrate } from "../ownership.js";
+import { withOwnedSessionOrRehydrate, withOwnedSessionRead } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -156,13 +156,20 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			script: z.string(),
 			timeout: z.number().int().positive().optional(),
 			debug: z.boolean().optional().describe("When true, prepends 'set -x' for command-level tracing in stderr"),
+			readOnly: z
+				.boolean()
+				.optional()
+				.describe(
+					"When true, runs the script in read-only mode: parallel reads are unblocked across calls (no exclusive lock) and any mutating filesystem op is rejected with EREADONLY at the offending command.",
+				),
 		},
 		async (args) => {
 			const timeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 			const scriptToRun = args.debug ? `set -x\n${args.script}` : args.script;
+			const runner = args.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 
 			try {
-				const result = await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) => {
+				const result = await runner(sessionManager, tenant, args.id, owner, async (session) => {
 					const controller = new AbortController();
 					let timedOut = false;
 					const startMs = Date.now();
@@ -233,6 +240,21 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 						],
 					};
 				}
+				if (code === "EREADONLY_VIOLATION") {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									stdout: "",
+									stderr: "EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem",
+									exitCode: 1,
+									code: "EREADONLY_VIOLATION",
+								}),
+							},
+						],
+					};
+				}
 				const message = err instanceof Error ? err.message : String(err);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ stdout: "", stderr: message, exitCode: 1 }) }],
@@ -262,12 +284,19 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				.min(1)
 				.max(50),
 			timeout: z.number().int().positive().optional(),
+			readOnly: z
+				.boolean()
+				.optional()
+				.describe(
+					"When true, runs all scripts in the batch in read-only mode: parallel reads are unblocked across calls and any mutating filesystem op is rejected with EREADONLY at the offending command.",
+				),
 		},
 		async (args) => {
 			const totalTimeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+			const runner = args.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 
 			try {
-				const results = await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) =>
+				const results = await runner(sessionManager, tenant, args.id, owner, async (session) =>
 					executeBatch(sessionManager, session, args.scripts, totalTimeoutMs),
 				);
 
@@ -284,6 +313,20 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				if (code === "ENOENT") {
 					return {
 						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "sandbox not found" }) }],
+					};
+				}
+				if (code === "EREADONLY_VIOLATION") {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									ok: false,
+									code: "EREADONLY_VIOLATION",
+									error: "readOnly script attempted to mutate the filesystem",
+								}),
+							},
+						],
 					};
 				}
 				console.error(

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.20",
+		version: "0.3.0",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -60,6 +60,11 @@ const execBodySchema = {
 			type: "boolean",
 			description: "When true, prepends 'set -x' for command-level tracing in stderr.",
 		},
+		readOnly: {
+			type: "boolean",
+			description:
+				"When true, runs the script in read-only mode: parallel reads against the same sandbox are unblocked (no exclusive lock), and any mutating filesystem op is rejected with EREADONLY at the offending command. If the script attempts a write, the request fails with HTTP 422 EREADONLY_VIOLATION after the script returns. Single-replica only: cross-replica writers are still serialized via the distributed exec lock.",
+		},
 	},
 	required: ["script"],
 } as const;
@@ -685,6 +690,10 @@ export const openapiSpec = {
 							},
 						},
 					},
+					"422": {
+						description: "readOnly script attempted to mutate the filesystem",
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
 				},
 			},
 		},
@@ -717,6 +726,11 @@ export const openapiSpec = {
 										maxItems: 50,
 									},
 									timeoutMs: { type: "integer", example: 30000, minimum: 1, maximum: 300000 },
+									readOnly: {
+										type: "boolean",
+										description:
+											"When true, runs all scripts in the batch in read-only mode: parallel reads are unblocked across calls and any mutating filesystem op is rejected with EREADONLY at the offending command. Returns HTTP 422 EREADONLY_VIOLATION if any script attempts a write.",
+									},
 								},
 								required: ["scripts"],
 							},
@@ -761,6 +775,10 @@ export const openapiSpec = {
 					},
 					"404": {
 						description: "Sandbox not found",
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
+					"422": {
+						description: "readOnly batch attempted to mutate the filesystem",
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
 					},
 				},

--- a/src/api/ownership.ts
+++ b/src/api/ownership.ts
@@ -42,3 +42,29 @@ export async function withOwnedSessionOrRehydrate<T>(
 		runtimeOptions,
 	);
 }
+
+/**
+ * readOnly variant of withOwnedSessionOrRehydrate. Routes through
+ * `SessionManager.withSessionRead` (shared RWLock, no distributed exec
+ * lock, FS in read-only scope). The owner check still runs inside the
+ * session's shared scope so cold sandboxes restored from Postgres are
+ * authorized under lock rather than via a racy in-memory snapshot.
+ */
+export async function withOwnedSessionRead<T>(
+	sessionManager: SessionManager,
+	tenantId: string,
+	sandboxId: string,
+	caller: string,
+	fn: (session: Session) => Promise<T>,
+	runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+	return sessionManager.withSessionRead(
+		tenantId,
+		sandboxId,
+		async (session) => {
+			assertSessionOwner(session, caller);
+			return fn(session);
+		},
+		runtimeOptions,
+	);
+}

--- a/src/api/read-only-context.ts
+++ b/src/api/read-only-context.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-call attribution for read-only scope violations.
+ *
+ * The parallel-readOnly bash exec path lets multiple readers run concurrently
+ * against a single shared SqlFs. A boolean violation flag on the FS would be
+ * shared across readers — a lying script in one reader would falsely flag
+ * every concurrent innocent reader. We use AsyncLocalStorage so each
+ * `withSessionRead` call gets its own context that follows its async stack
+ * down into bash.exec / SqlFs writes; SqlFs marks the *calling* context on
+ * EREADONLY rather than a shared flag.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface ReadOnlyContext {
+	violated: boolean;
+}
+
+export const readOnlyContext = new AsyncLocalStorage<ReadOnlyContext>();

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -11,7 +11,12 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
 import { type BatchScriptResult, executeBatch } from "../lib/batch-exec.js";
-import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
+import {
+	forbiddenResponse,
+	isForbiddenError,
+	withOwnedSessionOrRehydrate,
+	withOwnedSessionRead,
+} from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -26,6 +31,7 @@ const execBodySchema = z.object({
 	env: z.record(z.string(), z.string()).optional(),
 	timeoutMs: z.number().int().positive().max(MAX_TIMEOUT_MS).optional(),
 	debug: z.boolean().optional(),
+	readOnly: z.boolean().optional(),
 });
 
 const batchExecBodySchema = z.object({
@@ -39,6 +45,7 @@ const batchExecBodySchema = z.object({
 		.min(1)
 		.max(MAX_BATCH_SCRIPTS),
 	timeoutMs: z.number().int().positive().optional(),
+	readOnly: z.boolean().optional(),
 });
 
 type ExecBody = z.infer<typeof execBodySchema>;
@@ -147,51 +154,56 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		let execResult: ExecSyncResult;
 		try {
-			execResult = await withOwnedSessionOrRehydrate<ExecSyncResult>(
-				sessionManager,
-				tenant,
-				sandboxId,
-				c.get("owner"),
-				async (session) => {
-					const controller = new AbortController();
-					let timedOut = false;
-					const startMs = Date.now();
+			const runner = body.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			execResult = await runner<ExecSyncResult>(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
+				const controller = new AbortController();
+				let timedOut = false;
+				const startMs = Date.now();
 
-					const timer = setTimeout(() => {
-						timedOut = true;
-						controller.abort();
-					}, timeoutMs);
+				const timer = setTimeout(() => {
+					timedOut = true;
+					controller.abort();
+				}, timeoutMs);
 
-					try {
-						const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-							signal: controller.signal,
-							cwd: body.cwd,
-							env,
-						});
-						clearTimeout(timer);
+				try {
+					const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
+						signal: controller.signal,
+						cwd: body.cwd,
+						env,
+					});
+					clearTimeout(timer);
 
-						if (timedOut) {
-							return { kind: "timeout", durationMs: Date.now() - startMs };
-						}
-
-						return {
-							kind: "ok",
-							stdout: result.stdout,
-							stderr: result.stderr,
-							exitCode: result.exitCode,
-							durationMs: Date.now() - startMs,
-						};
-					} catch (e) {
-						clearTimeout(timer);
-						if (timedOut) {
-							return { kind: "timeout", durationMs: Date.now() - startMs };
-						}
-						throw e;
+					if (timedOut) {
+						return { kind: "timeout", durationMs: Date.now() - startMs };
 					}
-				},
-			);
+
+					return {
+						kind: "ok",
+						stdout: result.stdout,
+						stderr: result.stderr,
+						exitCode: result.exitCode,
+						durationMs: Date.now() - startMs,
+					};
+				} catch (e) {
+					clearTimeout(timer);
+					if (timedOut) {
+						return { kind: "timeout", durationMs: Date.now() - startMs };
+					}
+					throw e;
+				}
+			});
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
+			if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+				return c.json(
+					{
+						error: "read_only_violation",
+						code: "EREADONLY_VIOLATION",
+						details: ["readOnly script attempted to mutate the filesystem"],
+					},
+					422 as ContentfulStatusCode,
+				);
+			}
 			throw err;
 		}
 
@@ -228,8 +240,10 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		const timeoutMs = body.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		const scriptToRun = body.debug ? wrapDebugScript(body.script) : body.script;
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;
+		const readOnly = body.readOnly === true;
 		try {
-			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async () => undefined);
+			const ownerCheck = readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			await ownerCheck(sessionManager, tenant, sandboxId, c.get("owner"), async () => undefined);
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
 			throw err;
@@ -250,51 +264,79 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 				controller.abort();
 			}, timeoutMs);
 
-			await sessionManager.withExistingSession(tenant, sandboxId, async (session) => {
-				try {
-					const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-						signal: controller.signal,
-						cwd: body.cwd,
-						env,
-					});
-					clearTimeout(timer);
+			const runner = readOnly
+				? sessionManager.withSessionRead.bind(sessionManager)
+				: sessionManager.withExistingSession.bind(sessionManager);
+			try {
+				await runner(tenant, sandboxId, async (session) => {
+					try {
+						const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
+							signal: controller.signal,
+							cwd: body.cwd,
+							env,
+						});
+						clearTimeout(timer);
 
-					if (timedOut) {
+						if (timedOut) {
+							await stream.writeSSE({
+								event: "exit",
+								data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							});
+							return;
+						}
+
+						if (result.stdout) {
+							await stream.writeSSE({
+								event: "stdout",
+								data: JSON.stringify({ t: "stdout", data: result.stdout }),
+							});
+						}
+						if (result.stderr) {
+							await stream.writeSSE({
+								event: "stderr",
+								data: JSON.stringify({ t: "stderr", data: result.stderr }),
+							});
+						}
 						await stream.writeSSE({
 							event: "exit",
-							data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							data: JSON.stringify({ t: "exit", exitCode: result.exitCode, durationMs: Date.now() - startMs }),
 						});
-						return;
+					} catch (e) {
+						clearTimeout(timer);
+						if (timedOut) {
+							await stream.writeSSE({
+								event: "exit",
+								data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							});
+							return;
+						}
+						throw e;
 					}
-
-					if (result.stdout) {
-						await stream.writeSSE({
-							event: "stdout",
-							data: JSON.stringify({ t: "stdout", data: result.stdout }),
-						});
-					}
-					if (result.stderr) {
-						await stream.writeSSE({
-							event: "stderr",
-							data: JSON.stringify({ t: "stderr", data: result.stderr }),
-						});
-					}
+				});
+			} catch (err) {
+				clearTimeout(timer);
+				if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+					await stream.writeSSE({
+						event: "error",
+						data: JSON.stringify({
+							t: "error",
+							code: "EREADONLY_VIOLATION",
+							error: "readOnly script attempted to mutate the filesystem",
+						}),
+					});
 					await stream.writeSSE({
 						event: "exit",
-						data: JSON.stringify({ t: "exit", exitCode: result.exitCode, durationMs: Date.now() - startMs }),
+						data: JSON.stringify({
+							t: "exit",
+							exitCode: -1,
+							durationMs: Date.now() - startMs,
+							error: "read_only_violation",
+						}),
 					});
-				} catch (e) {
-					clearTimeout(timer);
-					if (timedOut) {
-						await stream.writeSSE({
-							event: "exit",
-							data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
-						});
-						return;
-					}
-					throw e;
+					return;
 				}
-			});
+				throw err;
+			}
 		});
 	});
 
@@ -328,16 +370,22 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		let results: BatchScriptResult[];
 		try {
-			results = await withOwnedSessionOrRehydrate<BatchScriptResult[]>(
-				sessionManager,
-				tenant,
-				sandboxId,
-				c.get("owner"),
-				async (session) =>
-					executeBatch(sessionManager, session, body.scripts, totalTimeoutMs, disconnectController.signal),
+			const runner = body.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			results = await runner<BatchScriptResult[]>(sessionManager, tenant, sandboxId, c.get("owner"), async (session) =>
+				executeBatch(sessionManager, session, body.scripts, totalTimeoutMs, disconnectController.signal),
 			);
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
+			if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+				return c.json(
+					{
+						error: "read_only_violation",
+						code: "EREADONLY_VIOLATION",
+						details: ["readOnly script attempted to mutate the filesystem"],
+					},
+					422 as ContentfulStatusCode,
+				);
+			}
 			throw err;
 		}
 

--- a/src/api/rw-lock.ts
+++ b/src/api/rw-lock.ts
@@ -1,0 +1,185 @@
+/**
+ * Async readers-writer lock with writer-priority.
+ *
+ * Contract:
+ *  - Multiple readers can hold the lock simultaneously (shared mode).
+ *  - At most one writer can hold the lock at a time (exclusive mode).
+ *  - While a writer holds the lock, no readers run.
+ *  - Writer-priority: when an exclusive waiter is queued, new shared
+ *    acquisitions wait behind it. This prevents reader starvation of the
+ *    (rare) writers that mutate the sandbox.
+ *  - Aborting via `signal` cancels a pending acquisition; it never affects an
+ *    already-held lock. Aborted waiters surface `Error('ABORTED')` with
+ *    `code: "ABORTED"` and `name: "AbortError"`.
+ *
+ * Drop-in compatible with the `runExclusive` shape used by `async-mutex`:
+ * existing call sites that previously held a `Mutex` may use this lock with
+ * no changes.
+ */
+
+type LockMode = "shared" | "exclusive";
+
+interface Waiter {
+	readonly mode: LockMode;
+	resolve: () => void;
+	reject: (err: Error) => void;
+	readonly signal: AbortSignal | undefined;
+	onAbort: (() => void) | undefined;
+	settled: boolean;
+}
+
+function makeAbortError(): Error {
+	return Object.assign(new Error("ABORTED"), { code: "ABORTED", name: "AbortError" });
+}
+
+export class RWLock {
+	#readers = 0;
+	#writerActive = false;
+	readonly #queue: Waiter[] = [];
+
+	/** Active reader count (for diagnostics/tests). */
+	get activeReaders(): number {
+		return this.#readers;
+	}
+
+	/** True iff a writer currently holds the lock. */
+	get writerHeld(): boolean {
+		return this.#writerActive;
+	}
+
+	/** Pending acquisitions that have not yet been granted. */
+	get pendingCount(): number {
+		let n = 0;
+		for (const w of this.#queue) if (!w.settled) n++;
+		return n;
+	}
+
+	async runShared<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.#acquire("shared", signal);
+		try {
+			return await fn();
+		} finally {
+			this.#releaseShared();
+		}
+	}
+
+	async runExclusive<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.#acquire("exclusive", signal);
+		try {
+			return await fn();
+		} finally {
+			this.#releaseExclusive();
+		}
+	}
+
+	#acquire(mode: LockMode, signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) return Promise.reject(makeAbortError());
+
+		if (mode === "shared") {
+			// Writer-priority: a queued writer blocks new readers, even if the
+			// lock is currently free or held in shared mode.
+			if (!this.#writerActive && !this.#hasQueuedWriter()) {
+				this.#readers++;
+				return Promise.resolve();
+			}
+		} else {
+			if (!this.#writerActive && this.#readers === 0) {
+				this.#writerActive = true;
+				return Promise.resolve();
+			}
+		}
+		return this.#enqueue(mode, signal);
+	}
+
+	#enqueue(mode: LockMode, signal: AbortSignal | undefined): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			const waiter: Waiter = {
+				mode,
+				resolve: () => {},
+				reject: () => {},
+				signal,
+				onAbort: undefined,
+				settled: false,
+			};
+			waiter.resolve = (): void => {
+				if (waiter.settled) return;
+				waiter.settled = true;
+				if (waiter.signal !== undefined && waiter.onAbort !== undefined) {
+					waiter.signal.removeEventListener("abort", waiter.onAbort);
+				}
+				resolve();
+			};
+			waiter.reject = (err: Error): void => {
+				if (waiter.settled) return;
+				waiter.settled = true;
+				if (waiter.signal !== undefined && waiter.onAbort !== undefined) {
+					waiter.signal.removeEventListener("abort", waiter.onAbort);
+				}
+				const idx = this.#queue.indexOf(waiter);
+				if (idx >= 0) this.#queue.splice(idx, 1);
+				reject(err);
+			};
+			if (signal !== undefined) {
+				const onAbort = (): void => waiter.reject(makeAbortError());
+				waiter.onAbort = onAbort;
+				signal.addEventListener("abort", onAbort, { once: true });
+			}
+			this.#queue.push(waiter);
+		});
+	}
+
+	#releaseShared(): void {
+		if (this.#readers === 0) {
+			throw new Error("RWLock: releaseShared called with no active readers");
+		}
+		this.#readers--;
+		if (this.#readers === 0) this.#dispatch();
+	}
+
+	#releaseExclusive(): void {
+		if (!this.#writerActive) {
+			throw new Error("RWLock: releaseExclusive called with no active writer");
+		}
+		this.#writerActive = false;
+		this.#dispatch();
+	}
+
+	#dispatch(): void {
+		// Discard any settled waiters at the head (aborted while queued).
+		while (this.#queue.length > 0 && this.#queue[0]!.settled) this.#queue.shift();
+		if (this.#queue.length === 0) return;
+		if (this.#writerActive) return;
+
+		const head = this.#queue[0]!;
+		if (head.mode === "exclusive") {
+			if (this.#readers > 0) return;
+			this.#queue.shift();
+			this.#writerActive = true;
+			head.resolve();
+			return;
+		}
+
+		// Wake every consecutive shared waiter until we hit a writer or empty
+		// the queue. This batches a parallel-reader handoff into a single
+		// dispatch pass.
+		while (this.#queue.length > 0) {
+			const next = this.#queue[0]!;
+			if (next.settled) {
+				this.#queue.shift();
+				continue;
+			}
+			if (next.mode !== "shared") break;
+			this.#queue.shift();
+			this.#readers++;
+			next.resolve();
+		}
+	}
+
+	#hasQueuedWriter(): boolean {
+		for (const w of this.#queue) {
+			if (w.settled) continue;
+			if (w.mode === "exclusive") return true;
+		}
+		return false;
+	}
+}

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -23,6 +23,7 @@ import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sq
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { logAudit } from "./lib/audit.js";
+import { type ReadOnlyContext, readOnlyContext } from "./read-only-context.js";
 import { RWLock } from "./rw-lock.js";
 import type { TenantConfig } from "./tenants.js";
 
@@ -53,11 +54,7 @@ function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 
 function asReadOnlyFs(fs: IFileSystem): IReadOnlyScopeFs | undefined {
 	const partial = fs as Partial<IReadOnlyScopeFs>;
-	if (
-		typeof partial.beginReadOnlyScope === "function" &&
-		typeof partial.endReadOnlyScope === "function" &&
-		typeof partial.readOnlyScopeActive === "boolean"
-	) {
+	if (typeof partial.beginReadOnlyScope === "function" && typeof partial.endReadOnlyScope === "function") {
 		return fs as IReadOnlyScopeFs;
 	}
 	return undefined;
@@ -549,43 +546,50 @@ export class SessionManager {
 			if (session.state === "closing") {
 				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 			}
+			const roFs = asReadOnlyFs(session.fs);
+			const ctx: ReadOnlyContext = { violated: false };
+
 			session.inFlight++;
 			session.lastUsed = Date.now();
-			const roFs = asReadOnlyFs(session.fs);
 			let scopeOpened = false;
-			if (roFs !== undefined) {
-				roFs.beginReadOnlyScope();
-				scopeOpened = true;
-			}
-			let primaryError: unknown;
-			let result: T | undefined;
-			let succeeded = false;
 			try {
-				result = await fn(session);
-				succeeded = true;
-			} catch (err) {
-				primaryError = err;
-			}
-			const violated = scopeOpened && roFs !== undefined && roFs.readOnlyViolated;
-			if (scopeOpened && roFs !== undefined) {
-				try {
-					roFs.endReadOnlyScope();
-				} catch {
-					// best-effort: scope toggle should not mask the primary error
+				if (roFs !== undefined) {
+					roFs.beginReadOnlyScope();
+					scopeOpened = true;
 				}
+				// `readOnlyContext.run` propagates `ctx` down the async stack into
+				// `bash.exec` → `SqlFs.#assertWritable`, which marks *this* call's
+				// context (not a shared FS flag). Innocent concurrent readers keep
+				// their own `ctx.violated === false`.
+				const result = await readOnlyContext.run(ctx, () => fn(session));
+				if (ctx.violated) {
+					logAudit("read_only_violation", { tenantId, sandboxId });
+					throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
+						code: "EREADONLY_VIOLATION",
+					});
+				}
+				return result;
+			} finally {
+				if (scopeOpened && roFs !== undefined) {
+					try {
+						roFs.endReadOnlyScope();
+					} catch (err) {
+						// Scope toggle must not mask the primary error; log and continue.
+						console.error(
+							JSON.stringify({
+								event: "end_read_only_scope_error",
+								tenantId,
+								sandboxId,
+								error: (err as Error).message,
+							}),
+						);
+					}
+				}
+				session.inFlight--;
+				// readOnly path never writes — no path-budget refresh, no version
+				// publish. The dirty flag is preserved so a subsequent writer's
+				// publishVersionIfDirty still fires (defense-in-depth).
 			}
-			session.inFlight--;
-			// readOnly path never writes — no path-budget refresh, no version
-			// publish. The dirty flag is preserved so a subsequent writer's
-			// publishVersionIfDirty still fires (defense-in-depth).
-			if (primaryError !== undefined) throw primaryError;
-			if (violated && succeeded) {
-				logAudit("read_only_violation", { tenantId, sandboxId });
-				throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
-					code: "EREADONLY_VIOLATION",
-				});
-			}
-			return result as T;
 		});
 	}
 
@@ -1064,8 +1068,13 @@ export class SessionManager {
 		const usesPython = session.runtimeOptions.python && PYTHON_INVOCATION_REGEX.test(script);
 		const usesJs = session.runtimeOptions.javascript && JS_INVOCATION_REGEX.test(script);
 
+		// readOnly execs skip scriptTx entirely: the FS rejects all writes via
+		// EREADONLY before any DB call, so the per-script transaction has
+		// nothing to commit, and beginScope/endScope on the shared SessionScopedFs
+		// would race across concurrent parallel readers.
+		const inReadOnlyScope = readOnlyContext.getStore() !== undefined;
 		const execFn = async (): Promise<BashExecResult> => {
-			if (session.scriptTx !== undefined) {
+			if (!inReadOnlyScope && session.scriptTx !== undefined) {
 				session.scriptTx.beginScope();
 				try {
 					const result = await session.bash.exec(script, opts);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -12,7 +12,6 @@
  * collisions are impossible.
  */
 
-import { Mutex } from "async-mutex";
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
 import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
@@ -20,10 +19,11 @@ import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/in
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import { SessionScopedFs } from "../fs/sql-fs/session-scoped-fs.js";
-import type { ICoherentFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
+import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { logAudit } from "./lib/audit.js";
+import { RWLock } from "./rw-lock.js";
 import type { TenantConfig } from "./tenants.js";
 
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
@@ -47,6 +47,18 @@ function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 		typeof partial.clearDirty === "function"
 	) {
 		return fs as ICoherentFs;
+	}
+	return undefined;
+}
+
+function asReadOnlyFs(fs: IFileSystem): IReadOnlyScopeFs | undefined {
+	const partial = fs as Partial<IReadOnlyScopeFs>;
+	if (
+		typeof partial.beginReadOnlyScope === "function" &&
+		typeof partial.endReadOnlyScope === "function" &&
+		typeof partial.readOnlyScopeActive === "boolean"
+	) {
+		return fs as IReadOnlyScopeFs;
 	}
 	return undefined;
 }
@@ -90,7 +102,12 @@ export interface Session {
 	readonly scriptTx: SessionScopedFs | undefined;
 	lastUsed: number;
 	inFlight: number;
-	readonly mutex: Mutex;
+	/**
+	 * Per-session async readers-writer lock. Writes (default exec path,
+	 * destroy, reaper, shutdown) take exclusive mode; readOnly execs take
+	 * shared mode and run in parallel.
+	 */
+	readonly lock: RWLock;
 	state: "active" | "closing";
 	owner: string;
 	name: string | null;
@@ -99,6 +116,13 @@ export interface Session {
 	overBudget: boolean;
 	destroyPromise?: Promise<void>;
 	lastSeenVersion: number;
+	/**
+	 * Single-flight guard for `ensureFreshCache`. While set, parallel readers
+	 * (and any concurrent writer entry) await the same probe + reload rather
+	 * than each issuing their own Redis GET / coherent.reload(). Cleared on
+	 * settle (success or failure).
+	 */
+	freshCacheInflight?: Promise<void>;
 	/**
 	 * Set to true when a previous turn's `publishVersionIfDirty` call failed
 	 * (the write committed to Postgres but the Redis INCR errored). The next
@@ -398,7 +422,7 @@ export class SessionManager {
 					scriptTx,
 					lastUsed: Date.now(),
 					inFlight: 0,
-					mutex: new Mutex(),
+					lock: new RWLock(),
 					state: "active",
 					owner: resolvedOwner,
 					name: null,
@@ -441,7 +465,7 @@ export class SessionManager {
 		return withDistributedLock(this.redis, execLockKey(tenantId, sandboxId), fn, this.execLockOptions);
 	}
 
-	/** Shared entry logic for all session wrappers. Must be called inside the distributed exec lock. */
+	/** Shared entry logic for all exclusive (write) session wrappers. */
 	private async withSessionEntry<T>(
 		tenantId: string,
 		sandboxId: string,
@@ -454,7 +478,7 @@ export class SessionManager {
 
 		await this.ensureFreshCache(tenantId, sandboxId, session);
 
-		return session.mutex.runExclusive(async () => {
+		return session.lock.runExclusive(async () => {
 			if (session.state === "closing") {
 				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 			}
@@ -499,29 +523,109 @@ export class SessionManager {
 		});
 	}
 
+	/**
+	 * Shared entry logic for the readOnly path. Holds the per-session RWLock
+	 * in shared mode so multiple readers run in parallel, and skips the
+	 * distributed exec lock + script-tx (no writes are permitted). The
+	 * session FS is put into read-only scope before fn runs and restored on
+	 * exit so any mutating syscall throws EREADONLY.
+	 *
+	 * Single-replica only: cross-replica visibility relies on the eventual
+	 * version-probe done by `ensureFreshCache` on the next op, same as today.
+	 */
+	private async withSessionReadEntry<T>(
+		tenantId: string,
+		sandboxId: string,
+		session: Session,
+		fn: (session: Session) => Promise<T>,
+	): Promise<T> {
+		if (session.state === "closing") {
+			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+		}
+
+		await this.ensureFreshCache(tenantId, sandboxId, session);
+
+		return session.lock.runShared(async () => {
+			if (session.state === "closing") {
+				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+			}
+			session.inFlight++;
+			session.lastUsed = Date.now();
+			const roFs = asReadOnlyFs(session.fs);
+			let scopeOpened = false;
+			if (roFs !== undefined) {
+				roFs.beginReadOnlyScope();
+				scopeOpened = true;
+			}
+			let primaryError: unknown;
+			let result: T | undefined;
+			let succeeded = false;
+			try {
+				result = await fn(session);
+				succeeded = true;
+			} catch (err) {
+				primaryError = err;
+			}
+			const violated = scopeOpened && roFs !== undefined && roFs.readOnlyViolated;
+			if (scopeOpened && roFs !== undefined) {
+				try {
+					roFs.endReadOnlyScope();
+				} catch {
+					// best-effort: scope toggle should not mask the primary error
+				}
+			}
+			session.inFlight--;
+			// readOnly path never writes — no path-budget refresh, no version
+			// publish. The dirty flag is preserved so a subsequent writer's
+			// publishVersionIfDirty still fires (defense-in-depth).
+			if (primaryError !== undefined) throw primaryError;
+			if (violated && succeeded) {
+				logAudit("read_only_violation", { tenantId, sandboxId });
+				throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
+					code: "EREADONLY_VIOLATION",
+				});
+			}
+			return result as T;
+		});
+	}
+
 	private async ensureFreshCache(tenantId: string, sandboxId: string, session: Session): Promise<void> {
 		if (this.redis === undefined) return;
 		const coherent = asCoherentFs(session.fs);
 		if (coherent === undefined) return;
 
-		let current: number;
-		try {
-			const raw = await this.redis.get(versionKey(tenantId, sandboxId));
-			current = raw === null ? 0 : Number(raw) || 0;
-		} catch (err) {
-			// Redis unavailable — can't determine whether the cache is fresh.
-			// Reload from Postgres so we don't serve stale data.
-			console.error(JSON.stringify({ event: "version_get_error", sandboxId, error: (err as Error).message }));
-			await coherent.reload();
-			return;
-		}
+		// Single-flight: parallel readers (and the rare writer that races
+		// them) share one Redis GET + reload() round trip. Without this,
+		// N concurrent readOnly execs would each issue their own probe and
+		// — on version mismatch — N concurrent loadAllPaths against
+		// Postgres.
+		const existing = session.freshCacheInflight;
+		if (existing !== undefined) return existing;
 
-		if (session.lastSeenVersion !== current) {
-			await coherent.reload();
-			session.lastSeenVersion = current;
-			coherent.clearDirty();
-			return;
-		}
+		const probe = (async (): Promise<void> => {
+			let current: number;
+			try {
+				const raw = await this.redis!.get(versionKey(tenantId, sandboxId));
+				current = raw === null ? 0 : Number(raw) || 0;
+			} catch (err) {
+				// Redis unavailable — can't determine whether the cache is fresh.
+				// Reload from Postgres so we don't serve stale data.
+				console.error(JSON.stringify({ event: "version_get_error", sandboxId, error: (err as Error).message }));
+				await coherent.reload();
+				return;
+			}
+
+			if (session.lastSeenVersion !== current) {
+				await coherent.reload();
+				session.lastSeenVersion = current;
+				coherent.clearDirty();
+			}
+		})().finally(() => {
+			session.freshCacheInflight = undefined;
+		});
+
+		session.freshCacheInflight = probe;
+		return probe;
 	}
 
 	private async publishVersionIfDirty(tenantId: string, sandboxId: string, session: Session): Promise<void> {
@@ -593,6 +697,53 @@ export class SessionManager {
 			}
 			return this.withSessionEntry(tenantId, sandboxId, session, fn);
 		});
+	}
+
+	/**
+	 * readOnly entry point. Acquires the per-session RWLock in shared mode so
+	 * multiple readers run in parallel, skips the distributed exec lock, and
+	 * activates a read-only scope on the session FS so any mutating syscall
+	 * throws EREADONLY at the offending command.
+	 *
+	 * Falls back to Postgres rehydrate (like withSessionOrRehydrate) when the
+	 * session was evicted from the in-memory pool but the sandbox still
+	 * exists in the persistent store.
+	 */
+	async withSessionRead<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
+		if (session !== undefined && session.state !== "closing") {
+			return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
+		}
+		return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions);
+	}
+
+	private async rehydrateAndExecRead<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		let meta: SandboxMeta | null | undefined;
+		if (this.getSandboxMetaFn !== undefined) {
+			meta = await this.getSandboxMetaFn(tenantId, sandboxId);
+			if (meta === null) {
+				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+			}
+		} else {
+			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+		}
+		const resolvedRuntime: RuntimeOptions = meta
+			? { python: meta.python, javascript: meta.javascript }
+			: (runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS);
+		const session = await this.getOrCreate(tenantId, sandboxId, resolvedRuntime, meta?.owner ?? "");
+		if (meta?.owner) session.owner = meta.owner;
+		if (meta?.name !== undefined) session.name = meta.name;
+		return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
 	}
 
 	/**
@@ -679,7 +830,7 @@ export class SessionManager {
 
 			session.state = "closing";
 
-			const p = session.mutex.runExclusive(async () => {
+			const p = session.lock.runExclusive(async () => {
 				this.sessions.delete(key);
 				// Disconnect the FS unconditionally — even if destroySandboxFn,
 				// version-key deletion, or path-snapshot cleanup throws — so the
@@ -777,7 +928,7 @@ export class SessionManager {
 				const remaining = Math.max(0, deadline - Date.now());
 				try {
 					await Promise.race([
-						session.mutex.runExclusive(async () => {
+						session.lock.runExclusive(async () => {
 							/* drain */
 						}),
 						new Promise<void>((resolve) => setTimeout(resolve, remaining)),
@@ -820,7 +971,7 @@ export class SessionManager {
 				// against a disconnected filesystem.
 				session.state = "closing";
 				this.sessions.delete(key);
-				void session.mutex
+				void session.lock
 					.runExclusive(async () => {
 						/* drain queued waiters; they will throw ESESSIONCLOSING */
 					})

--- a/src/api/tests/unit/exec.test.ts
+++ b/src/api/tests/unit/exec.test.ts
@@ -305,6 +305,71 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("readOnly:true routes through withSessionRead (parallel-safe path)", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		const readSpy = vi.spyOn(sessionManager, "withSessionRead");
+		const writeSpy = vi.spyOn(sessionManager, "withSessionOrRehydrate");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo readonly", readOnly: true }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(readSpy).toHaveBeenCalledTimes(1);
+		expect(writeSpy).not.toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+	});
+
+	it("readOnly:false (default) keeps using withSessionOrRehydrate", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		const readSpy = vi.spyOn(sessionManager, "withSessionRead");
+		const writeSpy = vi.spyOn(sessionManager, "withSessionOrRehydrate");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo write" }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect(readSpy).not.toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+	});
+
+	it("EREADONLY_VIOLATION from a lying readOnly script returns HTTP 422", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		// Force the lock-managed read entry to throw the violation we'd see
+		// from the safety net. We're testing the route mapping, not the
+		// underlying enforcement (which is unit-tested at SqlFs level).
+		vi.spyOn(sessionManager, "withSessionRead").mockRejectedValue(
+			Object.assign(new Error("EREADONLY_VIOLATION"), { code: "EREADONLY_VIOLATION" }),
+		);
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo lying > /tmp/x", readOnly: true }),
+		});
+
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("EREADONLY_VIOLATION");
+
+		vi.restoreAllMocks();
+	});
+
 	it("debug mode prepends set -x and produces trace output in stderr", async () => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);

--- a/src/api/tests/unit/rw-lock.test.ts
+++ b/src/api/tests/unit/rw-lock.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for the async readers-writer lock primitive used by the
+ * parallel-readOnly bash exec path.
+ *
+ * Coverage:
+ *  - Multiple readers run in parallel under shared mode.
+ *  - Writer waits for in-flight readers to drain before entering.
+ *  - New readers wait when a writer is queued (writer-priority — no
+ *    reader-starvation).
+ *  - Writers wait for prior writer to release.
+ *  - Aborting a queued waiter cancels it without affecting holders.
+ *  - fn errors release the lock.
+ */
+
+import { describe, expect, it } from "vitest";
+import { RWLock } from "../../rw-lock.js";
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe("RWLock", () => {
+	it("runs multiple shared acquisitions in parallel", async () => {
+		const lock = new RWLock();
+		let active = 0;
+		let peak = 0;
+		const work = async (): Promise<void> => {
+			active++;
+			peak = Math.max(peak, active);
+			await tick();
+			active--;
+		};
+
+		await Promise.all([lock.runShared(work), lock.runShared(work), lock.runShared(work), lock.runShared(work)]);
+
+		expect(peak).toBe(4);
+		expect(lock.activeReaders).toBe(0);
+		expect(lock.writerHeld).toBe(false);
+	});
+
+	it("a writer waits for in-flight readers to drain", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const reader1 = lock.runShared(async () => {
+			order.push("r1-acquired");
+			await new Promise<void>((res) => {
+				release1 = res;
+			});
+			order.push("r1-released");
+		});
+
+		await tick();
+		expect(lock.activeReaders).toBe(1);
+
+		const writer = lock.runExclusive(async () => {
+			order.push("w-acquired");
+		});
+
+		// Writer must not run while reader holds shared lock.
+		await tick();
+		await tick();
+		expect(order).toEqual(["r1-acquired"]);
+		expect(lock.writerHeld).toBe(false);
+
+		release1();
+		await reader1;
+		await writer;
+		expect(order).toEqual(["r1-acquired", "r1-released", "w-acquired"]);
+		expect(lock.writerHeld).toBe(false);
+	});
+
+	it("new readers wait when a writer is queued (writer-priority)", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const reader1 = lock.runShared(async () => {
+			order.push("r1-acquired");
+			await new Promise<void>((res) => {
+				release1 = res;
+			});
+			order.push("r1-released");
+		});
+		await tick();
+
+		// Queue a writer behind the in-flight reader.
+		const writer = lock.runExclusive(async () => {
+			order.push("w-acquired");
+		});
+		await tick();
+
+		// New readers arrive while the writer is queued — they must wait
+		// behind the writer (no reader-starvation of the writer).
+		const reader2 = lock.runShared(async () => {
+			order.push("r2-acquired");
+		});
+		const reader3 = lock.runShared(async () => {
+			order.push("r3-acquired");
+		});
+		await tick();
+
+		expect(order).toEqual(["r1-acquired"]);
+
+		release1();
+		await Promise.all([reader1, writer, reader2, reader3]);
+
+		// Writer entered before the queued readers, then both readers proceeded
+		// in parallel after the writer released.
+		expect(order).toEqual([
+			"r1-acquired",
+			"r1-released",
+			"w-acquired",
+			expect.stringMatching(/^r[23]-acquired$/),
+			expect.stringMatching(/^r[23]-acquired$/),
+		]);
+	});
+
+	it("queued shared waiters batch-wake after a writer releases", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const writer = lock.runExclusive(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		let active = 0;
+		let peak = 0;
+		const reader = (): Promise<void> =>
+			lock.runShared(async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await tick();
+				active--;
+			});
+
+		const readers = Promise.all([reader(), reader(), reader()]);
+		await tick();
+		expect(peak).toBe(0); // none have entered yet
+
+		release();
+		await writer;
+		await readers;
+		expect(peak).toBe(3); // all three woke up in one dispatch and ran in parallel
+	});
+
+	it("subsequent writer waits for prior writer", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const w1 = lock.runExclusive(async () => {
+			order.push("w1-acquired");
+			await new Promise<void>((r) => {
+				release1 = r;
+			});
+		});
+		await tick();
+		const w2 = lock.runExclusive(async () => {
+			order.push("w2-acquired");
+		});
+		await tick();
+		expect(order).toEqual(["w1-acquired"]);
+		release1();
+		await Promise.all([w1, w2]);
+		expect(order).toEqual(["w1-acquired", "w2-acquired"]);
+	});
+
+	it("aborts a queued shared acquisition without affecting holders", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const writer = lock.runExclusive(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		const ac = new AbortController();
+		const reader = lock.runShared(async () => {
+			throw new Error("must not run");
+		}, ac.signal);
+		await tick();
+		expect(lock.pendingCount).toBe(1);
+
+		ac.abort();
+		await expect(reader).rejects.toMatchObject({ code: "ABORTED" });
+		expect(lock.pendingCount).toBe(0);
+
+		release();
+		await writer;
+	});
+
+	it("aborts a queued exclusive acquisition without affecting holders", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const reader = lock.runShared(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		const ac = new AbortController();
+		const writer = lock.runExclusive(async () => {
+			throw new Error("must not run");
+		}, ac.signal);
+		await tick();
+		ac.abort();
+		await expect(writer).rejects.toMatchObject({ code: "ABORTED" });
+
+		release();
+		await reader;
+
+		// Lock is fully drained; a fresh exclusive should acquire immediately.
+		await lock.runExclusive(async () => {});
+	});
+
+	it("rejects immediately for a pre-aborted signal", async () => {
+		const lock = new RWLock();
+		const ac = new AbortController();
+		ac.abort();
+		await expect(lock.runShared(async () => {}, ac.signal)).rejects.toMatchObject({ code: "ABORTED" });
+		await expect(lock.runExclusive(async () => {}, ac.signal)).rejects.toMatchObject({ code: "ABORTED" });
+		expect(lock.pendingCount).toBe(0);
+	});
+
+	it("releases the lock when fn throws", async () => {
+		const lock = new RWLock();
+		await expect(
+			lock.runExclusive(async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(lock.writerHeld).toBe(false);
+
+		await expect(
+			lock.runShared(async () => {
+				throw new Error("boom2");
+			}),
+		).rejects.toThrow("boom2");
+		expect(lock.activeReaders).toBe(0);
+
+		// Lock is reusable post-error.
+		await lock.runExclusive(async () => {});
+	});
+});

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for SessionManager's parallel-readOnly bash exec entry point.
+ *
+ * Coverage:
+ *  - Multiple withSessionRead calls run in parallel against the same sandbox.
+ *  - withSessionRead waits for an in-flight write; a new write waits for
+ *    in-flight readers.
+ *  - The session FS is put into a read-only scope before fn runs and
+ *    restored on exit; a violated flag surfaces EREADONLY_VIOLATION.
+ *  - ensureFreshCache is single-flighted across parallel readers (one Redis
+ *    GET, one reload).
+ */
+
+import type { Redis } from "ioredis";
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+const T = "default";
+
+/**
+ * Minimal IReadOnlyScopeFs that piggybacks on InMemoryFs. Tracks scope
+ * begin/end calls and exposes a `simulateViolation()` switch the test can
+ * flip to mark the FS as having attempted a write under read-only scope.
+ */
+class TestReadOnlyFs {
+	readonly inner: InMemoryFs;
+	readOnlyScopeActive = false;
+	readOnlyViolated = false;
+	beginCount = 0;
+	endCount = 0;
+	constructor() {
+		this.inner = new InMemoryFs();
+	}
+	beginReadOnlyScope(): void {
+		if (this.readOnlyScopeActive) throw new Error("scope already active");
+		this.readOnlyScopeActive = true;
+		this.readOnlyViolated = false;
+		this.beginCount++;
+	}
+	endReadOnlyScope(): void {
+		this.readOnlyScopeActive = false;
+		this.endCount++;
+	}
+	simulateViolation(): void {
+		this.readOnlyViolated = true;
+	}
+}
+
+function adaptReadOnlyFs(host: TestReadOnlyFs): IFileSystem {
+	// Proxy: forward IFileSystem calls to InMemoryFs but expose the
+	// IReadOnlyScopeFs surface (begin/end/active/violated) on the same
+	// object so SessionManager's `asReadOnlyFs` duck-typed check sees it.
+	const fs = host.inner as unknown as Record<string, unknown>;
+	const merged = new Proxy(host as unknown as Record<string, unknown>, {
+		get(target, prop, receiver) {
+			if (prop in target) return Reflect.get(target, prop, receiver);
+			const v = fs[prop as string];
+			return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(host.inner) : v;
+		},
+	});
+	return merged as unknown as IFileSystem;
+}
+
+/** Minimal ICoherentFs around InMemoryFs so ensureFreshCache will probe Redis. */
+class CoherentInMemoryFs {
+	readonly inner: InMemoryFs;
+	#dirty = false;
+	reloadCount = 0;
+	constructor() {
+		this.inner = new InMemoryFs();
+	}
+	wasDirty(): boolean {
+		return this.#dirty;
+	}
+	clearDirty(): void {
+		this.#dirty = false;
+	}
+	async reload(): Promise<void> {
+		this.reloadCount++;
+	}
+}
+
+function adaptCoherentFs(host: CoherentInMemoryFs): IFileSystem {
+	const fs = host.inner as unknown as Record<string, unknown>;
+	return new Proxy(host as unknown as Record<string, unknown>, {
+		get(target, prop, receiver) {
+			if (prop in target) return Reflect.get(target, prop, receiver);
+			const v = fs[prop as string];
+			return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(host.inner) : v;
+		},
+	}) as unknown as IFileSystem;
+}
+
+describe("SessionManager.withSessionRead", () => {
+	it("multiple readOnly calls run in parallel on the same sandbox", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-parallel");
+
+		let active = 0;
+		let peak = 0;
+		const work = async (): Promise<void> => {
+			active++;
+			peak = Math.max(peak, active);
+			await new Promise((r) => setImmediate(r));
+			active--;
+		};
+
+		await Promise.all([
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+		]);
+
+		expect(peak).toBeGreaterThanOrEqual(2); // at minimum, parallel
+		expect(peak).toBe(4); // exact: all four ran simultaneously
+	});
+
+	it("readOnly waits for an in-flight writer", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-w-blocks-r");
+		const order: string[] = [];
+
+		let releaseW!: () => void;
+		const writer = sm.withSession(T, "sb-w-blocks-r", async () => {
+			order.push("w-start");
+			await new Promise<void>((r) => {
+				releaseW = r;
+			});
+			order.push("w-end");
+		});
+
+		// Wait for writer to enter
+		await new Promise((r) => setImmediate(r));
+
+		const reader = sm.withSessionRead(T, "sb-w-blocks-r", async () => {
+			order.push("r-start");
+			order.push("r-end");
+		});
+
+		await new Promise((r) => setImmediate(r));
+		expect(order).toEqual(["w-start"]);
+
+		releaseW();
+		await Promise.all([writer, reader]);
+		expect(order).toEqual(["w-start", "w-end", "r-start", "r-end"]);
+	});
+
+	it("a writer waits for in-flight readers and queues new readers behind it", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-r-blocks-w");
+		const order: string[] = [];
+
+		let releaseR1!: () => void;
+		const reader1 = sm.withSessionRead(T, "sb-r-blocks-w", async () => {
+			order.push("r1-start");
+			await new Promise<void>((r) => {
+				releaseR1 = r;
+			});
+			order.push("r1-end");
+		});
+		await new Promise((r) => setImmediate(r));
+
+		const writer = sm.withSession(T, "sb-r-blocks-w", async () => {
+			order.push("w-acquired");
+		});
+		await new Promise((r) => setImmediate(r));
+
+		// New reader must wait behind the queued writer (writer-priority)
+		const reader2 = sm.withSessionRead(T, "sb-r-blocks-w", async () => {
+			order.push("r2-acquired");
+		});
+		await new Promise((r) => setImmediate(r));
+		expect(order).toEqual(["r1-start"]);
+
+		releaseR1();
+		await Promise.all([reader1, writer, reader2]);
+		expect(order).toEqual(["r1-start", "r1-end", "w-acquired", "r2-acquired"]);
+	});
+
+	it("opens and closes the read-only scope around fn on a scoped FS", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-scope");
+
+		let activeDuringFn: boolean | undefined;
+		await sm.withSessionRead(T, "sb-scope", async () => {
+			activeDuringFn = host.readOnlyScopeActive;
+		});
+		expect(activeDuringFn).toBe(true);
+		expect(host.readOnlyScopeActive).toBe(false);
+		expect(host.beginCount).toBe(1);
+		expect(host.endCount).toBe(1);
+	});
+
+	it("surfaces EREADONLY_VIOLATION when fn returns successfully but the FS recorded a violation", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-violation");
+
+		await expect(
+			sm.withSessionRead(T, "sb-violation", async () => {
+				host.simulateViolation();
+			}),
+		).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
+
+		// Scope is still closed even on the violation throw
+		expect(host.readOnlyScopeActive).toBe(false);
+		expect(host.endCount).toBe(1);
+	});
+
+	it("preserves the original error when fn throws even if a violation was recorded", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-violation-throw");
+
+		await expect(
+			sm.withSessionRead(T, "sb-violation-throw", async () => {
+				host.simulateViolation();
+				throw new Error("script blew up");
+			}),
+		).rejects.toThrow("script blew up");
+		expect(host.readOnlyScopeActive).toBe(false);
+	});
+
+	it("single-flights ensureFreshCache across parallel readers", async () => {
+		// Fake Redis that records every GET. The probe done by getOrCreate
+		// for the initial version returns immediately; the probes done by
+		// ensureFreshCache for the parallel readers block on `block` so we
+		// can observe how many concurrent GETs are in-flight.
+		const getCalls: string[] = [];
+		let blockReads = false;
+		let onceResolve!: () => void;
+		const block = new Promise<void>((r) => {
+			onceResolve = r;
+		});
+		const fakeRedis: Partial<Redis> = {
+			get: vi.fn(async (key: string) => {
+				getCalls.push(key);
+				if (blockReads) await block;
+				return "0";
+			}),
+			incr: vi.fn(async () => 1),
+			expire: vi.fn(async () => 1),
+		};
+
+		const host = new CoherentInMemoryFs();
+		const sm = new SessionManager({
+			createFs: async () => adaptCoherentFs(host),
+			redis: fakeRedis as Redis,
+		});
+		await sm.getOrCreate(T, "sb-single-flight");
+		const initialGets = getCalls.length;
+		blockReads = true;
+
+		// Five readers in flight before the first GET resolves.
+		const readers = Array.from({ length: 5 }, () => sm.withSessionRead(T, "sb-single-flight", async () => "ok"));
+
+		// Let the readers reach ensureFreshCache.
+		await new Promise((r) => setImmediate(r));
+		await new Promise((r) => setImmediate(r));
+		// All five share one in-flight GET (single-flight ensureFreshCache).
+		expect(getCalls.length - initialGets).toBe(1);
+
+		onceResolve();
+		await Promise.all(readers);
+		// And no extra GET was issued for the rest of the cohort.
+		expect(getCalls.length - initialGets).toBe(1);
+
+		await sm.shutdown();
+	});
+});

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -15,43 +15,46 @@ import type { Redis } from "ioredis";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { describe, expect, it, vi } from "vitest";
+import { readOnlyContext } from "../../read-only-context.js";
 import { SessionManager } from "../../session-manager.js";
 
 const T = "default";
 
 /**
- * Minimal IReadOnlyScopeFs that piggybacks on InMemoryFs. Tracks scope
- * begin/end calls and exposes a `simulateViolation()` switch the test can
- * flip to mark the FS as having attempted a write under read-only scope.
+ * Reference-counted IReadOnlyScopeFs that piggybacks on InMemoryFs. The
+ * production SqlFs uses the same refcount + AsyncLocalStorage scheme — this
+ * mock tracks depth so concurrent readers don't collide on a boolean flag.
+ *
+ * The host also exposes `simulateViolation(ctx)` so a test can mark a
+ * specific reader's `readOnlyContext` store as violated, exercising the
+ * per-cohort attribution path the SessionManager uses.
  */
 class TestReadOnlyFs {
 	readonly inner: InMemoryFs;
-	readOnlyScopeActive = false;
-	readOnlyViolated = false;
+	depth = 0;
 	beginCount = 0;
 	endCount = 0;
 	constructor() {
 		this.inner = new InMemoryFs();
 	}
+	get readOnlyScopeActive(): boolean {
+		return this.depth > 0;
+	}
 	beginReadOnlyScope(): void {
-		if (this.readOnlyScopeActive) throw new Error("scope already active");
-		this.readOnlyScopeActive = true;
-		this.readOnlyViolated = false;
+		this.depth++;
 		this.beginCount++;
 	}
 	endReadOnlyScope(): void {
-		this.readOnlyScopeActive = false;
+		if (this.depth === 0) throw new Error("no active read-only scope");
+		this.depth--;
 		this.endCount++;
-	}
-	simulateViolation(): void {
-		this.readOnlyViolated = true;
 	}
 }
 
 function adaptReadOnlyFs(host: TestReadOnlyFs): IFileSystem {
 	// Proxy: forward IFileSystem calls to InMemoryFs but expose the
-	// IReadOnlyScopeFs surface (begin/end/active/violated) on the same
-	// object so SessionManager's `asReadOnlyFs` duck-typed check sees it.
+	// IReadOnlyScopeFs surface (begin/end/active) on the same object so
+	// SessionManager's `asReadOnlyFs` duck-typed check sees it.
 	const fs = host.inner as unknown as Record<string, unknown>;
 	const merged = new Proxy(host as unknown as Record<string, unknown>, {
 		get(target, prop, receiver) {
@@ -94,15 +97,21 @@ function adaptCoherentFs(host: CoherentInMemoryFs): IFileSystem {
 }
 
 describe("SessionManager.withSessionRead", () => {
-	it("multiple readOnly calls run in parallel on the same sandbox", async () => {
-		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+	it("multiple readOnly calls run in parallel on the same sandbox (refcounted scope)", async () => {
+		// Uses a real IReadOnlyScopeFs mock so the refcount path is exercised.
+		// The pre-fix impl threw "scope already active" on the second concurrent
+		// reader against a scoped FS; this test would have caught that.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
 		await sm.getOrCreate(T, "sb-parallel");
 
 		let active = 0;
 		let peak = 0;
+		let peakDepth = 0;
 		const work = async (): Promise<void> => {
 			active++;
 			peak = Math.max(peak, active);
+			peakDepth = Math.max(peakDepth, host.depth);
 			await new Promise((r) => setImmediate(r));
 			active--;
 		};
@@ -114,8 +123,11 @@ describe("SessionManager.withSessionRead", () => {
 			sm.withSessionRead(T, "sb-parallel", work),
 		]);
 
-		expect(peak).toBeGreaterThanOrEqual(2); // at minimum, parallel
-		expect(peak).toBe(4); // exact: all four ran simultaneously
+		expect(peak).toBe(4); // all four ran simultaneously
+		expect(peakDepth).toBe(4); // refcount tracked all four under shared scope
+		expect(host.depth).toBe(0); // last reader cleared the scope
+		expect(host.beginCount).toBe(4);
+		expect(host.endCount).toBe(4);
 	});
 
 	it("readOnly waits for an in-flight writer", async () => {
@@ -195,20 +207,54 @@ describe("SessionManager.withSessionRead", () => {
 		expect(host.endCount).toBe(1);
 	});
 
-	it("surfaces EREADONLY_VIOLATION when fn returns successfully but the FS recorded a violation", async () => {
+	it("surfaces EREADONLY_VIOLATION when the per-call context was marked", async () => {
 		const host = new TestReadOnlyFs();
 		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
 		await sm.getOrCreate(T, "sb-violation");
 
 		await expect(
 			sm.withSessionRead(T, "sb-violation", async () => {
-				host.simulateViolation();
+				// Simulate the SqlFs `#assertWritable` path marking *this* call's
+				// AsyncLocalStorage context.
+				const ctx = readOnlyContext.getStore();
+				if (ctx !== undefined) ctx.violated = true;
 			}),
 		).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
 
 		// Scope is still closed even on the violation throw
 		expect(host.readOnlyScopeActive).toBe(false);
 		expect(host.endCount).toBe(1);
+	});
+
+	it("does not falsely flag an innocent concurrent reader when a sibling is lying", async () => {
+		// Two readers run in parallel under one shared scope. Reader A's fn
+		// triggers a violation on its own ALS context. Reader B's context
+		// stays clean — it must not surface EREADONLY_VIOLATION.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-mixed");
+
+		let releaseInnocent!: () => void;
+		const innocentBlocker = new Promise<void>((r) => {
+			releaseInnocent = r;
+		});
+
+		const liarP = sm.withSessionRead(T, "sb-mixed", async () => {
+			// Wait until innocent reader is also in-flight so depth is 2.
+			await new Promise((r) => setImmediate(r));
+			expect(host.depth).toBe(2);
+			const ctx = readOnlyContext.getStore();
+			if (ctx !== undefined) ctx.violated = true;
+		});
+
+		const innocentP = sm.withSessionRead(T, "sb-mixed", async () => {
+			await innocentBlocker;
+		});
+
+		await expect(liarP).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
+		releaseInnocent();
+		await expect(innocentP).resolves.toBeUndefined();
+		expect(host.depth).toBe(0);
 	});
 
 	it("preserves the original error when fn throws even if a violation was recorded", async () => {
@@ -218,11 +264,28 @@ describe("SessionManager.withSessionRead", () => {
 
 		await expect(
 			sm.withSessionRead(T, "sb-violation-throw", async () => {
-				host.simulateViolation();
+				const ctx = readOnlyContext.getStore();
+				if (ctx !== undefined) ctx.violated = true;
 				throw new Error("script blew up");
 			}),
 		).rejects.toThrow("script blew up");
 		expect(host.readOnlyScopeActive).toBe(false);
+	});
+
+	it("does not leak inFlight when fn throws", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		const session = await sm.getOrCreate(T, "sb-inflight");
+		expect(session.inFlight).toBe(0);
+
+		await expect(
+			sm.withSessionRead(T, "sb-inflight", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		expect(session.inFlight).toBe(0);
+		expect(host.depth).toBe(0);
 	});
 
 	it("single-flights ensureFreshCache across parallel readers", async () => {

--- a/src/fs/sql-fs/errors.ts
+++ b/src/fs/sql-fs/errors.ts
@@ -50,6 +50,16 @@ export function createEinval(path: string): Error {
 	return makeFsError("EINVAL", `EINVAL: invalid argument, '${path}'`, path);
 }
 
+/**
+ * EREADONLY: write attempted while the filesystem is in read-only scope.
+ * Surfaced when a `readOnly: true` exec script tries to mutate state. The
+ * session-manager wraps the script-level handler so the offending command
+ * fails fast and other concurrent readers never observe partial state.
+ */
+export function createEreadonly(path: string, op: string): Error {
+	return makeFsError("EREADONLY", `EREADONLY: read-only filesystem, ${op} '${path}'`, path);
+}
+
 // ── Sensitive-pattern stripping ───────────────────────────────────────────────
 
 /** Patterns whose matches are replaced with [redacted] in sanitized error messages. */

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -13,6 +13,7 @@ import type { CpOptions, FileContent, FsStat, IFileSystem, MkdirOptions, RmOptio
 import { DefenseInDepthBox } from "just-bash";
 import { LRUCache } from "lru-cache";
 
+import { readOnlyContext } from "../../api/read-only-context.js";
 import {
 	createEexist,
 	createEinval,
@@ -126,21 +127,17 @@ export interface IScriptTxFs extends ICoherentFs {
  * EREADONLY immediately — the offending bash command fails fast and no
  * partial state escapes to other concurrent readers.
  *
- * SqlFs satisfies this interface; the `memory` backend does not (its
- * factory wraps it separately when needed).
+ * Reference-counted: every concurrent reader calls `beginReadOnlyScope`
+ * on entry and `endReadOnlyScope` on exit. The scope stays active while
+ * any reader holds it. Violation attribution is per-call via the
+ * `readOnlyContext` AsyncLocalStorage rather than an FS-level flag, so
+ * a lying script in one reader cannot falsely flag innocent readers
+ * sharing the same FS.
  */
 export interface IReadOnlyScopeFs extends IFileSystem {
 	beginReadOnlyScope(): void;
 	endReadOnlyScope(): void;
 	readonly readOnlyScopeActive: boolean;
-	/**
-	 * True iff at least one mutating syscall was attempted while the
-	 * read-only scope was active. Cleared on the next `beginReadOnlyScope`.
-	 * Used by the session manager to surface a structured violation error
-	 * after the bash script returns even though the offending command
-	 * itself just exited non-zero.
-	 */
-	readonly readOnlyViolated: boolean;
 }
 
 export class SqlFs<Tx = unknown> implements ICoherentFs {
@@ -176,8 +173,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	#scriptTxEnd: (() => void) | undefined;
 	#scriptTxAbort: ((err: Error) => void) | undefined;
 	#scriptTxPromise: Promise<void> | undefined;
-	#readOnlyScope = false;
-	#readOnlyViolated = false;
+	#readOnlyDepth = 0;
 
 	constructor(opts: SqlFsOptions<Tx>) {
 		this.#dialect = opts.dialect;
@@ -571,28 +567,31 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	// ── Read-only scope (parallel readOnly bash exec) ────────────────────────────
 
 	get readOnlyScopeActive(): boolean {
-		return this.#readOnlyScope;
+		return this.#readOnlyDepth > 0;
 	}
 
-	get readOnlyViolated(): boolean {
-		return this.#readOnlyViolated;
-	}
-
+	/**
+	 * Reference-counted: every concurrent reader bumps the depth, the last
+	 * one to exit clears it. The shared SqlFs is mutation-locked while any
+	 * reader holds a scope. Per-cohort violation attribution is delegated
+	 * to `readOnlyContext` (AsyncLocalStorage) so a lying script in one
+	 * reader never falsely flags innocent concurrent readers.
+	 */
 	beginReadOnlyScope(): void {
-		if (this.#readOnlyScope) {
-			throw new Error("beginReadOnlyScope: a read-only scope is already active");
-		}
-		this.#readOnlyScope = true;
-		this.#readOnlyViolated = false;
+		this.#readOnlyDepth++;
 	}
 
 	endReadOnlyScope(): void {
-		this.#readOnlyScope = false;
+		if (this.#readOnlyDepth === 0) {
+			throw new Error("endReadOnlyScope: no active read-only scope");
+		}
+		this.#readOnlyDepth--;
 	}
 
 	#assertWritable(path: string, op: string): void {
-		if (this.#readOnlyScope) {
-			this.#readOnlyViolated = true;
+		if (this.#readOnlyDepth > 0) {
+			const ctx = readOnlyContext.getStore();
+			if (ctx !== undefined) ctx.violated = true;
 			throw createEreadonly(path, op);
 		}
 	}

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -21,6 +21,7 @@ import {
 	createEnotdir,
 	createEnotempty,
 	createEperm,
+	createEreadonly,
 } from "./errors.js";
 import type { RedisBlobCache } from "./redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "./redis-path-snapshot.js";
@@ -119,6 +120,29 @@ export interface IScriptTxFs extends ICoherentFs {
 	readonly scriptTxOpen: boolean;
 }
 
+/**
+ * Read-only scope hooks used by the parallel-readOnly bash exec path. While
+ * the scope is active every mutating method on the filesystem throws
+ * EREADONLY immediately — the offending bash command fails fast and no
+ * partial state escapes to other concurrent readers.
+ *
+ * SqlFs satisfies this interface; the `memory` backend does not (its
+ * factory wraps it separately when needed).
+ */
+export interface IReadOnlyScopeFs extends IFileSystem {
+	beginReadOnlyScope(): void;
+	endReadOnlyScope(): void;
+	readonly readOnlyScopeActive: boolean;
+	/**
+	 * True iff at least one mutating syscall was attempted while the
+	 * read-only scope was active. Cleared on the next `beginReadOnlyScope`.
+	 * Used by the session manager to surface a structured violation error
+	 * after the bash script returns even though the offending command
+	 * itself just exited non-zero.
+	 */
+	readonly readOnlyViolated: boolean;
+}
+
 export class SqlFs<Tx = unknown> implements ICoherentFs {
 	readonly #dialect: SqlDialect<Tx>;
 	readonly #sandboxId: string;
@@ -152,6 +176,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	#scriptTxEnd: (() => void) | undefined;
 	#scriptTxAbort: ((err: Error) => void) | undefined;
 	#scriptTxPromise: Promise<void> | undefined;
+	#readOnlyScope = false;
+	#readOnlyViolated = false;
 
 	constructor(opts: SqlFsOptions<Tx>) {
 		this.#dialect = opts.dialect;
@@ -542,6 +568,35 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		this.#scriptScope = true;
 	}
 
+	// ── Read-only scope (parallel readOnly bash exec) ────────────────────────────
+
+	get readOnlyScopeActive(): boolean {
+		return this.#readOnlyScope;
+	}
+
+	get readOnlyViolated(): boolean {
+		return this.#readOnlyViolated;
+	}
+
+	beginReadOnlyScope(): void {
+		if (this.#readOnlyScope) {
+			throw new Error("beginReadOnlyScope: a read-only scope is already active");
+		}
+		this.#readOnlyScope = true;
+		this.#readOnlyViolated = false;
+	}
+
+	endReadOnlyScope(): void {
+		this.#readOnlyScope = false;
+	}
+
+	#assertWritable(path: string, op: string): void {
+		if (this.#readOnlyScope) {
+			this.#readOnlyViolated = true;
+			throw createEreadonly(path, op);
+		}
+	}
+
 	async endScriptScope(): Promise<void> {
 		if (!this.#scriptScope) return;
 		this.#scriptScope = false;
@@ -594,6 +649,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	// shadowing each other — the dialect would commit only one and drop the rest.
 	async bulkIngest(files: BulkIngestFile[]): Promise<void> {
 		if (files.length === 0) return;
+		this.#assertWritable("/", "bulkIngest");
 		const normalized: BulkIngestFile[] = [];
 		const seen = new Set<string>();
 		const bytesByPath = new Map<string, Uint8Array>();
@@ -631,6 +687,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async writeFile(inputPath: string, content: FileContent, _options?: WriteFileOpts): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "writeFile");
 		const { name, parentEntry } = this.#requireParentDir(path);
 
 		const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
@@ -682,6 +739,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async appendFile(inputPath: string, content: FileContent, _options?: WriteFileOpts): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "appendFile");
 
 		const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
 		const mtime = new Date();
@@ -749,6 +807,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async mkdir(inputPath: string, options?: MkdirOptions): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "mkdir");
 		const recursive = options?.recursive ?? false;
 		const mtime = new Date();
 
@@ -826,6 +885,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async rm(inputPath: string, options?: RmOptions): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "rm");
 		const entry = this.#pathCache.get(path);
 
 		if (!entry) {
@@ -897,6 +957,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async chmod(inputPath: string, mode: number): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "chmod");
 		const entry = this.#pathCache.get(path);
 		if (!entry) throw createEnoent(path);
 
@@ -910,6 +971,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async utimes(inputPath: string, _atime: Date, mtime: Date): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "utimes");
 		const entry = this.#pathCache.get(path);
 		if (!entry) throw createEnoent(path);
 
@@ -1026,6 +1088,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async cp(inputSrc: string, inputDest: string, options?: CpOptions): Promise<void> {
 		const src = validatePath(inputSrc);
 		const dest = validatePath(inputDest);
+		this.#assertWritable(dest, "cp");
 		const srcEntry = this.#pathCache.get(src);
 		if (!srcEntry) throw createEnoent(src);
 
@@ -1114,6 +1177,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async mv(inputSrc: string, inputDest: string): Promise<void> {
 		const src = validatePath(inputSrc);
 		const dest = validatePath(inputDest);
+		this.#assertWritable(dest, "mv");
 		const srcEntry = this.#pathCache.get(src);
 		if (!srcEntry) throw createEnoent(src);
 
@@ -1191,6 +1255,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async symlink(target: string, inputLinkPath: string): Promise<void> {
 		const linkPath = validatePath(inputLinkPath);
+		this.#assertWritable(linkPath, "symlink");
 		// Note: target is intentionally not normalized - it's stored as-is
 		if (target.includes("\0")) throw createEinval(target);
 		if (!this.#allowSymlinks) throw createEperm(linkPath, "symlink");
@@ -1226,6 +1291,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async link(inputExistingPath: string, inputNewPath: string): Promise<void> {
 		const existingPath = validatePath(inputExistingPath);
 		const newPath = validatePath(inputNewPath);
+		this.#assertWritable(newPath, "link");
 		const srcEntry = this.#pathCache.get(existingPath);
 		if (!srcEntry) throw createEnoent(existingPath);
 		if (srcEntry.kind === INODE_KIND.DIRECTORY) throw createEperm(existingPath, "link");

--- a/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
+++ b/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readOnlyContext } from "../../../../api/read-only-context.js";
 import { SqlFs } from "../../sql-fs.js";
 import type { PathCacheEntry, SqlDialect } from "../../types.js";
 
@@ -92,15 +93,26 @@ describe("SqlFs.readOnlyScope", () => {
 		expect(fs.readOnlyScopeActive).toBe(false);
 	});
 
-	it("nested begin throws", () => {
+	it("ref-counts nested begin/end (parallel readers)", () => {
 		fs.beginReadOnlyScope();
-		expect(() => fs.beginReadOnlyScope()).toThrow(/already active/);
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true);
 		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true); // still held by the first begin
+		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
+	});
+
+	it("endReadOnlyScope without an active scope throws", () => {
+		expect(() => fs.endReadOnlyScope()).toThrow(/no active read-only scope/);
 	});
 
 	it("writeFile throws EREADONLY before issuing any DB call", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		const ctx = { violated: false };
+		await readOnlyContext.run(ctx, async () => {
+			await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
 		// The throw happens before any new transaction is opened — only the
 		// initial loadAllPaths transaction from ready() may have run.
 		expect(dialect.upsertBlob).not.toHaveBeenCalled();
@@ -108,22 +120,43 @@ describe("SqlFs.readOnlyScope", () => {
 		expect(dialect.upsertDirent).not.toHaveBeenCalled();
 		expect(dialect.deleteDirent).not.toHaveBeenCalled();
 		expect(dialect.updateInode).not.toHaveBeenCalled();
-		expect(fs.readOnlyViolated).toBe(true);
+		expect(ctx.violated).toBe(true);
+		fs.endReadOnlyScope();
+	});
+
+	it("violation marks only the originating reader's context, not concurrent ones", async () => {
+		fs.beginReadOnlyScope();
+		fs.beginReadOnlyScope();
+		const ctxLying = { violated: false };
+		const ctxInnocent = { violated: false };
+
+		await readOnlyContext.run(ctxLying, async () => {
+			await expect(fs.writeFile("/lie.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
+		await readOnlyContext.run(ctxInnocent, async () => {
+			await fs.exists("/file.txt");
+		});
+
+		expect(ctxLying.violated).toBe(true);
+		expect(ctxInnocent.violated).toBe(false);
+		fs.endReadOnlyScope();
 		fs.endReadOnlyScope();
 	});
 
 	it("appendFile, mkdir, rm, chmod, utimes, cp, mv, link all throw EREADONLY", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
-			code: "EREADONLY",
+		await readOnlyContext.run({ violated: false }, async () => {
+			await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
+				code: "EREADONLY",
+			});
 		});
 		// The throw happens before any new transaction is opened — only the
 		// initial loadAllPaths transaction from ready() may have run.
@@ -137,7 +170,9 @@ describe("SqlFs.readOnlyScope", () => {
 
 	it("symlink also throws EREADONLY (even before the symlinks-disabled check)", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await readOnlyContext.run({ violated: false }, async () => {
+			await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
 		fs.endReadOnlyScope();
 	});
 
@@ -151,19 +186,24 @@ describe("SqlFs.readOnlyScope", () => {
 		fs.endReadOnlyScope();
 	});
 
-	it("after end, writes succeed again and the violated flag persists until the next begin", async () => {
+	it("after the last end, writes succeed again and #assertWritable is a no-op", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
-		expect(fs.readOnlyViolated).toBe(true);
+		const ctx = { violated: false };
+		await readOnlyContext.run(ctx, async () => {
+			await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
+		expect(ctx.violated).toBe(true);
 		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
 
-		// Outside the scope the violated flag is sticky until the next
-		// beginReadOnlyScope resets it — that's intentional so the session
-		// manager can read it after fn returns.
-		expect(fs.readOnlyViolated).toBe(true);
-
-		fs.beginReadOnlyScope();
-		expect(fs.readOnlyViolated).toBe(false);
-		fs.endReadOnlyScope();
+		// A fresh context outside any scope is never marked as violated —
+		// even if a context is in scope, writes are unguarded once depth is 0.
+		const fresh = { violated: false };
+		await readOnlyContext.run(fresh, async () => {
+			// Reads obviously work; writes would also work (we don't actually
+			// fire one to avoid the dialect mocks; the depth check is enough).
+			expect(fs.readOnlyScopeActive).toBe(false);
+		});
+		expect(fresh.violated).toBe(false);
 	});
 });

--- a/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
+++ b/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for SqlFs read-only scope (parallel readOnly bash exec).
+ *
+ * Coverage:
+ *  - Begin/end scope toggles the active flag.
+ *  - Every mutating method throws EREADONLY while the scope is active.
+ *  - The violated flag flips to true on the first attempted mutation and is
+ *    reset on the next beginReadOnlyScope.
+ *  - Read methods continue to work while the scope is active.
+ *  - No DB write methods are dispatched (dialect mocks remain uncalled) — the
+ *    rejection is a fast pre-DB guard.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "../../sql-fs.js";
+import type { PathCacheEntry, SqlDialect } from "../../types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+const ROOT: { path: string } & PathCacheEntry = {
+	path: "/",
+	inodeId: 1n,
+	kind: 2,
+	mode: 0o755,
+	size: 0,
+	mtime: now,
+	contentSha256: null,
+	symlinkTarget: null,
+};
+
+const FILE: { path: string } & PathCacheEntry = {
+	path: "/file.txt",
+	inodeId: 10n,
+	kind: 1,
+	mode: 0o644,
+	size: 5,
+	mtime: now,
+	contentSha256: new Uint8Array(32),
+	symlinkTarget: null,
+};
+
+function makeFs() {
+	const dialect = {
+		connect: vi.fn(),
+		disconnect: vi.fn(),
+		transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+		setSandboxContext: vi.fn(),
+		setSandboxContextWithLock: vi.fn(),
+		loadAllPaths: vi.fn(async () => [ROOT, FILE]),
+		createSandbox: vi.fn(),
+		deleteSandbox: vi.fn(),
+		createInode: vi.fn(),
+		getInode: vi.fn(),
+		updateInode: vi.fn(),
+		deleteInode: vi.fn(),
+		incrementNlink: vi.fn(),
+		decrementNlink: vi.fn(),
+		insertDirent: vi.fn(),
+		upsertDirent: vi.fn(),
+		deleteDirent: vi.fn(),
+		listDirents: vi.fn(),
+		moveDirent: vi.fn(),
+		upsertBlob: vi.fn(),
+		getBlob: vi.fn(async () => null),
+		getBlobNoTx: vi.fn(async () => null),
+		gcOrphanBlobs: vi.fn(),
+		getBlobsForSandbox: vi.fn(async () => []),
+		loadSubtreeInodes: vi.fn(async () => []),
+		bulkIngest: vi.fn(),
+		resolvePath: vi.fn(),
+	} as unknown as SqlDialect<unknown>;
+	const fs = new SqlFs({ dialect, sandboxId: "s1" });
+	return { fs, dialect };
+}
+
+describe("SqlFs.readOnlyScope", () => {
+	let fs: SqlFs;
+	let dialect: SqlDialect<unknown>;
+
+	beforeEach(async () => {
+		const made = makeFs();
+		fs = made.fs;
+		dialect = made.dialect;
+		await fs.ready();
+	});
+
+	it("begin/end toggles the active flag", () => {
+		expect(fs.readOnlyScopeActive).toBe(false);
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true);
+		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
+	});
+
+	it("nested begin throws", () => {
+		fs.beginReadOnlyScope();
+		expect(() => fs.beginReadOnlyScope()).toThrow(/already active/);
+		fs.endReadOnlyScope();
+	});
+
+	it("writeFile throws EREADONLY before issuing any DB call", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		// The throw happens before any new transaction is opened — only the
+		// initial loadAllPaths transaction from ready() may have run.
+		expect(dialect.upsertBlob).not.toHaveBeenCalled();
+		expect(dialect.createInode).not.toHaveBeenCalled();
+		expect(dialect.upsertDirent).not.toHaveBeenCalled();
+		expect(dialect.deleteDirent).not.toHaveBeenCalled();
+		expect(dialect.updateInode).not.toHaveBeenCalled();
+		expect(fs.readOnlyViolated).toBe(true);
+		fs.endReadOnlyScope();
+	});
+
+	it("appendFile, mkdir, rm, chmod, utimes, cp, mv, link all throw EREADONLY", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
+			code: "EREADONLY",
+		});
+		// The throw happens before any new transaction is opened — only the
+		// initial loadAllPaths transaction from ready() may have run.
+		expect(dialect.upsertBlob).not.toHaveBeenCalled();
+		expect(dialect.createInode).not.toHaveBeenCalled();
+		expect(dialect.upsertDirent).not.toHaveBeenCalled();
+		expect(dialect.deleteDirent).not.toHaveBeenCalled();
+		expect(dialect.updateInode).not.toHaveBeenCalled();
+		fs.endReadOnlyScope();
+	});
+
+	it("symlink also throws EREADONLY (even before the symlinks-disabled check)", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		fs.endReadOnlyScope();
+	});
+
+	it("read methods still work while the scope is active", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.exists("/file.txt")).resolves.toBe(true);
+		await expect(fs.exists("/missing")).resolves.toBe(false);
+		await expect(fs.readdir("/")).resolves.toEqual(["file.txt"]);
+		const stat = await fs.stat("/file.txt");
+		expect(stat.size).toBe(5);
+		fs.endReadOnlyScope();
+	});
+
+	it("after end, writes succeed again and the violated flag persists until the next begin", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		expect(fs.readOnlyViolated).toBe(true);
+		fs.endReadOnlyScope();
+
+		// Outside the scope the violated flag is sticky until the next
+		// beginReadOnlyScope resets it — that's intentional so the session
+		// manager can read it after fn returns.
+		expect(fs.readOnlyViolated).toBe(true);
+
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyViolated).toBe(false);
+		fs.endReadOnlyScope();
+	});
+});


### PR DESCRIPTION
## Summary

Implement parallel read-only bash execution on the same sandbox by introducing an async readers-writer lock primitive and read-only filesystem scope enforcement. This allows multiple `readOnly: true` exec requests to run concurrently without blocking each other, while maintaining mutual exclusion with write operations.

## Key Changes

- **New RWLock primitive** (`src/api/rw-lock.ts`): Async readers-writer lock with writer-priority to prevent reader starvation. Supports AbortSignal for cancellation and is drop-in compatible with `async-mutex`.

- **Read-only scope enforcement** (`src/fs/sql-fs/sql-fs.ts`): Added `IReadOnlyScopeFs` interface and implementation in SqlFs with `beginReadOnlyScope()` / `endReadOnlyScope()` methods. All mutating filesystem operations (writeFile, mkdir, rm, chmod, etc.) throw `EREADONLY` when scope is active, with a `readOnlyViolated` flag to track violations.

- **Session-level RWLock**: Replaced per-session `Mutex` with `RWLock` to enable shared (read) and exclusive (write) modes. Write operations (default exec, destroy, reaper) use exclusive mode; `readOnly` execs use shared mode.

- **New `withSessionRead` entry point** (`src/api/session-manager.ts`): Parallel-safe session access that:
  - Holds the per-session RWLock in shared mode (multiple readers run in parallel)
  - Skips the distributed exec lock and script-tx (no writes permitted)
  - Wraps the session FS in read-only scope before executing user code
  - Single-flights `ensureFreshCache` across parallel readers to avoid redundant Redis probes

- **API support for `readOnly` flag**: Added optional `readOnly: true` parameter to:
  - POST `/v1/sandboxes/:id/exec-sync` 
  - POST `/v1/sandboxes/:id/exec` (streaming)
  - POST `/v1/sandboxes/:id/exec-batch`
  - MCP `bash_execute` tool

- **Error handling**: New `EREADONLY_VIOLATION` error (HTTP 422) when a `readOnly` script attempts to mutate the filesystem. Preserves original script errors if both an error and violation occur.

- **Comprehensive test coverage**: Unit tests for RWLock (parallel readers, writer-priority, abort handling), SqlFs read-only scope (all mutating methods blocked, reads still work), and SessionManager parallel readOnly behavior (single-flighted cache, scope lifecycle, violation detection).

## Implementation Details

- **Writer-priority**: When an exclusive waiter is queued, new shared acquisitions wait behind it, preventing writer starvation while allowing parallel readers.
- **Single-flighted cache**: The `freshCacheInflight` promise on Session ensures parallel readers share a single Redis GET and coherent.reload() call.
- **Scope lifecycle**: Read-only scope is opened before user code runs and closed afterward, even if the code throws or violates the scope.
- **Single-replica only**: Cross-replica visibility relies on eventual version probes on the next operation (same as today).

https://claude.ai/code/session_01L7gJusfPoYnaTpFadV68dT