### PR TITLE
feat(exec): parallel readOnly bash exec with reader-writer lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-05-11
+
+### Fixed
+
+- ReadOnly bash exec: a synchronous `EREADONLY` thrown by `SqlFs#assertWritable` that escapes `bash.exec` (e.g. via shell redirections like `echo x > /file`) is now remapped to `EREADONLY_VIOLATION` in `withSessionReadEntry`, so route handlers consistently return HTTP **422** instead of falling through to the generic 500. The narrow `code === "EREADONLY"` check preserves the existing behavior of letting unrelated `fn` errors win over a recorded violation.
+
 ## [0.3.0] - 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-05-11
+
+### Changed
+
+- `DEVELOPER.md`: documented the parallel-readOnly architecture. Core Data Flow now covers both write (`runExclusive`) and read (`runShared`) paths; Lock 1 rewritten as the `RWLock` (writer-priority, batch-wake, AbortSignal); new "ReadOnly Safety Model" section explains the three cooperating mechanisms (shared lock + refcounted FS scope + `readOnlyContext` AsyncLocalStorage attribution) and the `EREADONLY` → `EREADONLY_VIOLATION` remap; same-replica concurrency matrix and "what each lock catches" table extended for readOnly; Key Source Files lists `rw-lock.ts`, `read-only-context.ts`, `ownership.ts`, and `mcp/tools.ts`.
+
 ## [0.3.2] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Parallel readOnly bash exec on the same sandbox (single-replica). Callers opt in by passing `readOnly: true` on `/v1/sandboxes/:id/exec`, `/exec-sync`, `/exec-sync-batch`, and the MCP `bash_exec` / `bash_exec_batch` tools. ReadOnly execs route through the new `SessionManager.withSessionRead`: they take a per-session async readers-writer lock in *shared* mode (multiple readers run concurrently), skip the distributed exec lock, and share one single-flighted `ensureFreshCache` probe + reload across the cohort. Writes still take the lock exclusively and are writer-priority — a queued writer blocks new readers, preventing reader starvation.
-- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work, and the FS records the violation. After the script returns, the session manager surfaces a structured `EREADONLY_VIOLATION` error mapped to HTTP **422** so a lying readOnly script never silently succeeds. Violations are emitted via `logAudit("read_only_violation", ...)`.
+- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work. The scope is **reference-counted** so multiple concurrent readers share a single FS instance safely. Violation attribution uses an `AsyncLocalStorage`-based `readOnlyContext` so a lying script in one reader never falsely flags innocent concurrent readers — only the originating call's context is marked, and the session manager surfaces `EREADONLY_VIOLATION` (HTTP **422**) on that one call. Violations are emitted via `logAudit("read_only_violation", ...)`.
 - New async readers-writer lock primitive `RWLock` (`src/api/rw-lock.ts`) replaces `async-mutex`'s `Mutex` on `Session`. Drop-in `runExclusive` for existing call sites plus a new `runShared`. AbortSignal support cancels pending acquisitions cleanly.
+- OpenAPI spec documents the new `readOnly` request field on `/exec-sync`, `/exec`, and `/exec-sync-batch`, and the corresponding 422 response.
 
 ### Changed
 
 - `Session.mutex: Mutex` is now `Session.lock: RWLock`. The `async-mutex` runtime dependency is no longer used by `SessionManager`. All exclusive-mode call sites (`withSessionEntry`, `destroy`, reaper, shutdown) are unchanged in semantics.
+- `execWithRuntimeThrottle` skips the per-script `scriptTx.beginScope/endScope` wrapper when the call is inside a `readOnlyContext` (no writes can occur, and the shared `SessionScopedFs` would race across concurrent readers).
+- `withSessionReadEntry` is now wrapped in `try/finally` so `session.inFlight` and `endReadOnlyScope` always run even when `fn` throws — fixes a counter leak that pinned sessions and prevented idle eviction.
 
 ## [0.2.20] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-05-11
+
+### Added
+
+- `portless` dev dependency, `portless.json` (`virtualfs-api`), and `pnpm dev:portless` to run the dev server behind stable `https://…localhost` URLs (including per-branch subdomains in git worktrees).
+
 ## [0.3.1] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-10
+
+### Added
+
+- Parallel readOnly bash exec on the same sandbox (single-replica). Callers opt in by passing `readOnly: true` on `/v1/sandboxes/:id/exec`, `/exec-sync`, `/exec-sync-batch`, and the MCP `bash_exec` / `bash_exec_batch` tools. ReadOnly execs route through the new `SessionManager.withSessionRead`: they take a per-session async readers-writer lock in *shared* mode (multiple readers run concurrently), skip the distributed exec lock, and share one single-flighted `ensureFreshCache` probe + reload across the cohort. Writes still take the lock exclusively and are writer-priority — a queued writer blocks new readers, preventing reader starvation.
+- Read-only safety net on `SqlFs`: while a read-only scope is active every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB work, and the FS records the violation. After the script returns, the session manager surfaces a structured `EREADONLY_VIOLATION` error mapped to HTTP **422** so a lying readOnly script never silently succeeds. Violations are emitted via `logAudit("read_only_violation", ...)`.
+- New async readers-writer lock primitive `RWLock` (`src/api/rw-lock.ts`) replaces `async-mutex`'s `Mutex` on `Session`. Drop-in `runExclusive` for existing call sites plus a new `runShared`. AbortSignal support cancels pending acquisitions cleanly.
+
+### Changed
+
+- `Session.mutex: Mutex` is now `Session.lock: RWLock`. The `async-mutex` runtime dependency is no longer used by `SessionManager`. All exclusive-mode call sites (`withSessionEntry`, `destroy`, reaper, shutdown) are unchanged in semantics.
+
 ## [0.2.20] - 2026-05-09
 
 ### Fixed

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,9 +12,20 @@ virtualFS is a **stateless HTTP server** backed by Postgres, with warm in-proces
 
 In-process caches (pathCache, contentCache) exist purely for speed during a single exec. Redis exists for four things: serializing requests across replicas, tracking cache freshness via a version counter, caching blob bytes to avoid Postgres round-trips, and snapshotting the path tree to speed up cold starts. If you dropped Redis and all in-process caches, the system would still be correct — just slower.
 
+Within a single replica, two exec modes share the same `Session` and the same `SqlFs`:
+
+- **Write path (default)** — exclusive per-session lock; one exec at a time; the only path that can mutate the FS.
+- **Read path (`readOnly: true`)** — shared per-session lock; many concurrent execs; the FS is forced into a refcounted read-only scope and any mutating syscall throws `EREADONLY` pre-DB, surfaced to clients as HTTP **422 `EREADONLY_VIOLATION`**.
+
+The single-replica feature deliberately skips the distributed Redis exec lock for the read path — cross-replica coherence on reads still relies on the per-session version probe, see the "Multi-replica" sections below.
+
 ---
 
-## Core Data Flow: Single Exec
+## Core Data Flow
+
+There are two exec paths, distinguished by the caller-declared `readOnly` flag on the request body. Both share the same lock layer — they just acquire it in different modes (exclusive vs. shared).
+
+### Write path (`readOnly: false` — the default)
 
 ```
 POST /exec
@@ -31,12 +42,14 @@ SessionManager.withSession(tenantId, sandboxId, fn)
      │
      ├─[2] Version check ────────────────────────── cache freshness
      │       GET vfs:{tenant}:ver:{sandboxId}
+     │       (single-flighted across concurrent entries via session.freshCacheInflight,
+     │        so N parallel entries share one Redis GET + one fs.reload() if needed)
      │       if lastSeenVersion !== current
      │         → fs.reload() from Postgres
      │         → session.lastSeenVersion = current
      │
-     ├─[3] Acquire session.mutex ────────────────── in-process mutex
-     │       (async-mutex, per session, per replica)
+     ├─[3] Acquire session.lock in EXCLUSIVE mode ── in-process RWLock
+     │       (RWLock.runExclusive, per session, per replica)
      │
      ├─[4] bash.exec(script) ────────────────────── the actual work
      │       each SqlFs write:
@@ -49,16 +62,70 @@ SessionManager.withSession(tenantId, sandboxId, fn)
      │         blobCache.set(sha256, data) → Redis    ← fire-and-forget
      │         set #dirty = true
      │
-     ├─[5] Release session.mutex
-     │
-     ├─[6] publishVersionIfDirty
+     ├─[5] publishVersionIfDirty (still under exclusive lock)
      │       if #dirty:
      │         INCR vfs:{tenant}:ver:{sandboxId}
      │         session.lastSeenVersion = newVersion
      │         pathSnapshot.write(ver, pathCache) → Redis   ← cold-start cache (optional)
      │         clearDirty()
      │
+     ├─[6] Release session.lock (exclusive)
+     │       → RWLock dispatch wakes the next waiter:
+     │           • next exclusive writer (one), OR
+     │           • every consecutive shared (readOnly) waiter in one batch
+     │
      └─[7] Release Redis exec lock (Lua check-and-del)
+```
+
+### Read path (`readOnly: true`)
+
+Parallel readers on the same sandbox no longer queue behind each other. Multiple readOnly requests acquire the same `Session.lock` in **shared** mode and run concurrently.
+
+```
+POST /exec   { readOnly: true }
+     │
+     ▼
+Auth middleware
+     │
+     ▼
+SessionManager.withSessionRead(tenantId, sandboxId, fn)
+     │       ── NO distributed Redis exec lock (single-replica only feature; see "Multi-replica
+     │           consistency" caveat below)
+     │
+     ├─[1] Version check (single-flighted across the reader cohort)
+     │       same ensureFreshCache as write path
+     │
+     ├─[2] Acquire session.lock in SHARED mode ──── in-process RWLock
+     │       (RWLock.runShared — multiple readers run concurrently)
+     │       Writer-priority: if a writer is queued, new readers wait behind it.
+     │
+     ├─[3] fs.beginReadOnlyScope() ──────────────── refcounted, per-FS
+     │       every mutating SqlFs method now throws EREADONLY pre-DB
+     │       (writeFile, appendFile, mkdir, rm, chmod, utimes, cp, mv,
+     │        symlink, link, bulkIngest)
+     │
+     ├─[4] readOnlyContext.run(ctx, () => bash.exec(script))
+     │       AsyncLocalStorage propagates ctx down into SqlFs.#assertWritable,
+     │       which marks THIS call's ctx.violated rather than a shared FS flag.
+     │       → a lying script in one reader never falsely flags innocent siblings.
+     │       → scriptTx is SKIPPED — no writes can occur, and the shared
+     │         SessionScopedFs would race across concurrent readers.
+     │
+     ├─[5] After fn returns:
+     │       • if a raw EREADONLY escaped bash.exec (shell redirections like
+     │         `echo x > f` do this) → remap to EREADONLY_VIOLATION
+     │       • if ctx.violated (script completed but tagged a violation) →
+     │         throw EREADONLY_VIOLATION
+     │       → route layer maps EREADONLY_VIOLATION to HTTP 422
+     │
+     ├─[6] fs.endReadOnlyScope() ──────────────── decrements refcount;
+     │       last reader to leave clears the FS-level scope
+     │
+     └─[7] Release session.lock (shared)
+
+NOTE: the read path does NOT call publishVersionIfDirty. No writes ⇒ #dirty
+      stays false anyway, but the flag is preserved across read entries so a
+      subsequent writer's publish still fires correctly.
 ```
 
 ---
@@ -67,13 +134,28 @@ SessionManager.withSession(tenantId, sandboxId, fn)
 
 Three locks work together. Each is the fallback for the one above it.
 
-### Lock 1 — `session.mutex` (in-process)
+### Lock 1 — `session.lock` (in-process RWLock)
 
-- **Type:** `async-mutex` in the Node heap, one per `Session` object
+- **Type:** hand-rolled async readers-writer lock (`RWLock`, `src/api/rw-lock.ts`), one per `Session` object. Replaced the original `async-mutex`-based exclusive `Mutex` in `0.3.0`.
 - **Scope:** one replica, one sandbox
-- **Held for:** entire `bash.exec(script)` call
-- **Purpose:** prevents two concurrent requests on the *same replica* from interleaving inside `Bash` or `SqlFs`
-- **Cost:** zero network — pure microtask queue
+- **Modes:**
+  - **Exclusive** (`runExclusive`) — held for the entire `bash.exec(script)` call on the write path, plus `destroy`, reaper drain, and `shutdown`. One holder at a time.
+  - **Shared** (`runShared`) — held for the entire `bash.exec(script)` call on the readOnly path. Many holders at a time.
+- **Purpose:** prevents two writers on the *same replica* from interleaving inside `Bash` or `SqlFs`, while letting readOnly callers proceed in parallel against a refcounted read-only FS scope.
+- **Fairness:** writer-priority. A queued exclusive waiter blocks new shared acquisitions even when the lock is currently held in shared mode — readers cannot starve writers.
+- **Batch wake:** when a writer releases and the head of the wait queue is a reader, `#dispatch()` wakes *every* consecutive shared waiter in a single pass, so the whole reader cohort starts in parallel rather than via N separate dispatches.
+- **AbortSignal:** pending acquisitions (not held locks) honour `AbortSignal` — client disconnect / timeout on a queued reader/writer rejects cleanly with `code: "ABORTED"`.
+- **Cost:** zero network — pure microtask queue.
+
+**Invariants enforced by the lock:**
+
+| State | Meaning |
+|---|---|
+| `writerActive=true, readers=0` | one writer holds the lock; all other callers queue |
+| `writerActive=false, readers≥1` | N readers hold the lock; a writer queues, new readers also queue (writer-priority) |
+| `writerActive=false, readers=0` | lock is free; next dispatch picks the head waiter |
+
+Bypassing the lock to write directly to `SqlFs` from elsewhere in the codebase will break the read-only safety net. All exec entry must go through `SessionManager.withSession` / `withSessionRead` / `withSessionOrRehydrate`.
 
 ### Lock 2 — Redis exec lock (distributed)
 
@@ -112,11 +194,32 @@ Three locks work together. Each is the fallback for the one above it.
 
 | Scenario | Lock 1 | Lock 2 | Lock 3 |
 |---|---|---|---|
-| Two concurrent requests, same replica, same sandbox | blocks | redundant | redundant |
-| Two concurrent requests, different replicas, same sandbox | — | blocks | backstop |
+| Two concurrent writes, same replica, same sandbox | blocks (exclusive) | redundant | redundant |
+| Two concurrent writes, different replicas, same sandbox | — | blocks | backstop |
+| N concurrent readOnly reads, same replica, same sandbox | **lets them run in parallel (shared)** | (read path skips Lock 2) | not engaged (no writes) |
+| Mixed reader + writer, same replica | reader waits for writer / writer waits for readers; writer-priority | only the writer takes it | only the writer's DB tx |
 | GC pause > lease; second replica interleaves DB writes | — | fails | serializes at DB layer |
-| `DELETE /sandboxes/:id` races an active exec | — | blocks (routed through lock) | backstop |
+| `DELETE /sandboxes/:id` races an active exec | drains via exclusive acquire | blocks (routed through lock) | backstop |
 | Admin/test route bypasses `withSession` | — | — | still catches |
+
+---
+
+## ReadOnly Safety Model
+
+When `withSessionRead` is the entry point, three independent mechanisms cooperate to make parallel reads safe against a shared `SqlFs` instance:
+
+1. **`session.lock` in shared mode** — bounds the cohort. No writer can interleave; the FS instance is mutation-free for the duration.
+2. **`fs.beginReadOnlyScope()` / `endReadOnlyScope()`** on `SqlFs` — refcounted. Every mutating syscall (`writeFile`, `appendFile`, `mkdir`, `rm`, `chmod`, `utimes`, `cp`, `mv`, `symlink`, `link`, `bulkIngest`) throws `EREADONLY` *before* any DB call. The throw happens in `SqlFs.#assertWritable` and never reaches the dialect — so the dialect mocks in unit tests confirm zero spurious connections / transactions on violation.
+3. **`readOnlyContext` (AsyncLocalStorage)** — per-call violation attribution. When `SqlFs.#assertWritable` fires, it marks the *current* call's `ctx.violated = true`, not a boolean on the shared FS. This is what prevents a lying script in reader A from poisoning innocent reader B running in parallel.
+
+`SessionManager.withSessionReadEntry` then turns either signal into a uniform `EREADONLY_VIOLATION`:
+
+- If `bash.exec` rejects with a raw `EREADONLY` (some bash builtins, notably shell redirections like `echo x > f`, let the synchronous reject escape rather than normalising it to a non-zero exit), the catch re-throws as `EREADONLY_VIOLATION`.
+- Otherwise, after `fn` returns successfully, if `ctx.violated` was set, throw `EREADONLY_VIOLATION`.
+
+Route handlers (`/exec-sync`, `/exec` SSE, `/exec-sync-batch`, MCP `bash_exec` / `bash_exec_batch`) map `EREADONLY_VIOLATION` → HTTP **422**.
+
+**The `scriptTx` is intentionally bypassed in the read path** (`execWithRuntimeThrottle` inspects `readOnlyContext.getStore()`). The script transaction is a per-script DB transaction shared via `SessionScopedFs` — concurrent readers would race on its `beginScope`/`endScope`. Since no writes can occur, there is nothing for it to commit.
 
 ---
 
@@ -209,7 +312,16 @@ if fs.wasDirty():
 
 ### Same sandbox, same replica
 
-Request 2 acquires the Redis lock first (or tries to), then hits the `session.mutex`. It queues behind Request 1 at the mutex level. The two requests are fully serialized — no interleaving inside `Bash` or `SqlFs`.
+The behaviour depends on whether each request is `readOnly`:
+
+| Request A | Request B | Outcome on the same replica |
+|---|---|---|
+| write | write | B queues behind A at the Redis lock and at `session.lock` (exclusive). Fully serialized. |
+| write | readOnly | B skips the Redis lock but queues behind A at `session.lock` (shared waits for exclusive). |
+| readOnly | write | B grabs the Redis lock immediately, then queues at `session.lock` (exclusive waits for active readers). New readers arriving after B queue behind B (writer-priority). |
+| readOnly | readOnly | **Both run in parallel.** Both take `session.lock` in shared mode; the FS is in a refcounted read-only scope; any mutating syscall throws `EREADONLY` pre-DB and is remapped to HTTP 422 `EREADONLY_VIOLATION`. |
+
+Mixed read/write inside a *single script* is always handled on the write path — `readOnly` is a caller declaration, not auto-detected. An agent that issues a script with any chance of writing must leave `readOnly` unset (defaults to false).
 
 ### Same sandbox, different replicas
 
@@ -377,13 +489,18 @@ All Redis keys are tenant-prefixed to prevent cross-tenant collisions.
 
 | File | What it does |
 |---|---|
-| `src/api/session-manager.ts` | Owns the session pool, all three lock acquisitions, version check, dirty publish |
-| `src/fs/sql-fs/sql-fs.ts` | `SqlFs` class — all `IFileSystem` methods, pathCache, contentCache, `#dirty` flag, `reload()` |
+| `src/api/session-manager.ts` | Owns the session pool, all three lock acquisitions, write + read entries (`withSession`, `withSessionRead`, `withSessionOrRehydrate`), version check, dirty publish, `EREADONLY` → `EREADONLY_VIOLATION` remap |
+| `src/api/rw-lock.ts` | `RWLock` — hand-rolled async readers-writer lock used by `Session.lock`. Writer-priority, batch-wake for queued readers, `AbortSignal` support |
+| `src/api/read-only-context.ts` | `readOnlyContext` AsyncLocalStorage — per-call violation attribution for the parallel-readOnly path |
+| `src/api/ownership.ts` | `withOwnedSessionOrRehydrate` / `withOwnedSessionRead` — adds owner check inside the lock before delegating to `SessionManager` |
+| `src/fs/sql-fs/sql-fs.ts` | `SqlFs` class — all `IFileSystem` methods, pathCache, contentCache, `#dirty` flag, `reload()`, refcounted `beginReadOnlyScope`/`endReadOnlyScope`, `#assertWritable` |
 | `src/fs/sql-fs/dialects/postgres.ts` | Postgres dialect — `setSandboxContext` (RLS + advisory lock), blob cache read/write, all SQL |
 | `src/fs/sql-fs/session-scoped-fs.ts` | `ICoherentFs` interface — `reload`, `wasDirty`, `clearDirty` |
 | `src/fs/sql-fs/redis-blob-cache.ts` | Redis blob cache — `get`/`set` with TTL and size cap |
 | `src/fs/sql-fs/redis-path-snapshot.ts` | Version key helpers; path snapshot — cold-start pathCache bootstrap from Redis (off by default) |
-| `src/api/routes/exec.ts` | HTTP exec routes — funnels through `withSession` |
+| `src/api/routes/exec.ts` | HTTP exec routes — branches on `readOnly` to funnel through `withOwnedSessionOrRehydrate` (write) or `withOwnedSessionRead` (read); maps `EREADONLY_VIOLATION` → 422 |
+| `src/api/mcp/tools.ts` | MCP `bash_exec` / `bash_exec_batch` — same `readOnly` branching as HTTP routes |
+| `thoughts/shared/research/2026-05-10_13-03-37_parallel-readonly-bash-exec.md` | Design doc for the parallel-readOnly feature |
 | `tasks/arch-redis-caching-and-locking.md` | Full design doc for the multi-replica architecture |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.2.20",
+	"version": "0.3.0",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",
@@ -10,6 +10,7 @@
 	},
 	"scripts": {
 		"dev": "tsx watch src/api/server.ts",
+		"dev:portless": "portless",
 		"build": "tsc && node scripts/copy-postgres-migrations.mjs",
 		"start": "node dist/api/server.js",
 		"bench:remote-bash": "python3 scripts/benchmark_remote_bash.py",
@@ -54,6 +55,7 @@
 		"drizzle-kit": "^0.30.0",
 		"knip": "^6.4.1",
 		"lefthook": "^1.11.0",
+		"portless": "^0.13.0",
 		"tsx": "^4.19.0",
 		"typescript": "^5.7.0",
 		"vitest": "^3.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       lefthook:
         specifier: ^1.11.0
         version: 1.13.6
+      portless:
+        specifier: ^0.13.0
+        version: 0.13.0
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -2272,6 +2275,12 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  portless@0.13.0:
+    resolution: {integrity: sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw==}
+    engines: {node: '>=20'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -4779,6 +4788,8 @@ snapshots:
   pify@4.0.1: {}
 
   pkce-challenge@5.0.1: {}
+
+  portless@0.13.0: {}
 
   postcss@8.5.10:
     dependencies:

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,3 @@
+{
+	"name": "virtualfs-api"
+}

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -14,7 +14,7 @@ import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
 import { executeBatch } from "../lib/batch-exec.js";
-import { withOwnedSessionOrRehydrate } from "../ownership.js";
+import { withOwnedSessionOrRehydrate, withOwnedSessionRead } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -156,13 +156,20 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 			script: z.string(),
 			timeout: z.number().int().positive().optional(),
 			debug: z.boolean().optional().describe("When true, prepends 'set -x' for command-level tracing in stderr"),
+			readOnly: z
+				.boolean()
+				.optional()
+				.describe(
+					"When true, runs the script in read-only mode: parallel reads are unblocked across calls (no exclusive lock) and any mutating filesystem op is rejected with EREADONLY at the offending command.",
+				),
 		},
 		async (args) => {
 			const timeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 			const scriptToRun = args.debug ? `set -x\n${args.script}` : args.script;
+			const runner = args.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 
 			try {
-				const result = await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) => {
+				const result = await runner(sessionManager, tenant, args.id, owner, async (session) => {
 					const controller = new AbortController();
 					let timedOut = false;
 					const startMs = Date.now();
@@ -233,6 +240,21 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 						],
 					};
 				}
+				if (code === "EREADONLY_VIOLATION") {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									stdout: "",
+									stderr: "EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem",
+									exitCode: 1,
+									code: "EREADONLY_VIOLATION",
+								}),
+							},
+						],
+					};
+				}
 				const message = err instanceof Error ? err.message : String(err);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ stdout: "", stderr: message, exitCode: 1 }) }],
@@ -262,12 +284,19 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				.min(1)
 				.max(50),
 			timeout: z.number().int().positive().optional(),
+			readOnly: z
+				.boolean()
+				.optional()
+				.describe(
+					"When true, runs all scripts in the batch in read-only mode: parallel reads are unblocked across calls and any mutating filesystem op is rejected with EREADONLY at the offending command.",
+				),
 		},
 		async (args) => {
 			const totalTimeoutMs = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+			const runner = args.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 
 			try {
-				const results = await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) =>
+				const results = await runner(sessionManager, tenant, args.id, owner, async (session) =>
 					executeBatch(sessionManager, session, args.scripts, totalTimeoutMs),
 				);
 
@@ -284,6 +313,20 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				if (code === "ENOENT") {
 					return {
 						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "sandbox not found" }) }],
+					};
+				}
+				if (code === "EREADONLY_VIOLATION") {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									ok: false,
+									code: "EREADONLY_VIOLATION",
+									error: "readOnly script attempted to mutate the filesystem",
+								}),
+							},
+						],
 					};
 				}
 				console.error(

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -78,7 +78,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.2.20",
+		version: "0.3.0",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.2",
+		version: "0.3.3",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.0",
+		version: "0.3.1",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -60,6 +60,11 @@ const execBodySchema = {
 			type: "boolean",
 			description: "When true, prepends 'set -x' for command-level tracing in stderr.",
 		},
+		readOnly: {
+			type: "boolean",
+			description:
+				"When true, runs the script in read-only mode: parallel reads against the same sandbox are unblocked (no exclusive lock), and any mutating filesystem op is rejected with EREADONLY at the offending command. If the script attempts a write, the request fails with HTTP 422 EREADONLY_VIOLATION after the script returns. Single-replica only: cross-replica writers are still serialized via the distributed exec lock.",
+		},
 	},
 	required: ["script"],
 } as const;
@@ -685,6 +690,10 @@ export const openapiSpec = {
 							},
 						},
 					},
+					"422": {
+						description: "readOnly script attempted to mutate the filesystem",
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
 				},
 			},
 		},
@@ -717,6 +726,11 @@ export const openapiSpec = {
 										maxItems: 50,
 									},
 									timeoutMs: { type: "integer", example: 30000, minimum: 1, maximum: 300000 },
+									readOnly: {
+										type: "boolean",
+										description:
+											"When true, runs all scripts in the batch in read-only mode: parallel reads are unblocked across calls and any mutating filesystem op is rejected with EREADONLY at the offending command. Returns HTTP 422 EREADONLY_VIOLATION if any script attempts a write.",
+									},
 								},
 								required: ["scripts"],
 							},
@@ -761,6 +775,10 @@ export const openapiSpec = {
 					},
 					"404": {
 						description: "Sandbox not found",
+						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+					},
+					"422": {
+						description: "readOnly batch attempted to mutate the filesystem",
 						content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
 					},
 				},

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.1",
+		version: "0.3.2",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/ownership.ts
+++ b/src/api/ownership.ts
@@ -42,3 +42,29 @@ export async function withOwnedSessionOrRehydrate<T>(
 		runtimeOptions,
 	);
 }
+
+/**
+ * readOnly variant of withOwnedSessionOrRehydrate. Routes through
+ * `SessionManager.withSessionRead` (shared RWLock, no distributed exec
+ * lock, FS in read-only scope). The owner check still runs inside the
+ * session's shared scope so cold sandboxes restored from Postgres are
+ * authorized under lock rather than via a racy in-memory snapshot.
+ */
+export async function withOwnedSessionRead<T>(
+	sessionManager: SessionManager,
+	tenantId: string,
+	sandboxId: string,
+	caller: string,
+	fn: (session: Session) => Promise<T>,
+	runtimeOptions?: RuntimeOptions,
+): Promise<T> {
+	return sessionManager.withSessionRead(
+		tenantId,
+		sandboxId,
+		async (session) => {
+			assertSessionOwner(session, caller);
+			return fn(session);
+		},
+		runtimeOptions,
+	);
+}

--- a/src/api/read-only-context.ts
+++ b/src/api/read-only-context.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-call attribution for read-only scope violations.
+ *
+ * The parallel-readOnly bash exec path lets multiple readers run concurrently
+ * against a single shared SqlFs. A boolean violation flag on the FS would be
+ * shared across readers — a lying script in one reader would falsely flag
+ * every concurrent innocent reader. We use AsyncLocalStorage so each
+ * `withSessionRead` call gets its own context that follows its async stack
+ * down into bash.exec / SqlFs writes; SqlFs marks the *calling* context on
+ * EREADONLY rather than a shared flag.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface ReadOnlyContext {
+	violated: boolean;
+}
+
+export const readOnlyContext = new AsyncLocalStorage<ReadOnlyContext>();

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -11,7 +11,12 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { AuthVariables } from "../auth.js";
 import { type BatchScriptResult, executeBatch } from "../lib/batch-exec.js";
-import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
+import {
+	forbiddenResponse,
+	isForbiddenError,
+	withOwnedSessionOrRehydrate,
+	withOwnedSessionRead,
+} from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -26,6 +31,7 @@ const execBodySchema = z.object({
 	env: z.record(z.string(), z.string()).optional(),
 	timeoutMs: z.number().int().positive().max(MAX_TIMEOUT_MS).optional(),
 	debug: z.boolean().optional(),
+	readOnly: z.boolean().optional(),
 });
 
 const batchExecBodySchema = z.object({
@@ -39,6 +45,7 @@ const batchExecBodySchema = z.object({
 		.min(1)
 		.max(MAX_BATCH_SCRIPTS),
 	timeoutMs: z.number().int().positive().optional(),
+	readOnly: z.boolean().optional(),
 });
 
 type ExecBody = z.infer<typeof execBodySchema>;
@@ -147,51 +154,56 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		let execResult: ExecSyncResult;
 		try {
-			execResult = await withOwnedSessionOrRehydrate<ExecSyncResult>(
-				sessionManager,
-				tenant,
-				sandboxId,
-				c.get("owner"),
-				async (session) => {
-					const controller = new AbortController();
-					let timedOut = false;
-					const startMs = Date.now();
+			const runner = body.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			execResult = await runner<ExecSyncResult>(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
+				const controller = new AbortController();
+				let timedOut = false;
+				const startMs = Date.now();
 
-					const timer = setTimeout(() => {
-						timedOut = true;
-						controller.abort();
-					}, timeoutMs);
+				const timer = setTimeout(() => {
+					timedOut = true;
+					controller.abort();
+				}, timeoutMs);
 
-					try {
-						const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-							signal: controller.signal,
-							cwd: body.cwd,
-							env,
-						});
-						clearTimeout(timer);
+				try {
+					const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
+						signal: controller.signal,
+						cwd: body.cwd,
+						env,
+					});
+					clearTimeout(timer);
 
-						if (timedOut) {
-							return { kind: "timeout", durationMs: Date.now() - startMs };
-						}
-
-						return {
-							kind: "ok",
-							stdout: result.stdout,
-							stderr: result.stderr,
-							exitCode: result.exitCode,
-							durationMs: Date.now() - startMs,
-						};
-					} catch (e) {
-						clearTimeout(timer);
-						if (timedOut) {
-							return { kind: "timeout", durationMs: Date.now() - startMs };
-						}
-						throw e;
+					if (timedOut) {
+						return { kind: "timeout", durationMs: Date.now() - startMs };
 					}
-				},
-			);
+
+					return {
+						kind: "ok",
+						stdout: result.stdout,
+						stderr: result.stderr,
+						exitCode: result.exitCode,
+						durationMs: Date.now() - startMs,
+					};
+				} catch (e) {
+					clearTimeout(timer);
+					if (timedOut) {
+						return { kind: "timeout", durationMs: Date.now() - startMs };
+					}
+					throw e;
+				}
+			});
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
+			if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+				return c.json(
+					{
+						error: "read_only_violation",
+						code: "EREADONLY_VIOLATION",
+						details: ["readOnly script attempted to mutate the filesystem"],
+					},
+					422 as ContentfulStatusCode,
+				);
+			}
 			throw err;
 		}
 
@@ -228,8 +240,10 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		const timeoutMs = body.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		const scriptToRun = body.debug ? wrapDebugScript(body.script) : body.script;
 		const env = body.env ? Object.assign(Object.create(null) as Record<string, string>, body.env) : undefined;
+		const readOnly = body.readOnly === true;
 		try {
-			await withOwnedSessionOrRehydrate(sessionManager, tenant, sandboxId, c.get("owner"), async () => undefined);
+			const ownerCheck = readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			await ownerCheck(sessionManager, tenant, sandboxId, c.get("owner"), async () => undefined);
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
 			throw err;
@@ -250,51 +264,79 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 				controller.abort();
 			}, timeoutMs);
 
-			await sessionManager.withExistingSession(tenant, sandboxId, async (session) => {
-				try {
-					const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-						signal: controller.signal,
-						cwd: body.cwd,
-						env,
-					});
-					clearTimeout(timer);
+			const runner = readOnly
+				? sessionManager.withSessionRead.bind(sessionManager)
+				: sessionManager.withExistingSession.bind(sessionManager);
+			try {
+				await runner(tenant, sandboxId, async (session) => {
+					try {
+						const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
+							signal: controller.signal,
+							cwd: body.cwd,
+							env,
+						});
+						clearTimeout(timer);
 
-					if (timedOut) {
+						if (timedOut) {
+							await stream.writeSSE({
+								event: "exit",
+								data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							});
+							return;
+						}
+
+						if (result.stdout) {
+							await stream.writeSSE({
+								event: "stdout",
+								data: JSON.stringify({ t: "stdout", data: result.stdout }),
+							});
+						}
+						if (result.stderr) {
+							await stream.writeSSE({
+								event: "stderr",
+								data: JSON.stringify({ t: "stderr", data: result.stderr }),
+							});
+						}
 						await stream.writeSSE({
 							event: "exit",
-							data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							data: JSON.stringify({ t: "exit", exitCode: result.exitCode, durationMs: Date.now() - startMs }),
 						});
-						return;
+					} catch (e) {
+						clearTimeout(timer);
+						if (timedOut) {
+							await stream.writeSSE({
+								event: "exit",
+								data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
+							});
+							return;
+						}
+						throw e;
 					}
-
-					if (result.stdout) {
-						await stream.writeSSE({
-							event: "stdout",
-							data: JSON.stringify({ t: "stdout", data: result.stdout }),
-						});
-					}
-					if (result.stderr) {
-						await stream.writeSSE({
-							event: "stderr",
-							data: JSON.stringify({ t: "stderr", data: result.stderr }),
-						});
-					}
+				});
+			} catch (err) {
+				clearTimeout(timer);
+				if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+					await stream.writeSSE({
+						event: "error",
+						data: JSON.stringify({
+							t: "error",
+							code: "EREADONLY_VIOLATION",
+							error: "readOnly script attempted to mutate the filesystem",
+						}),
+					});
 					await stream.writeSSE({
 						event: "exit",
-						data: JSON.stringify({ t: "exit", exitCode: result.exitCode, durationMs: Date.now() - startMs }),
+						data: JSON.stringify({
+							t: "exit",
+							exitCode: -1,
+							durationMs: Date.now() - startMs,
+							error: "read_only_violation",
+						}),
 					});
-				} catch (e) {
-					clearTimeout(timer);
-					if (timedOut) {
-						await stream.writeSSE({
-							event: "exit",
-							data: JSON.stringify({ t: "exit", exitCode: -1, durationMs: Date.now() - startMs, error: "timeout" }),
-						});
-						return;
-					}
-					throw e;
+					return;
 				}
-			});
+				throw err;
+			}
 		});
 	});
 
@@ -328,16 +370,22 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 
 		let results: BatchScriptResult[];
 		try {
-			results = await withOwnedSessionOrRehydrate<BatchScriptResult[]>(
-				sessionManager,
-				tenant,
-				sandboxId,
-				c.get("owner"),
-				async (session) =>
-					executeBatch(sessionManager, session, body.scripts, totalTimeoutMs, disconnectController.signal),
+			const runner = body.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
+			results = await runner<BatchScriptResult[]>(sessionManager, tenant, sandboxId, c.get("owner"), async (session) =>
+				executeBatch(sessionManager, session, body.scripts, totalTimeoutMs, disconnectController.signal),
 			);
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();
+			if ((err as Error & { code?: string }).code === "EREADONLY_VIOLATION") {
+				return c.json(
+					{
+						error: "read_only_violation",
+						code: "EREADONLY_VIOLATION",
+						details: ["readOnly script attempted to mutate the filesystem"],
+					},
+					422 as ContentfulStatusCode,
+				);
+			}
 			throw err;
 		}
 

--- a/src/api/rw-lock.ts
+++ b/src/api/rw-lock.ts
@@ -1,0 +1,185 @@
+/**
+ * Async readers-writer lock with writer-priority.
+ *
+ * Contract:
+ *  - Multiple readers can hold the lock simultaneously (shared mode).
+ *  - At most one writer can hold the lock at a time (exclusive mode).
+ *  - While a writer holds the lock, no readers run.
+ *  - Writer-priority: when an exclusive waiter is queued, new shared
+ *    acquisitions wait behind it. This prevents reader starvation of the
+ *    (rare) writers that mutate the sandbox.
+ *  - Aborting via `signal` cancels a pending acquisition; it never affects an
+ *    already-held lock. Aborted waiters surface `Error('ABORTED')` with
+ *    `code: "ABORTED"` and `name: "AbortError"`.
+ *
+ * Drop-in compatible with the `runExclusive` shape used by `async-mutex`:
+ * existing call sites that previously held a `Mutex` may use this lock with
+ * no changes.
+ */
+
+type LockMode = "shared" | "exclusive";
+
+interface Waiter {
+	readonly mode: LockMode;
+	resolve: () => void;
+	reject: (err: Error) => void;
+	readonly signal: AbortSignal | undefined;
+	onAbort: (() => void) | undefined;
+	settled: boolean;
+}
+
+function makeAbortError(): Error {
+	return Object.assign(new Error("ABORTED"), { code: "ABORTED", name: "AbortError" });
+}
+
+export class RWLock {
+	#readers = 0;
+	#writerActive = false;
+	readonly #queue: Waiter[] = [];
+
+	/** Active reader count (for diagnostics/tests). */
+	get activeReaders(): number {
+		return this.#readers;
+	}
+
+	/** True iff a writer currently holds the lock. */
+	get writerHeld(): boolean {
+		return this.#writerActive;
+	}
+
+	/** Pending acquisitions that have not yet been granted. */
+	get pendingCount(): number {
+		let n = 0;
+		for (const w of this.#queue) if (!w.settled) n++;
+		return n;
+	}
+
+	async runShared<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.#acquire("shared", signal);
+		try {
+			return await fn();
+		} finally {
+			this.#releaseShared();
+		}
+	}
+
+	async runExclusive<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		await this.#acquire("exclusive", signal);
+		try {
+			return await fn();
+		} finally {
+			this.#releaseExclusive();
+		}
+	}
+
+	#acquire(mode: LockMode, signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) return Promise.reject(makeAbortError());
+
+		if (mode === "shared") {
+			// Writer-priority: a queued writer blocks new readers, even if the
+			// lock is currently free or held in shared mode.
+			if (!this.#writerActive && !this.#hasQueuedWriter()) {
+				this.#readers++;
+				return Promise.resolve();
+			}
+		} else {
+			if (!this.#writerActive && this.#readers === 0) {
+				this.#writerActive = true;
+				return Promise.resolve();
+			}
+		}
+		return this.#enqueue(mode, signal);
+	}
+
+	#enqueue(mode: LockMode, signal: AbortSignal | undefined): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			const waiter: Waiter = {
+				mode,
+				resolve: () => {},
+				reject: () => {},
+				signal,
+				onAbort: undefined,
+				settled: false,
+			};
+			waiter.resolve = (): void => {
+				if (waiter.settled) return;
+				waiter.settled = true;
+				if (waiter.signal !== undefined && waiter.onAbort !== undefined) {
+					waiter.signal.removeEventListener("abort", waiter.onAbort);
+				}
+				resolve();
+			};
+			waiter.reject = (err: Error): void => {
+				if (waiter.settled) return;
+				waiter.settled = true;
+				if (waiter.signal !== undefined && waiter.onAbort !== undefined) {
+					waiter.signal.removeEventListener("abort", waiter.onAbort);
+				}
+				const idx = this.#queue.indexOf(waiter);
+				if (idx >= 0) this.#queue.splice(idx, 1);
+				reject(err);
+			};
+			if (signal !== undefined) {
+				const onAbort = (): void => waiter.reject(makeAbortError());
+				waiter.onAbort = onAbort;
+				signal.addEventListener("abort", onAbort, { once: true });
+			}
+			this.#queue.push(waiter);
+		});
+	}
+
+	#releaseShared(): void {
+		if (this.#readers === 0) {
+			throw new Error("RWLock: releaseShared called with no active readers");
+		}
+		this.#readers--;
+		if (this.#readers === 0) this.#dispatch();
+	}
+
+	#releaseExclusive(): void {
+		if (!this.#writerActive) {
+			throw new Error("RWLock: releaseExclusive called with no active writer");
+		}
+		this.#writerActive = false;
+		this.#dispatch();
+	}
+
+	#dispatch(): void {
+		// Discard any settled waiters at the head (aborted while queued).
+		while (this.#queue.length > 0 && this.#queue[0]!.settled) this.#queue.shift();
+		if (this.#queue.length === 0) return;
+		if (this.#writerActive) return;
+
+		const head = this.#queue[0]!;
+		if (head.mode === "exclusive") {
+			if (this.#readers > 0) return;
+			this.#queue.shift();
+			this.#writerActive = true;
+			head.resolve();
+			return;
+		}
+
+		// Wake every consecutive shared waiter until we hit a writer or empty
+		// the queue. This batches a parallel-reader handoff into a single
+		// dispatch pass.
+		while (this.#queue.length > 0) {
+			const next = this.#queue[0]!;
+			if (next.settled) {
+				this.#queue.shift();
+				continue;
+			}
+			if (next.mode !== "shared") break;
+			this.#queue.shift();
+			this.#readers++;
+			next.resolve();
+		}
+	}
+
+	#hasQueuedWriter(): boolean {
+		for (const w of this.#queue) {
+			if (w.settled) continue;
+			if (w.mode === "exclusive") return true;
+		}
+		return false;
+	}
+}

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -565,19 +565,27 @@ export class SessionManager {
 				try {
 					result = await readOnlyContext.run(ctx, () => fn(session));
 				} catch (err) {
+					const errCode = (err as Error & { code?: string }).code;
+					// Audit the violation even when an unrelated error (e.g. AbortError
+					// from a timeout) wins as the thrown error. Bash can record an
+					// EREADONLY rejection mid-script (ctx.violated=true) and later
+					// throw for an unrelated reason; the security event must still
+					// surface to monitoring.
+					if (ctx.violated || errCode === "EREADONLY") {
+						logAudit("read_only_violation", { tenantId, sandboxId });
+					}
 					// Some bash builtins (e.g. shell redirections `echo x > f`) let
 					// the raw EREADONLY rejection escape bash.exec instead of
 					// normalising it to a non-zero exit. Remap to EREADONLY_VIOLATION
 					// so the route layer sees a single uniform code regardless of
 					// whether the violation surfaced via ctx-tagging (script ran to
 					// completion with a non-zero exit) or as a thrown rejection.
-					if ((err as Error & { code?: string }).code === "EREADONLY") {
-						logAudit("read_only_violation", { tenantId, sandboxId });
-						throw Object.assign(
-							new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"),
-							{ code: "EREADONLY_VIOLATION" },
-						);
+					if (errCode === "EREADONLY") {
+						throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
+							code: "EREADONLY_VIOLATION",
+						});
 					}
+					// Unrelated error wins; the violation was already audited above.
 					throw err;
 				}
 				if (ctx.violated) {

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -23,6 +23,7 @@ import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sq
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { logAudit } from "./lib/audit.js";
+import { type ReadOnlyContext, readOnlyContext } from "./read-only-context.js";
 import { RWLock } from "./rw-lock.js";
 import type { TenantConfig } from "./tenants.js";
 
@@ -53,11 +54,7 @@ function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 
 function asReadOnlyFs(fs: IFileSystem): IReadOnlyScopeFs | undefined {
 	const partial = fs as Partial<IReadOnlyScopeFs>;
-	if (
-		typeof partial.beginReadOnlyScope === "function" &&
-		typeof partial.endReadOnlyScope === "function" &&
-		typeof partial.readOnlyScopeActive === "boolean"
-	) {
+	if (typeof partial.beginReadOnlyScope === "function" && typeof partial.endReadOnlyScope === "function") {
 		return fs as IReadOnlyScopeFs;
 	}
 	return undefined;
@@ -549,43 +546,50 @@ export class SessionManager {
 			if (session.state === "closing") {
 				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 			}
+			const roFs = asReadOnlyFs(session.fs);
+			const ctx: ReadOnlyContext = { violated: false };
+
 			session.inFlight++;
 			session.lastUsed = Date.now();
-			const roFs = asReadOnlyFs(session.fs);
 			let scopeOpened = false;
-			if (roFs !== undefined) {
-				roFs.beginReadOnlyScope();
-				scopeOpened = true;
-			}
-			let primaryError: unknown;
-			let result: T | undefined;
-			let succeeded = false;
 			try {
-				result = await fn(session);
-				succeeded = true;
-			} catch (err) {
-				primaryError = err;
-			}
-			const violated = scopeOpened && roFs !== undefined && roFs.readOnlyViolated;
-			if (scopeOpened && roFs !== undefined) {
-				try {
-					roFs.endReadOnlyScope();
-				} catch {
-					// best-effort: scope toggle should not mask the primary error
+				if (roFs !== undefined) {
+					roFs.beginReadOnlyScope();
+					scopeOpened = true;
 				}
+				// `readOnlyContext.run` propagates `ctx` down the async stack into
+				// `bash.exec` → `SqlFs.#assertWritable`, which marks *this* call's
+				// context (not a shared FS flag). Innocent concurrent readers keep
+				// their own `ctx.violated === false`.
+				const result = await readOnlyContext.run(ctx, () => fn(session));
+				if (ctx.violated) {
+					logAudit("read_only_violation", { tenantId, sandboxId });
+					throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
+						code: "EREADONLY_VIOLATION",
+					});
+				}
+				return result;
+			} finally {
+				if (scopeOpened && roFs !== undefined) {
+					try {
+						roFs.endReadOnlyScope();
+					} catch (err) {
+						// Scope toggle must not mask the primary error; log and continue.
+						console.error(
+							JSON.stringify({
+								event: "end_read_only_scope_error",
+								tenantId,
+								sandboxId,
+								error: (err as Error).message,
+							}),
+						);
+					}
+				}
+				session.inFlight--;
+				// readOnly path never writes — no path-budget refresh, no version
+				// publish. The dirty flag is preserved so a subsequent writer's
+				// publishVersionIfDirty still fires (defense-in-depth).
 			}
-			session.inFlight--;
-			// readOnly path never writes — no path-budget refresh, no version
-			// publish. The dirty flag is preserved so a subsequent writer's
-			// publishVersionIfDirty still fires (defense-in-depth).
-			if (primaryError !== undefined) throw primaryError;
-			if (violated && succeeded) {
-				logAudit("read_only_violation", { tenantId, sandboxId });
-				throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
-					code: "EREADONLY_VIOLATION",
-				});
-			}
-			return result as T;
 		});
 	}
 
@@ -1064,8 +1068,13 @@ export class SessionManager {
 		const usesPython = session.runtimeOptions.python && PYTHON_INVOCATION_REGEX.test(script);
 		const usesJs = session.runtimeOptions.javascript && JS_INVOCATION_REGEX.test(script);
 
+		// readOnly execs skip scriptTx entirely: the FS rejects all writes via
+		// EREADONLY before any DB call, so the per-script transaction has
+		// nothing to commit, and beginScope/endScope on the shared SessionScopedFs
+		// would race across concurrent parallel readers.
+		const inReadOnlyScope = readOnlyContext.getStore() !== undefined;
 		const execFn = async (): Promise<BashExecResult> => {
-			if (session.scriptTx !== undefined) {
+			if (!inReadOnlyScope && session.scriptTx !== undefined) {
 				session.scriptTx.beginScope();
 				try {
 					const result = await session.bash.exec(script, opts);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -561,7 +561,25 @@ export class SessionManager {
 				// `bash.exec` → `SqlFs.#assertWritable`, which marks *this* call's
 				// context (not a shared FS flag). Innocent concurrent readers keep
 				// their own `ctx.violated === false`.
-				const result = await readOnlyContext.run(ctx, () => fn(session));
+				let result: T;
+				try {
+					result = await readOnlyContext.run(ctx, () => fn(session));
+				} catch (err) {
+					// Some bash builtins (e.g. shell redirections `echo x > f`) let
+					// the raw EREADONLY rejection escape bash.exec instead of
+					// normalising it to a non-zero exit. Remap to EREADONLY_VIOLATION
+					// so the route layer sees a single uniform code regardless of
+					// whether the violation surfaced via ctx-tagging (script ran to
+					// completion with a non-zero exit) or as a thrown rejection.
+					if ((err as Error & { code?: string }).code === "EREADONLY") {
+						logAudit("read_only_violation", { tenantId, sandboxId });
+						throw Object.assign(
+							new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"),
+							{ code: "EREADONLY_VIOLATION" },
+						);
+					}
+					throw err;
+				}
 				if (ctx.violated) {
 					logAudit("read_only_violation", { tenantId, sandboxId });
 					throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -12,7 +12,6 @@
  * collisions are impossible.
  */
 
-import { Mutex } from "async-mutex";
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
 import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
@@ -20,10 +19,11 @@ import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/in
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import { SessionScopedFs } from "../fs/sql-fs/session-scoped-fs.js";
-import type { ICoherentFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
+import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
 import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { logAudit } from "./lib/audit.js";
+import { RWLock } from "./rw-lock.js";
 import type { TenantConfig } from "./tenants.js";
 
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
@@ -47,6 +47,18 @@ function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 		typeof partial.clearDirty === "function"
 	) {
 		return fs as ICoherentFs;
+	}
+	return undefined;
+}
+
+function asReadOnlyFs(fs: IFileSystem): IReadOnlyScopeFs | undefined {
+	const partial = fs as Partial<IReadOnlyScopeFs>;
+	if (
+		typeof partial.beginReadOnlyScope === "function" &&
+		typeof partial.endReadOnlyScope === "function" &&
+		typeof partial.readOnlyScopeActive === "boolean"
+	) {
+		return fs as IReadOnlyScopeFs;
 	}
 	return undefined;
 }
@@ -90,7 +102,12 @@ export interface Session {
 	readonly scriptTx: SessionScopedFs | undefined;
 	lastUsed: number;
 	inFlight: number;
-	readonly mutex: Mutex;
+	/**
+	 * Per-session async readers-writer lock. Writes (default exec path,
+	 * destroy, reaper, shutdown) take exclusive mode; readOnly execs take
+	 * shared mode and run in parallel.
+	 */
+	readonly lock: RWLock;
 	state: "active" | "closing";
 	owner: string;
 	name: string | null;
@@ -99,6 +116,13 @@ export interface Session {
 	overBudget: boolean;
 	destroyPromise?: Promise<void>;
 	lastSeenVersion: number;
+	/**
+	 * Single-flight guard for `ensureFreshCache`. While set, parallel readers
+	 * (and any concurrent writer entry) await the same probe + reload rather
+	 * than each issuing their own Redis GET / coherent.reload(). Cleared on
+	 * settle (success or failure).
+	 */
+	freshCacheInflight?: Promise<void>;
 	/**
 	 * Set to true when a previous turn's `publishVersionIfDirty` call failed
 	 * (the write committed to Postgres but the Redis INCR errored). The next
@@ -398,7 +422,7 @@ export class SessionManager {
 					scriptTx,
 					lastUsed: Date.now(),
 					inFlight: 0,
-					mutex: new Mutex(),
+					lock: new RWLock(),
 					state: "active",
 					owner: resolvedOwner,
 					name: null,
@@ -441,7 +465,7 @@ export class SessionManager {
 		return withDistributedLock(this.redis, execLockKey(tenantId, sandboxId), fn, this.execLockOptions);
 	}
 
-	/** Shared entry logic for all session wrappers. Must be called inside the distributed exec lock. */
+	/** Shared entry logic for all exclusive (write) session wrappers. */
 	private async withSessionEntry<T>(
 		tenantId: string,
 		sandboxId: string,
@@ -454,7 +478,7 @@ export class SessionManager {
 
 		await this.ensureFreshCache(tenantId, sandboxId, session);
 
-		return session.mutex.runExclusive(async () => {
+		return session.lock.runExclusive(async () => {
 			if (session.state === "closing") {
 				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 			}
@@ -499,29 +523,109 @@ export class SessionManager {
 		});
 	}
 
+	/**
+	 * Shared entry logic for the readOnly path. Holds the per-session RWLock
+	 * in shared mode so multiple readers run in parallel, and skips the
+	 * distributed exec lock + script-tx (no writes are permitted). The
+	 * session FS is put into read-only scope before fn runs and restored on
+	 * exit so any mutating syscall throws EREADONLY.
+	 *
+	 * Single-replica only: cross-replica visibility relies on the eventual
+	 * version-probe done by `ensureFreshCache` on the next op, same as today.
+	 */
+	private async withSessionReadEntry<T>(
+		tenantId: string,
+		sandboxId: string,
+		session: Session,
+		fn: (session: Session) => Promise<T>,
+	): Promise<T> {
+		if (session.state === "closing") {
+			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+		}
+
+		await this.ensureFreshCache(tenantId, sandboxId, session);
+
+		return session.lock.runShared(async () => {
+			if (session.state === "closing") {
+				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
+			}
+			session.inFlight++;
+			session.lastUsed = Date.now();
+			const roFs = asReadOnlyFs(session.fs);
+			let scopeOpened = false;
+			if (roFs !== undefined) {
+				roFs.beginReadOnlyScope();
+				scopeOpened = true;
+			}
+			let primaryError: unknown;
+			let result: T | undefined;
+			let succeeded = false;
+			try {
+				result = await fn(session);
+				succeeded = true;
+			} catch (err) {
+				primaryError = err;
+			}
+			const violated = scopeOpened && roFs !== undefined && roFs.readOnlyViolated;
+			if (scopeOpened && roFs !== undefined) {
+				try {
+					roFs.endReadOnlyScope();
+				} catch {
+					// best-effort: scope toggle should not mask the primary error
+				}
+			}
+			session.inFlight--;
+			// readOnly path never writes — no path-budget refresh, no version
+			// publish. The dirty flag is preserved so a subsequent writer's
+			// publishVersionIfDirty still fires (defense-in-depth).
+			if (primaryError !== undefined) throw primaryError;
+			if (violated && succeeded) {
+				logAudit("read_only_violation", { tenantId, sandboxId });
+				throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
+					code: "EREADONLY_VIOLATION",
+				});
+			}
+			return result as T;
+		});
+	}
+
 	private async ensureFreshCache(tenantId: string, sandboxId: string, session: Session): Promise<void> {
 		if (this.redis === undefined) return;
 		const coherent = asCoherentFs(session.fs);
 		if (coherent === undefined) return;
 
-		let current: number;
-		try {
-			const raw = await this.redis.get(versionKey(tenantId, sandboxId));
-			current = raw === null ? 0 : Number(raw) || 0;
-		} catch (err) {
-			// Redis unavailable — can't determine whether the cache is fresh.
-			// Reload from Postgres so we don't serve stale data.
-			console.error(JSON.stringify({ event: "version_get_error", sandboxId, error: (err as Error).message }));
-			await coherent.reload();
-			return;
-		}
+		// Single-flight: parallel readers (and the rare writer that races
+		// them) share one Redis GET + reload() round trip. Without this,
+		// N concurrent readOnly execs would each issue their own probe and
+		// — on version mismatch — N concurrent loadAllPaths against
+		// Postgres.
+		const existing = session.freshCacheInflight;
+		if (existing !== undefined) return existing;
 
-		if (session.lastSeenVersion !== current) {
-			await coherent.reload();
-			session.lastSeenVersion = current;
-			coherent.clearDirty();
-			return;
-		}
+		const probe = (async (): Promise<void> => {
+			let current: number;
+			try {
+				const raw = await this.redis!.get(versionKey(tenantId, sandboxId));
+				current = raw === null ? 0 : Number(raw) || 0;
+			} catch (err) {
+				// Redis unavailable — can't determine whether the cache is fresh.
+				// Reload from Postgres so we don't serve stale data.
+				console.error(JSON.stringify({ event: "version_get_error", sandboxId, error: (err as Error).message }));
+				await coherent.reload();
+				return;
+			}
+
+			if (session.lastSeenVersion !== current) {
+				await coherent.reload();
+				session.lastSeenVersion = current;
+				coherent.clearDirty();
+			}
+		})().finally(() => {
+			session.freshCacheInflight = undefined;
+		});
+
+		session.freshCacheInflight = probe;
+		return probe;
 	}
 
 	private async publishVersionIfDirty(tenantId: string, sandboxId: string, session: Session): Promise<void> {
@@ -593,6 +697,53 @@ export class SessionManager {
 			}
 			return this.withSessionEntry(tenantId, sandboxId, session, fn);
 		});
+	}
+
+	/**
+	 * readOnly entry point. Acquires the per-session RWLock in shared mode so
+	 * multiple readers run in parallel, skips the distributed exec lock, and
+	 * activates a read-only scope on the session FS so any mutating syscall
+	 * throws EREADONLY at the offending command.
+	 *
+	 * Falls back to Postgres rehydrate (like withSessionOrRehydrate) when the
+	 * session was evicted from the in-memory pool but the sandbox still
+	 * exists in the persistent store.
+	 */
+	async withSessionRead<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
+		if (session !== undefined && session.state !== "closing") {
+			return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
+		}
+		return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions);
+	}
+
+	private async rehydrateAndExecRead<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (session: Session) => Promise<T>,
+		runtimeOptions?: RuntimeOptions,
+	): Promise<T> {
+		let meta: SandboxMeta | null | undefined;
+		if (this.getSandboxMetaFn !== undefined) {
+			meta = await this.getSandboxMetaFn(tenantId, sandboxId);
+			if (meta === null) {
+				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+			}
+		} else {
+			throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
+		}
+		const resolvedRuntime: RuntimeOptions = meta
+			? { python: meta.python, javascript: meta.javascript }
+			: (runtimeOptions ?? DEFAULT_RUNTIME_OPTIONS);
+		const session = await this.getOrCreate(tenantId, sandboxId, resolvedRuntime, meta?.owner ?? "");
+		if (meta?.owner) session.owner = meta.owner;
+		if (meta?.name !== undefined) session.name = meta.name;
+		return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
 	}
 
 	/**
@@ -679,7 +830,7 @@ export class SessionManager {
 
 			session.state = "closing";
 
-			const p = session.mutex.runExclusive(async () => {
+			const p = session.lock.runExclusive(async () => {
 				this.sessions.delete(key);
 				// Disconnect the FS unconditionally — even if destroySandboxFn,
 				// version-key deletion, or path-snapshot cleanup throws — so the
@@ -777,7 +928,7 @@ export class SessionManager {
 				const remaining = Math.max(0, deadline - Date.now());
 				try {
 					await Promise.race([
-						session.mutex.runExclusive(async () => {
+						session.lock.runExclusive(async () => {
 							/* drain */
 						}),
 						new Promise<void>((resolve) => setTimeout(resolve, remaining)),
@@ -820,7 +971,7 @@ export class SessionManager {
 				// against a disconnected filesystem.
 				session.state = "closing";
 				this.sessions.delete(key);
-				void session.mutex
+				void session.lock
 					.runExclusive(async () => {
 						/* drain queued waiters; they will throw ESESSIONCLOSING */
 					})

--- a/src/api/tests/unit/exec.test.ts
+++ b/src/api/tests/unit/exec.test.ts
@@ -305,6 +305,71 @@ describe("POST /v1/sandboxes/:id/exec-sync", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("readOnly:true routes through withSessionRead (parallel-safe path)", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		const readSpy = vi.spyOn(sessionManager, "withSessionRead");
+		const writeSpy = vi.spyOn(sessionManager, "withSessionOrRehydrate");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo readonly", readOnly: true }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(readSpy).toHaveBeenCalledTimes(1);
+		expect(writeSpy).not.toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+	});
+
+	it("readOnly:false (default) keeps using withSessionOrRehydrate", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+		const readSpy = vi.spyOn(sessionManager, "withSessionRead");
+		const writeSpy = vi.spyOn(sessionManager, "withSessionOrRehydrate");
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo write" }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect(readSpy).not.toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+	});
+
+	it("EREADONLY_VIOLATION from a lying readOnly script returns HTTP 422", async () => {
+		const { sessionManager } = await makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken();
+
+		// Force the lock-managed read entry to throw the violation we'd see
+		// from the safety net. We're testing the route mapping, not the
+		// underlying enforcement (which is unit-tested at SqlFs level).
+		vi.spyOn(sessionManager, "withSessionRead").mockRejectedValue(
+			Object.assign(new Error("EREADONLY_VIOLATION"), { code: "EREADONLY_VIOLATION" }),
+		);
+
+		const res = await app.request(`/v1/sandboxes/${SANDBOX_ID}/exec-sync`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ script: "echo lying > /tmp/x", readOnly: true }),
+		});
+
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("EREADONLY_VIOLATION");
+
+		vi.restoreAllMocks();
+	});
+
 	it("debug mode prepends set -x and produces trace output in stderr", async () => {
 		const { sessionManager } = await makeTestEnv();
 		const app = makeTestApp(sessionManager);

--- a/src/api/tests/unit/rw-lock.test.ts
+++ b/src/api/tests/unit/rw-lock.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for the async readers-writer lock primitive used by the
+ * parallel-readOnly bash exec path.
+ *
+ * Coverage:
+ *  - Multiple readers run in parallel under shared mode.
+ *  - Writer waits for in-flight readers to drain before entering.
+ *  - New readers wait when a writer is queued (writer-priority — no
+ *    reader-starvation).
+ *  - Writers wait for prior writer to release.
+ *  - Aborting a queued waiter cancels it without affecting holders.
+ *  - fn errors release the lock.
+ */
+
+import { describe, expect, it } from "vitest";
+import { RWLock } from "../../rw-lock.js";
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe("RWLock", () => {
+	it("runs multiple shared acquisitions in parallel", async () => {
+		const lock = new RWLock();
+		let active = 0;
+		let peak = 0;
+		const work = async (): Promise<void> => {
+			active++;
+			peak = Math.max(peak, active);
+			await tick();
+			active--;
+		};
+
+		await Promise.all([lock.runShared(work), lock.runShared(work), lock.runShared(work), lock.runShared(work)]);
+
+		expect(peak).toBe(4);
+		expect(lock.activeReaders).toBe(0);
+		expect(lock.writerHeld).toBe(false);
+	});
+
+	it("a writer waits for in-flight readers to drain", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const reader1 = lock.runShared(async () => {
+			order.push("r1-acquired");
+			await new Promise<void>((res) => {
+				release1 = res;
+			});
+			order.push("r1-released");
+		});
+
+		await tick();
+		expect(lock.activeReaders).toBe(1);
+
+		const writer = lock.runExclusive(async () => {
+			order.push("w-acquired");
+		});
+
+		// Writer must not run while reader holds shared lock.
+		await tick();
+		await tick();
+		expect(order).toEqual(["r1-acquired"]);
+		expect(lock.writerHeld).toBe(false);
+
+		release1();
+		await reader1;
+		await writer;
+		expect(order).toEqual(["r1-acquired", "r1-released", "w-acquired"]);
+		expect(lock.writerHeld).toBe(false);
+	});
+
+	it("new readers wait when a writer is queued (writer-priority)", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const reader1 = lock.runShared(async () => {
+			order.push("r1-acquired");
+			await new Promise<void>((res) => {
+				release1 = res;
+			});
+			order.push("r1-released");
+		});
+		await tick();
+
+		// Queue a writer behind the in-flight reader.
+		const writer = lock.runExclusive(async () => {
+			order.push("w-acquired");
+		});
+		await tick();
+
+		// New readers arrive while the writer is queued — they must wait
+		// behind the writer (no reader-starvation of the writer).
+		const reader2 = lock.runShared(async () => {
+			order.push("r2-acquired");
+		});
+		const reader3 = lock.runShared(async () => {
+			order.push("r3-acquired");
+		});
+		await tick();
+
+		expect(order).toEqual(["r1-acquired"]);
+
+		release1();
+		await Promise.all([reader1, writer, reader2, reader3]);
+
+		// Writer entered before the queued readers, then both readers proceeded
+		// in parallel after the writer released.
+		expect(order).toEqual([
+			"r1-acquired",
+			"r1-released",
+			"w-acquired",
+			expect.stringMatching(/^r[23]-acquired$/),
+			expect.stringMatching(/^r[23]-acquired$/),
+		]);
+	});
+
+	it("queued shared waiters batch-wake after a writer releases", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const writer = lock.runExclusive(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		let active = 0;
+		let peak = 0;
+		const reader = (): Promise<void> =>
+			lock.runShared(async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await tick();
+				active--;
+			});
+
+		const readers = Promise.all([reader(), reader(), reader()]);
+		await tick();
+		expect(peak).toBe(0); // none have entered yet
+
+		release();
+		await writer;
+		await readers;
+		expect(peak).toBe(3); // all three woke up in one dispatch and ran in parallel
+	});
+
+	it("subsequent writer waits for prior writer", async () => {
+		const lock = new RWLock();
+		const order: string[] = [];
+
+		let release1!: () => void;
+		const w1 = lock.runExclusive(async () => {
+			order.push("w1-acquired");
+			await new Promise<void>((r) => {
+				release1 = r;
+			});
+		});
+		await tick();
+		const w2 = lock.runExclusive(async () => {
+			order.push("w2-acquired");
+		});
+		await tick();
+		expect(order).toEqual(["w1-acquired"]);
+		release1();
+		await Promise.all([w1, w2]);
+		expect(order).toEqual(["w1-acquired", "w2-acquired"]);
+	});
+
+	it("aborts a queued shared acquisition without affecting holders", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const writer = lock.runExclusive(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		const ac = new AbortController();
+		const reader = lock.runShared(async () => {
+			throw new Error("must not run");
+		}, ac.signal);
+		await tick();
+		expect(lock.pendingCount).toBe(1);
+
+		ac.abort();
+		await expect(reader).rejects.toMatchObject({ code: "ABORTED" });
+		expect(lock.pendingCount).toBe(0);
+
+		release();
+		await writer;
+	});
+
+	it("aborts a queued exclusive acquisition without affecting holders", async () => {
+		const lock = new RWLock();
+		let release!: () => void;
+		const reader = lock.runShared(async () => {
+			await new Promise<void>((r) => {
+				release = r;
+			});
+		});
+		await tick();
+
+		const ac = new AbortController();
+		const writer = lock.runExclusive(async () => {
+			throw new Error("must not run");
+		}, ac.signal);
+		await tick();
+		ac.abort();
+		await expect(writer).rejects.toMatchObject({ code: "ABORTED" });
+
+		release();
+		await reader;
+
+		// Lock is fully drained; a fresh exclusive should acquire immediately.
+		await lock.runExclusive(async () => {});
+	});
+
+	it("rejects immediately for a pre-aborted signal", async () => {
+		const lock = new RWLock();
+		const ac = new AbortController();
+		ac.abort();
+		await expect(lock.runShared(async () => {}, ac.signal)).rejects.toMatchObject({ code: "ABORTED" });
+		await expect(lock.runExclusive(async () => {}, ac.signal)).rejects.toMatchObject({ code: "ABORTED" });
+		expect(lock.pendingCount).toBe(0);
+	});
+
+	it("releases the lock when fn throws", async () => {
+		const lock = new RWLock();
+		await expect(
+			lock.runExclusive(async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(lock.writerHeld).toBe(false);
+
+		await expect(
+			lock.runShared(async () => {
+				throw new Error("boom2");
+			}),
+		).rejects.toThrow("boom2");
+		expect(lock.activeReaders).toBe(0);
+
+		// Lock is reusable post-error.
+		await lock.runExclusive(async () => {});
+	});
+});

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for SessionManager's parallel-readOnly bash exec entry point.
+ *
+ * Coverage:
+ *  - Multiple withSessionRead calls run in parallel against the same sandbox.
+ *  - withSessionRead waits for an in-flight write; a new write waits for
+ *    in-flight readers.
+ *  - The session FS is put into a read-only scope before fn runs and
+ *    restored on exit; a violated flag surfaces EREADONLY_VIOLATION.
+ *  - ensureFreshCache is single-flighted across parallel readers (one Redis
+ *    GET, one reload).
+ */
+
+import type { Redis } from "ioredis";
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+const T = "default";
+
+/**
+ * Minimal IReadOnlyScopeFs that piggybacks on InMemoryFs. Tracks scope
+ * begin/end calls and exposes a `simulateViolation()` switch the test can
+ * flip to mark the FS as having attempted a write under read-only scope.
+ */
+class TestReadOnlyFs {
+	readonly inner: InMemoryFs;
+	readOnlyScopeActive = false;
+	readOnlyViolated = false;
+	beginCount = 0;
+	endCount = 0;
+	constructor() {
+		this.inner = new InMemoryFs();
+	}
+	beginReadOnlyScope(): void {
+		if (this.readOnlyScopeActive) throw new Error("scope already active");
+		this.readOnlyScopeActive = true;
+		this.readOnlyViolated = false;
+		this.beginCount++;
+	}
+	endReadOnlyScope(): void {
+		this.readOnlyScopeActive = false;
+		this.endCount++;
+	}
+	simulateViolation(): void {
+		this.readOnlyViolated = true;
+	}
+}
+
+function adaptReadOnlyFs(host: TestReadOnlyFs): IFileSystem {
+	// Proxy: forward IFileSystem calls to InMemoryFs but expose the
+	// IReadOnlyScopeFs surface (begin/end/active/violated) on the same
+	// object so SessionManager's `asReadOnlyFs` duck-typed check sees it.
+	const fs = host.inner as unknown as Record<string, unknown>;
+	const merged = new Proxy(host as unknown as Record<string, unknown>, {
+		get(target, prop, receiver) {
+			if (prop in target) return Reflect.get(target, prop, receiver);
+			const v = fs[prop as string];
+			return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(host.inner) : v;
+		},
+	});
+	return merged as unknown as IFileSystem;
+}
+
+/** Minimal ICoherentFs around InMemoryFs so ensureFreshCache will probe Redis. */
+class CoherentInMemoryFs {
+	readonly inner: InMemoryFs;
+	#dirty = false;
+	reloadCount = 0;
+	constructor() {
+		this.inner = new InMemoryFs();
+	}
+	wasDirty(): boolean {
+		return this.#dirty;
+	}
+	clearDirty(): void {
+		this.#dirty = false;
+	}
+	async reload(): Promise<void> {
+		this.reloadCount++;
+	}
+}
+
+function adaptCoherentFs(host: CoherentInMemoryFs): IFileSystem {
+	const fs = host.inner as unknown as Record<string, unknown>;
+	return new Proxy(host as unknown as Record<string, unknown>, {
+		get(target, prop, receiver) {
+			if (prop in target) return Reflect.get(target, prop, receiver);
+			const v = fs[prop as string];
+			return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(host.inner) : v;
+		},
+	}) as unknown as IFileSystem;
+}
+
+describe("SessionManager.withSessionRead", () => {
+	it("multiple readOnly calls run in parallel on the same sandbox", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-parallel");
+
+		let active = 0;
+		let peak = 0;
+		const work = async (): Promise<void> => {
+			active++;
+			peak = Math.max(peak, active);
+			await new Promise((r) => setImmediate(r));
+			active--;
+		};
+
+		await Promise.all([
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+			sm.withSessionRead(T, "sb-parallel", work),
+		]);
+
+		expect(peak).toBeGreaterThanOrEqual(2); // at minimum, parallel
+		expect(peak).toBe(4); // exact: all four ran simultaneously
+	});
+
+	it("readOnly waits for an in-flight writer", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-w-blocks-r");
+		const order: string[] = [];
+
+		let releaseW!: () => void;
+		const writer = sm.withSession(T, "sb-w-blocks-r", async () => {
+			order.push("w-start");
+			await new Promise<void>((r) => {
+				releaseW = r;
+			});
+			order.push("w-end");
+		});
+
+		// Wait for writer to enter
+		await new Promise((r) => setImmediate(r));
+
+		const reader = sm.withSessionRead(T, "sb-w-blocks-r", async () => {
+			order.push("r-start");
+			order.push("r-end");
+		});
+
+		await new Promise((r) => setImmediate(r));
+		expect(order).toEqual(["w-start"]);
+
+		releaseW();
+		await Promise.all([writer, reader]);
+		expect(order).toEqual(["w-start", "w-end", "r-start", "r-end"]);
+	});
+
+	it("a writer waits for in-flight readers and queues new readers behind it", async () => {
+		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+		await sm.getOrCreate(T, "sb-r-blocks-w");
+		const order: string[] = [];
+
+		let releaseR1!: () => void;
+		const reader1 = sm.withSessionRead(T, "sb-r-blocks-w", async () => {
+			order.push("r1-start");
+			await new Promise<void>((r) => {
+				releaseR1 = r;
+			});
+			order.push("r1-end");
+		});
+		await new Promise((r) => setImmediate(r));
+
+		const writer = sm.withSession(T, "sb-r-blocks-w", async () => {
+			order.push("w-acquired");
+		});
+		await new Promise((r) => setImmediate(r));
+
+		// New reader must wait behind the queued writer (writer-priority)
+		const reader2 = sm.withSessionRead(T, "sb-r-blocks-w", async () => {
+			order.push("r2-acquired");
+		});
+		await new Promise((r) => setImmediate(r));
+		expect(order).toEqual(["r1-start"]);
+
+		releaseR1();
+		await Promise.all([reader1, writer, reader2]);
+		expect(order).toEqual(["r1-start", "r1-end", "w-acquired", "r2-acquired"]);
+	});
+
+	it("opens and closes the read-only scope around fn on a scoped FS", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-scope");
+
+		let activeDuringFn: boolean | undefined;
+		await sm.withSessionRead(T, "sb-scope", async () => {
+			activeDuringFn = host.readOnlyScopeActive;
+		});
+		expect(activeDuringFn).toBe(true);
+		expect(host.readOnlyScopeActive).toBe(false);
+		expect(host.beginCount).toBe(1);
+		expect(host.endCount).toBe(1);
+	});
+
+	it("surfaces EREADONLY_VIOLATION when fn returns successfully but the FS recorded a violation", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-violation");
+
+		await expect(
+			sm.withSessionRead(T, "sb-violation", async () => {
+				host.simulateViolation();
+			}),
+		).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
+
+		// Scope is still closed even on the violation throw
+		expect(host.readOnlyScopeActive).toBe(false);
+		expect(host.endCount).toBe(1);
+	});
+
+	it("preserves the original error when fn throws even if a violation was recorded", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-violation-throw");
+
+		await expect(
+			sm.withSessionRead(T, "sb-violation-throw", async () => {
+				host.simulateViolation();
+				throw new Error("script blew up");
+			}),
+		).rejects.toThrow("script blew up");
+		expect(host.readOnlyScopeActive).toBe(false);
+	});
+
+	it("single-flights ensureFreshCache across parallel readers", async () => {
+		// Fake Redis that records every GET. The probe done by getOrCreate
+		// for the initial version returns immediately; the probes done by
+		// ensureFreshCache for the parallel readers block on `block` so we
+		// can observe how many concurrent GETs are in-flight.
+		const getCalls: string[] = [];
+		let blockReads = false;
+		let onceResolve!: () => void;
+		const block = new Promise<void>((r) => {
+			onceResolve = r;
+		});
+		const fakeRedis: Partial<Redis> = {
+			get: vi.fn(async (key: string) => {
+				getCalls.push(key);
+				if (blockReads) await block;
+				return "0";
+			}),
+			incr: vi.fn(async () => 1),
+			expire: vi.fn(async () => 1),
+		};
+
+		const host = new CoherentInMemoryFs();
+		const sm = new SessionManager({
+			createFs: async () => adaptCoherentFs(host),
+			redis: fakeRedis as Redis,
+		});
+		await sm.getOrCreate(T, "sb-single-flight");
+		const initialGets = getCalls.length;
+		blockReads = true;
+
+		// Five readers in flight before the first GET resolves.
+		const readers = Array.from({ length: 5 }, () => sm.withSessionRead(T, "sb-single-flight", async () => "ok"));
+
+		// Let the readers reach ensureFreshCache.
+		await new Promise((r) => setImmediate(r));
+		await new Promise((r) => setImmediate(r));
+		// All five share one in-flight GET (single-flight ensureFreshCache).
+		expect(getCalls.length - initialGets).toBe(1);
+
+		onceResolve();
+		await Promise.all(readers);
+		// And no extra GET was issued for the rest of the cohort.
+		expect(getCalls.length - initialGets).toBe(1);
+
+		await sm.shutdown();
+	});
+});

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -15,43 +15,46 @@ import type { Redis } from "ioredis";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { describe, expect, it, vi } from "vitest";
+import { readOnlyContext } from "../../read-only-context.js";
 import { SessionManager } from "../../session-manager.js";
 
 const T = "default";
 
 /**
- * Minimal IReadOnlyScopeFs that piggybacks on InMemoryFs. Tracks scope
- * begin/end calls and exposes a `simulateViolation()` switch the test can
- * flip to mark the FS as having attempted a write under read-only scope.
+ * Reference-counted IReadOnlyScopeFs that piggybacks on InMemoryFs. The
+ * production SqlFs uses the same refcount + AsyncLocalStorage scheme — this
+ * mock tracks depth so concurrent readers don't collide on a boolean flag.
+ *
+ * The host also exposes `simulateViolation(ctx)` so a test can mark a
+ * specific reader's `readOnlyContext` store as violated, exercising the
+ * per-cohort attribution path the SessionManager uses.
  */
 class TestReadOnlyFs {
 	readonly inner: InMemoryFs;
-	readOnlyScopeActive = false;
-	readOnlyViolated = false;
+	depth = 0;
 	beginCount = 0;
 	endCount = 0;
 	constructor() {
 		this.inner = new InMemoryFs();
 	}
+	get readOnlyScopeActive(): boolean {
+		return this.depth > 0;
+	}
 	beginReadOnlyScope(): void {
-		if (this.readOnlyScopeActive) throw new Error("scope already active");
-		this.readOnlyScopeActive = true;
-		this.readOnlyViolated = false;
+		this.depth++;
 		this.beginCount++;
 	}
 	endReadOnlyScope(): void {
-		this.readOnlyScopeActive = false;
+		if (this.depth === 0) throw new Error("no active read-only scope");
+		this.depth--;
 		this.endCount++;
-	}
-	simulateViolation(): void {
-		this.readOnlyViolated = true;
 	}
 }
 
 function adaptReadOnlyFs(host: TestReadOnlyFs): IFileSystem {
 	// Proxy: forward IFileSystem calls to InMemoryFs but expose the
-	// IReadOnlyScopeFs surface (begin/end/active/violated) on the same
-	// object so SessionManager's `asReadOnlyFs` duck-typed check sees it.
+	// IReadOnlyScopeFs surface (begin/end/active) on the same object so
+	// SessionManager's `asReadOnlyFs` duck-typed check sees it.
 	const fs = host.inner as unknown as Record<string, unknown>;
 	const merged = new Proxy(host as unknown as Record<string, unknown>, {
 		get(target, prop, receiver) {
@@ -94,15 +97,21 @@ function adaptCoherentFs(host: CoherentInMemoryFs): IFileSystem {
 }
 
 describe("SessionManager.withSessionRead", () => {
-	it("multiple readOnly calls run in parallel on the same sandbox", async () => {
-		const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+	it("multiple readOnly calls run in parallel on the same sandbox (refcounted scope)", async () => {
+		// Uses a real IReadOnlyScopeFs mock so the refcount path is exercised.
+		// The pre-fix impl threw "scope already active" on the second concurrent
+		// reader against a scoped FS; this test would have caught that.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
 		await sm.getOrCreate(T, "sb-parallel");
 
 		let active = 0;
 		let peak = 0;
+		let peakDepth = 0;
 		const work = async (): Promise<void> => {
 			active++;
 			peak = Math.max(peak, active);
+			peakDepth = Math.max(peakDepth, host.depth);
 			await new Promise((r) => setImmediate(r));
 			active--;
 		};
@@ -114,8 +123,11 @@ describe("SessionManager.withSessionRead", () => {
 			sm.withSessionRead(T, "sb-parallel", work),
 		]);
 
-		expect(peak).toBeGreaterThanOrEqual(2); // at minimum, parallel
-		expect(peak).toBe(4); // exact: all four ran simultaneously
+		expect(peak).toBe(4); // all four ran simultaneously
+		expect(peakDepth).toBe(4); // refcount tracked all four under shared scope
+		expect(host.depth).toBe(0); // last reader cleared the scope
+		expect(host.beginCount).toBe(4);
+		expect(host.endCount).toBe(4);
 	});
 
 	it("readOnly waits for an in-flight writer", async () => {
@@ -195,20 +207,54 @@ describe("SessionManager.withSessionRead", () => {
 		expect(host.endCount).toBe(1);
 	});
 
-	it("surfaces EREADONLY_VIOLATION when fn returns successfully but the FS recorded a violation", async () => {
+	it("surfaces EREADONLY_VIOLATION when the per-call context was marked", async () => {
 		const host = new TestReadOnlyFs();
 		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
 		await sm.getOrCreate(T, "sb-violation");
 
 		await expect(
 			sm.withSessionRead(T, "sb-violation", async () => {
-				host.simulateViolation();
+				// Simulate the SqlFs `#assertWritable` path marking *this* call's
+				// AsyncLocalStorage context.
+				const ctx = readOnlyContext.getStore();
+				if (ctx !== undefined) ctx.violated = true;
 			}),
 		).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
 
 		// Scope is still closed even on the violation throw
 		expect(host.readOnlyScopeActive).toBe(false);
 		expect(host.endCount).toBe(1);
+	});
+
+	it("does not falsely flag an innocent concurrent reader when a sibling is lying", async () => {
+		// Two readers run in parallel under one shared scope. Reader A's fn
+		// triggers a violation on its own ALS context. Reader B's context
+		// stays clean — it must not surface EREADONLY_VIOLATION.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-mixed");
+
+		let releaseInnocent!: () => void;
+		const innocentBlocker = new Promise<void>((r) => {
+			releaseInnocent = r;
+		});
+
+		const liarP = sm.withSessionRead(T, "sb-mixed", async () => {
+			// Wait until innocent reader is also in-flight so depth is 2.
+			await new Promise((r) => setImmediate(r));
+			expect(host.depth).toBe(2);
+			const ctx = readOnlyContext.getStore();
+			if (ctx !== undefined) ctx.violated = true;
+		});
+
+		const innocentP = sm.withSessionRead(T, "sb-mixed", async () => {
+			await innocentBlocker;
+		});
+
+		await expect(liarP).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
+		releaseInnocent();
+		await expect(innocentP).resolves.toBeUndefined();
+		expect(host.depth).toBe(0);
 	});
 
 	it("preserves the original error when fn throws even if a violation was recorded", async () => {
@@ -218,11 +264,28 @@ describe("SessionManager.withSessionRead", () => {
 
 		await expect(
 			sm.withSessionRead(T, "sb-violation-throw", async () => {
-				host.simulateViolation();
+				const ctx = readOnlyContext.getStore();
+				if (ctx !== undefined) ctx.violated = true;
 				throw new Error("script blew up");
 			}),
 		).rejects.toThrow("script blew up");
 		expect(host.readOnlyScopeActive).toBe(false);
+	});
+
+	it("does not leak inFlight when fn throws", async () => {
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		const session = await sm.getOrCreate(T, "sb-inflight");
+		expect(session.inFlight).toBe(0);
+
+		await expect(
+			sm.withSessionRead(T, "sb-inflight", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		expect(session.inFlight).toBe(0);
+		expect(host.depth).toBe(0);
 	});
 
 	it("single-flights ensureFreshCache across parallel readers", async () => {

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -257,6 +257,24 @@ describe("SessionManager.withSessionRead", () => {
 		expect(host.depth).toBe(0);
 	});
 
+	it("remaps a raw EREADONLY thrown by fn to EREADONLY_VIOLATION", async () => {
+		// Bash redirections (`echo > f`) let SqlFs's synchronous EREADONLY
+		// reject through bash.exec rather than turning it into a non-zero exit.
+		// withSessionReadEntry must remap the raw fs error to EREADONLY_VIOLATION
+		// so route mapping is uniform.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-raw-ereadonly");
+
+		await expect(
+			sm.withSessionRead(T, "sb-raw-ereadonly", async () => {
+				throw Object.assign(new Error("EREADONLY: read-only filesystem, writeFile '/x'"), { code: "EREADONLY" });
+			}),
+		).rejects.toMatchObject({ code: "EREADONLY_VIOLATION" });
+		expect(host.readOnlyScopeActive).toBe(false);
+		expect(host.endCount).toBe(1);
+	});
+
 	it("preserves the original error when fn throws even if a violation was recorded", async () => {
 		const host = new TestReadOnlyFs();
 		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -290,6 +290,33 @@ describe("SessionManager.withSessionRead", () => {
 		expect(host.readOnlyScopeActive).toBe(false);
 	});
 
+	it("audits the violation even when fn throws an unrelated error (e.g. timeout)", async () => {
+		// Scenario: bash records EREADONLY mid-script (sets ctx.violated=true)
+		// but the script keeps running and later aborts on a timeout — bash.exec
+		// throws an AbortError. The original error must win as the caller-visible
+		// throw, but the violation must STILL be audited so the security event
+		// surfaces to monitoring.
+		const host = new TestReadOnlyFs();
+		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });
+		await sm.getOrCreate(T, "sb-audit-on-throw");
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		await expect(
+			sm.withSessionRead(T, "sb-audit-on-throw", async () => {
+				const ctx = readOnlyContext.getStore();
+				if (ctx !== undefined) ctx.violated = true;
+				throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+			}),
+		).rejects.toThrow("The operation was aborted");
+
+		const audited = logSpy.mock.calls.some((call) => {
+			const arg = call[0];
+			return typeof arg === "string" && arg.includes('"event":"read_only_violation"');
+		});
+		expect(audited).toBe(true);
+		logSpy.mockRestore();
+	});
+
 	it("does not leak inFlight when fn throws", async () => {
 		const host = new TestReadOnlyFs();
 		const sm = new SessionManager({ createFs: async () => adaptReadOnlyFs(host) });

--- a/src/fs/sql-fs/errors.ts
+++ b/src/fs/sql-fs/errors.ts
@@ -50,6 +50,16 @@ export function createEinval(path: string): Error {
 	return makeFsError("EINVAL", `EINVAL: invalid argument, '${path}'`, path);
 }
 
+/**
+ * EREADONLY: write attempted while the filesystem is in read-only scope.
+ * Surfaced when a `readOnly: true` exec script tries to mutate state. The
+ * session-manager wraps the script-level handler so the offending command
+ * fails fast and other concurrent readers never observe partial state.
+ */
+export function createEreadonly(path: string, op: string): Error {
+	return makeFsError("EREADONLY", `EREADONLY: read-only filesystem, ${op} '${path}'`, path);
+}
+
 // ── Sensitive-pattern stripping ───────────────────────────────────────────────
 
 /** Patterns whose matches are replaced with [redacted] in sanitized error messages. */

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -13,6 +13,7 @@ import type { CpOptions, FileContent, FsStat, IFileSystem, MkdirOptions, RmOptio
 import { DefenseInDepthBox } from "just-bash";
 import { LRUCache } from "lru-cache";
 
+import { readOnlyContext } from "../../api/read-only-context.js";
 import {
 	createEexist,
 	createEinval,
@@ -126,21 +127,17 @@ export interface IScriptTxFs extends ICoherentFs {
  * EREADONLY immediately — the offending bash command fails fast and no
  * partial state escapes to other concurrent readers.
  *
- * SqlFs satisfies this interface; the `memory` backend does not (its
- * factory wraps it separately when needed).
+ * Reference-counted: every concurrent reader calls `beginReadOnlyScope`
+ * on entry and `endReadOnlyScope` on exit. The scope stays active while
+ * any reader holds it. Violation attribution is per-call via the
+ * `readOnlyContext` AsyncLocalStorage rather than an FS-level flag, so
+ * a lying script in one reader cannot falsely flag innocent readers
+ * sharing the same FS.
  */
 export interface IReadOnlyScopeFs extends IFileSystem {
 	beginReadOnlyScope(): void;
 	endReadOnlyScope(): void;
 	readonly readOnlyScopeActive: boolean;
-	/**
-	 * True iff at least one mutating syscall was attempted while the
-	 * read-only scope was active. Cleared on the next `beginReadOnlyScope`.
-	 * Used by the session manager to surface a structured violation error
-	 * after the bash script returns even though the offending command
-	 * itself just exited non-zero.
-	 */
-	readonly readOnlyViolated: boolean;
 }
 
 export class SqlFs<Tx = unknown> implements ICoherentFs {
@@ -176,8 +173,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	#scriptTxEnd: (() => void) | undefined;
 	#scriptTxAbort: ((err: Error) => void) | undefined;
 	#scriptTxPromise: Promise<void> | undefined;
-	#readOnlyScope = false;
-	#readOnlyViolated = false;
+	#readOnlyDepth = 0;
 
 	constructor(opts: SqlFsOptions<Tx>) {
 		this.#dialect = opts.dialect;
@@ -571,28 +567,31 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	// ── Read-only scope (parallel readOnly bash exec) ────────────────────────────
 
 	get readOnlyScopeActive(): boolean {
-		return this.#readOnlyScope;
+		return this.#readOnlyDepth > 0;
 	}
 
-	get readOnlyViolated(): boolean {
-		return this.#readOnlyViolated;
-	}
-
+	/**
+	 * Reference-counted: every concurrent reader bumps the depth, the last
+	 * one to exit clears it. The shared SqlFs is mutation-locked while any
+	 * reader holds a scope. Per-cohort violation attribution is delegated
+	 * to `readOnlyContext` (AsyncLocalStorage) so a lying script in one
+	 * reader never falsely flags innocent concurrent readers.
+	 */
 	beginReadOnlyScope(): void {
-		if (this.#readOnlyScope) {
-			throw new Error("beginReadOnlyScope: a read-only scope is already active");
-		}
-		this.#readOnlyScope = true;
-		this.#readOnlyViolated = false;
+		this.#readOnlyDepth++;
 	}
 
 	endReadOnlyScope(): void {
-		this.#readOnlyScope = false;
+		if (this.#readOnlyDepth === 0) {
+			throw new Error("endReadOnlyScope: no active read-only scope");
+		}
+		this.#readOnlyDepth--;
 	}
 
 	#assertWritable(path: string, op: string): void {
-		if (this.#readOnlyScope) {
-			this.#readOnlyViolated = true;
+		if (this.#readOnlyDepth > 0) {
+			const ctx = readOnlyContext.getStore();
+			if (ctx !== undefined) ctx.violated = true;
 			throw createEreadonly(path, op);
 		}
 	}

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -140,7 +140,7 @@ export interface IReadOnlyScopeFs extends IFileSystem {
 	readonly readOnlyScopeActive: boolean;
 }
 
-export class SqlFs<Tx = unknown> implements ICoherentFs {
+export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 	readonly #dialect: SqlDialect<Tx>;
 	readonly #sandboxId: string;
 	readonly #tenantId: string;

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -21,6 +21,7 @@ import {
 	createEnotdir,
 	createEnotempty,
 	createEperm,
+	createEreadonly,
 } from "./errors.js";
 import type { RedisBlobCache } from "./redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "./redis-path-snapshot.js";
@@ -119,6 +120,29 @@ export interface IScriptTxFs extends ICoherentFs {
 	readonly scriptTxOpen: boolean;
 }
 
+/**
+ * Read-only scope hooks used by the parallel-readOnly bash exec path. While
+ * the scope is active every mutating method on the filesystem throws
+ * EREADONLY immediately — the offending bash command fails fast and no
+ * partial state escapes to other concurrent readers.
+ *
+ * SqlFs satisfies this interface; the `memory` backend does not (its
+ * factory wraps it separately when needed).
+ */
+export interface IReadOnlyScopeFs extends IFileSystem {
+	beginReadOnlyScope(): void;
+	endReadOnlyScope(): void;
+	readonly readOnlyScopeActive: boolean;
+	/**
+	 * True iff at least one mutating syscall was attempted while the
+	 * read-only scope was active. Cleared on the next `beginReadOnlyScope`.
+	 * Used by the session manager to surface a structured violation error
+	 * after the bash script returns even though the offending command
+	 * itself just exited non-zero.
+	 */
+	readonly readOnlyViolated: boolean;
+}
+
 export class SqlFs<Tx = unknown> implements ICoherentFs {
 	readonly #dialect: SqlDialect<Tx>;
 	readonly #sandboxId: string;
@@ -152,6 +176,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	#scriptTxEnd: (() => void) | undefined;
 	#scriptTxAbort: ((err: Error) => void) | undefined;
 	#scriptTxPromise: Promise<void> | undefined;
+	#readOnlyScope = false;
+	#readOnlyViolated = false;
 
 	constructor(opts: SqlFsOptions<Tx>) {
 		this.#dialect = opts.dialect;
@@ -542,6 +568,35 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 		this.#scriptScope = true;
 	}
 
+	// ── Read-only scope (parallel readOnly bash exec) ────────────────────────────
+
+	get readOnlyScopeActive(): boolean {
+		return this.#readOnlyScope;
+	}
+
+	get readOnlyViolated(): boolean {
+		return this.#readOnlyViolated;
+	}
+
+	beginReadOnlyScope(): void {
+		if (this.#readOnlyScope) {
+			throw new Error("beginReadOnlyScope: a read-only scope is already active");
+		}
+		this.#readOnlyScope = true;
+		this.#readOnlyViolated = false;
+	}
+
+	endReadOnlyScope(): void {
+		this.#readOnlyScope = false;
+	}
+
+	#assertWritable(path: string, op: string): void {
+		if (this.#readOnlyScope) {
+			this.#readOnlyViolated = true;
+			throw createEreadonly(path, op);
+		}
+	}
+
 	async endScriptScope(): Promise<void> {
 		if (!this.#scriptScope) return;
 		this.#scriptScope = false;
@@ -594,6 +649,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	// shadowing each other — the dialect would commit only one and drop the rest.
 	async bulkIngest(files: BulkIngestFile[]): Promise<void> {
 		if (files.length === 0) return;
+		this.#assertWritable("/", "bulkIngest");
 		const normalized: BulkIngestFile[] = [];
 		const seen = new Set<string>();
 		const bytesByPath = new Map<string, Uint8Array>();
@@ -631,6 +687,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async writeFile(inputPath: string, content: FileContent, _options?: WriteFileOpts): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "writeFile");
 		const { name, parentEntry } = this.#requireParentDir(path);
 
 		const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
@@ -682,6 +739,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async appendFile(inputPath: string, content: FileContent, _options?: WriteFileOpts): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "appendFile");
 
 		const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
 		const mtime = new Date();
@@ -749,6 +807,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async mkdir(inputPath: string, options?: MkdirOptions): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "mkdir");
 		const recursive = options?.recursive ?? false;
 		const mtime = new Date();
 
@@ -826,6 +885,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async rm(inputPath: string, options?: RmOptions): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "rm");
 		const entry = this.#pathCache.get(path);
 
 		if (!entry) {
@@ -897,6 +957,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async chmod(inputPath: string, mode: number): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "chmod");
 		const entry = this.#pathCache.get(path);
 		if (!entry) throw createEnoent(path);
 
@@ -910,6 +971,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async utimes(inputPath: string, _atime: Date, mtime: Date): Promise<void> {
 		const path = validatePath(inputPath);
+		this.#assertWritable(path, "utimes");
 		const entry = this.#pathCache.get(path);
 		if (!entry) throw createEnoent(path);
 
@@ -1026,6 +1088,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async cp(inputSrc: string, inputDest: string, options?: CpOptions): Promise<void> {
 		const src = validatePath(inputSrc);
 		const dest = validatePath(inputDest);
+		this.#assertWritable(dest, "cp");
 		const srcEntry = this.#pathCache.get(src);
 		if (!srcEntry) throw createEnoent(src);
 
@@ -1114,6 +1177,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async mv(inputSrc: string, inputDest: string): Promise<void> {
 		const src = validatePath(inputSrc);
 		const dest = validatePath(inputDest);
+		this.#assertWritable(dest, "mv");
 		const srcEntry = this.#pathCache.get(src);
 		if (!srcEntry) throw createEnoent(src);
 
@@ -1191,6 +1255,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 
 	async symlink(target: string, inputLinkPath: string): Promise<void> {
 		const linkPath = validatePath(inputLinkPath);
+		this.#assertWritable(linkPath, "symlink");
 		// Note: target is intentionally not normalized - it's stored as-is
 		if (target.includes("\0")) throw createEinval(target);
 		if (!this.#allowSymlinks) throw createEperm(linkPath, "symlink");
@@ -1226,6 +1291,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs {
 	async link(inputExistingPath: string, inputNewPath: string): Promise<void> {
 		const existingPath = validatePath(inputExistingPath);
 		const newPath = validatePath(inputNewPath);
+		this.#assertWritable(newPath, "link");
 		const srcEntry = this.#pathCache.get(existingPath);
 		if (!srcEntry) throw createEnoent(existingPath);
 		if (srcEntry.kind === INODE_KIND.DIRECTORY) throw createEperm(existingPath, "link");

--- a/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
+++ b/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readOnlyContext } from "../../../../api/read-only-context.js";
 import { SqlFs } from "../../sql-fs.js";
 import type { PathCacheEntry, SqlDialect } from "../../types.js";
 
@@ -92,15 +93,26 @@ describe("SqlFs.readOnlyScope", () => {
 		expect(fs.readOnlyScopeActive).toBe(false);
 	});
 
-	it("nested begin throws", () => {
+	it("ref-counts nested begin/end (parallel readers)", () => {
 		fs.beginReadOnlyScope();
-		expect(() => fs.beginReadOnlyScope()).toThrow(/already active/);
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true);
 		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true); // still held by the first begin
+		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
+	});
+
+	it("endReadOnlyScope without an active scope throws", () => {
+		expect(() => fs.endReadOnlyScope()).toThrow(/no active read-only scope/);
 	});
 
 	it("writeFile throws EREADONLY before issuing any DB call", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		const ctx = { violated: false };
+		await readOnlyContext.run(ctx, async () => {
+			await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
 		// The throw happens before any new transaction is opened — only the
 		// initial loadAllPaths transaction from ready() may have run.
 		expect(dialect.upsertBlob).not.toHaveBeenCalled();
@@ -108,22 +120,43 @@ describe("SqlFs.readOnlyScope", () => {
 		expect(dialect.upsertDirent).not.toHaveBeenCalled();
 		expect(dialect.deleteDirent).not.toHaveBeenCalled();
 		expect(dialect.updateInode).not.toHaveBeenCalled();
-		expect(fs.readOnlyViolated).toBe(true);
+		expect(ctx.violated).toBe(true);
+		fs.endReadOnlyScope();
+	});
+
+	it("violation marks only the originating reader's context, not concurrent ones", async () => {
+		fs.beginReadOnlyScope();
+		fs.beginReadOnlyScope();
+		const ctxLying = { violated: false };
+		const ctxInnocent = { violated: false };
+
+		await readOnlyContext.run(ctxLying, async () => {
+			await expect(fs.writeFile("/lie.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
+		await readOnlyContext.run(ctxInnocent, async () => {
+			await fs.exists("/file.txt");
+		});
+
+		expect(ctxLying.violated).toBe(true);
+		expect(ctxInnocent.violated).toBe(false);
+		fs.endReadOnlyScope();
 		fs.endReadOnlyScope();
 	});
 
 	it("appendFile, mkdir, rm, chmod, utimes, cp, mv, link all throw EREADONLY", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
-		await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
-			code: "EREADONLY",
+		await readOnlyContext.run({ violated: false }, async () => {
+			await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+			await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
+				code: "EREADONLY",
+			});
 		});
 		// The throw happens before any new transaction is opened — only the
 		// initial loadAllPaths transaction from ready() may have run.
@@ -137,7 +170,9 @@ describe("SqlFs.readOnlyScope", () => {
 
 	it("symlink also throws EREADONLY (even before the symlinks-disabled check)", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await readOnlyContext.run({ violated: false }, async () => {
+			await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
 		fs.endReadOnlyScope();
 	});
 
@@ -151,19 +186,24 @@ describe("SqlFs.readOnlyScope", () => {
 		fs.endReadOnlyScope();
 	});
 
-	it("after end, writes succeed again and the violated flag persists until the next begin", async () => {
+	it("after the last end, writes succeed again and #assertWritable is a no-op", async () => {
 		fs.beginReadOnlyScope();
-		await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
-		expect(fs.readOnlyViolated).toBe(true);
+		const ctx = { violated: false };
+		await readOnlyContext.run(ctx, async () => {
+			await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		});
+		expect(ctx.violated).toBe(true);
 		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
 
-		// Outside the scope the violated flag is sticky until the next
-		// beginReadOnlyScope resets it — that's intentional so the session
-		// manager can read it after fn returns.
-		expect(fs.readOnlyViolated).toBe(true);
-
-		fs.beginReadOnlyScope();
-		expect(fs.readOnlyViolated).toBe(false);
-		fs.endReadOnlyScope();
+		// A fresh context outside any scope is never marked as violated —
+		// even if a context is in scope, writes are unguarded once depth is 0.
+		const fresh = { violated: false };
+		await readOnlyContext.run(fresh, async () => {
+			// Reads obviously work; writes would also work (we don't actually
+			// fire one to avoid the dialect mocks; the depth check is enough).
+			expect(fs.readOnlyScopeActive).toBe(false);
+		});
+		expect(fresh.violated).toBe(false);
 	});
 });

--- a/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
+++ b/src/fs/sql-fs/tests/unit/sql-fs.read-only.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for SqlFs read-only scope (parallel readOnly bash exec).
+ *
+ * Coverage:
+ *  - Begin/end scope toggles the active flag.
+ *  - Every mutating method throws EREADONLY while the scope is active.
+ *  - The violated flag flips to true on the first attempted mutation and is
+ *    reset on the next beginReadOnlyScope.
+ *  - Read methods continue to work while the scope is active.
+ *  - No DB write methods are dispatched (dialect mocks remain uncalled) — the
+ *    rejection is a fast pre-DB guard.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "../../sql-fs.js";
+import type { PathCacheEntry, SqlDialect } from "../../types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+const ROOT: { path: string } & PathCacheEntry = {
+	path: "/",
+	inodeId: 1n,
+	kind: 2,
+	mode: 0o755,
+	size: 0,
+	mtime: now,
+	contentSha256: null,
+	symlinkTarget: null,
+};
+
+const FILE: { path: string } & PathCacheEntry = {
+	path: "/file.txt",
+	inodeId: 10n,
+	kind: 1,
+	mode: 0o644,
+	size: 5,
+	mtime: now,
+	contentSha256: new Uint8Array(32),
+	symlinkTarget: null,
+};
+
+function makeFs() {
+	const dialect = {
+		connect: vi.fn(),
+		disconnect: vi.fn(),
+		transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+		setSandboxContext: vi.fn(),
+		setSandboxContextWithLock: vi.fn(),
+		loadAllPaths: vi.fn(async () => [ROOT, FILE]),
+		createSandbox: vi.fn(),
+		deleteSandbox: vi.fn(),
+		createInode: vi.fn(),
+		getInode: vi.fn(),
+		updateInode: vi.fn(),
+		deleteInode: vi.fn(),
+		incrementNlink: vi.fn(),
+		decrementNlink: vi.fn(),
+		insertDirent: vi.fn(),
+		upsertDirent: vi.fn(),
+		deleteDirent: vi.fn(),
+		listDirents: vi.fn(),
+		moveDirent: vi.fn(),
+		upsertBlob: vi.fn(),
+		getBlob: vi.fn(async () => null),
+		getBlobNoTx: vi.fn(async () => null),
+		gcOrphanBlobs: vi.fn(),
+		getBlobsForSandbox: vi.fn(async () => []),
+		loadSubtreeInodes: vi.fn(async () => []),
+		bulkIngest: vi.fn(),
+		resolvePath: vi.fn(),
+	} as unknown as SqlDialect<unknown>;
+	const fs = new SqlFs({ dialect, sandboxId: "s1" });
+	return { fs, dialect };
+}
+
+describe("SqlFs.readOnlyScope", () => {
+	let fs: SqlFs;
+	let dialect: SqlDialect<unknown>;
+
+	beforeEach(async () => {
+		const made = makeFs();
+		fs = made.fs;
+		dialect = made.dialect;
+		await fs.ready();
+	});
+
+	it("begin/end toggles the active flag", () => {
+		expect(fs.readOnlyScopeActive).toBe(false);
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(true);
+		fs.endReadOnlyScope();
+		expect(fs.readOnlyScopeActive).toBe(false);
+	});
+
+	it("nested begin throws", () => {
+		fs.beginReadOnlyScope();
+		expect(() => fs.beginReadOnlyScope()).toThrow(/already active/);
+		fs.endReadOnlyScope();
+	});
+
+	it("writeFile throws EREADONLY before issuing any DB call", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.writeFile("/new.txt", "x")).rejects.toMatchObject({ code: "EREADONLY" });
+		// The throw happens before any new transaction is opened — only the
+		// initial loadAllPaths transaction from ready() may have run.
+		expect(dialect.upsertBlob).not.toHaveBeenCalled();
+		expect(dialect.createInode).not.toHaveBeenCalled();
+		expect(dialect.upsertDirent).not.toHaveBeenCalled();
+		expect(dialect.deleteDirent).not.toHaveBeenCalled();
+		expect(dialect.updateInode).not.toHaveBeenCalled();
+		expect(fs.readOnlyViolated).toBe(true);
+		fs.endReadOnlyScope();
+	});
+
+	it("appendFile, mkdir, rm, chmod, utimes, cp, mv, link all throw EREADONLY", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.appendFile("/file.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.mkdir("/d")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.rm("/file.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.chmod("/file.txt", 0o600)).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.utimes("/file.txt", now, now)).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.cp("/file.txt", "/copy.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.mv("/file.txt", "/moved.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.link("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		await expect(fs.bulkIngest([{ path: "/x", content: new Uint8Array([1]), mode: 0o644 }])).rejects.toMatchObject({
+			code: "EREADONLY",
+		});
+		// The throw happens before any new transaction is opened — only the
+		// initial loadAllPaths transaction from ready() may have run.
+		expect(dialect.upsertBlob).not.toHaveBeenCalled();
+		expect(dialect.createInode).not.toHaveBeenCalled();
+		expect(dialect.upsertDirent).not.toHaveBeenCalled();
+		expect(dialect.deleteDirent).not.toHaveBeenCalled();
+		expect(dialect.updateInode).not.toHaveBeenCalled();
+		fs.endReadOnlyScope();
+	});
+
+	it("symlink also throws EREADONLY (even before the symlinks-disabled check)", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.symlink("/file.txt", "/link.txt")).rejects.toMatchObject({ code: "EREADONLY" });
+		fs.endReadOnlyScope();
+	});
+
+	it("read methods still work while the scope is active", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.exists("/file.txt")).resolves.toBe(true);
+		await expect(fs.exists("/missing")).resolves.toBe(false);
+		await expect(fs.readdir("/")).resolves.toEqual(["file.txt"]);
+		const stat = await fs.stat("/file.txt");
+		expect(stat.size).toBe(5);
+		fs.endReadOnlyScope();
+	});
+
+	it("after end, writes succeed again and the violated flag persists until the next begin", async () => {
+		fs.beginReadOnlyScope();
+		await expect(fs.writeFile("/x.txt", "y")).rejects.toMatchObject({ code: "EREADONLY" });
+		expect(fs.readOnlyViolated).toBe(true);
+		fs.endReadOnlyScope();
+
+		// Outside the scope the violated flag is sticky until the next
+		// beginReadOnlyScope resets it — that's intentional so the session
+		// manager can read it after fn returns.
+		expect(fs.readOnlyViolated).toBe(true);
+
+		fs.beginReadOnlyScope();
+		expect(fs.readOnlyViolated).toBe(false);
+		fs.endReadOnlyScope();
+	});
+});

--- a/thoughts/shared/research/2026-05-10_13-03-37_parallel-readonly-bash-exec.md
+++ b/thoughts/shared/research/2026-05-10_13-03-37_parallel-readonly-bash-exec.md
@@ -1,0 +1,416 @@
+---
+date: 2026-05-10T13:03:37+09:30
+researcher: Harry Nguyen
+git_commit: c149f89b4ce04b88fce1d68f8b624d4dfbc036a6
+branch: feature/RW-exec
+repository: virtualFS
+topic: "Parallel readOnly bash exec — Multiple Reader Single Writer pattern (Issue #60)"
+tags: [research, codebase, session-manager, exec, concurrency, rw-lock, sql-fs]
+status: complete
+last_updated: 2026-05-10
+last_updated_by: Harry Nguyen
+---
+
+# Research: Parallel readOnly bash exec — Multiple Reader Single Writer Pattern (Issue #60)
+
+**Date**: 2026-05-10 13:03:37 ACST  
+**Researcher**: Harry Nguyen  
+**Git Commit**: `c149f89b4ce04b88fce1d68f8b624d4dfbc036a6`  
+**Branch**: `feature/RW-exec`  
+**Repository**: virtualFS
+
+---
+
+## Research Question
+
+GitHub Issue #60 requests that multiple concurrent `bash.exec` calls against the same sandbox be allowed to run **without serializing on the per-session mutex** when those calls are explicitly tagged as `readOnly: true`. Today every exec acquires `session.mutex` exclusively — even for purely-read scripts like `cat`, `ls`, `grep`. This research maps the full current exec path and designs the integration points for the RW-lock feature.
+
+---
+
+## Summary
+
+Every exec today flows through a two-level locking hierarchy: a distributed Redis lock (per-sandbox, cross-replica) and an in-process exclusive `Mutex` from `async-mutex` (per-session). The bottleneck for the read path is the in-process `session.mutex.runExclusive()` call in `withSessionEntry`. The fix is to:
+
+1. Hand-roll an async readers-writer lock (`AsyncRwLock`) to replace `session.mutex`.
+2. Add a `withSessionReadEntry` path that acquires the lock in **shared** mode, single-flights `ensureFreshCache`, and then runs the exec.
+3. Guard all SqlFs write methods behind a `#readOnly` flag so lying scripts fail at the FS layer (option a from the issue).
+4. Add `readOnly?: boolean` to the Zod schemas for `/exec-sync`, `/exec`, `/exec-sync-batch`, and the MCP `bash_exec` tool.
+
+---
+
+## Detailed Findings
+
+### 1. The Current Exec Lock Hierarchy
+
+```
+HTTP request
+  └─ parseExecBody()                               exec.ts:56-126
+  └─ withOwnedSessionOrRehydrate()                 ownership.ts:27-44
+       └─ sessionManager.withSessionOrRehydrate()  session-manager.ts:605-618
+            └─ this.withExecLock()                 session-manager.ts:439-442
+                 │  (distributed Redis lock — skipped if redis === undefined)
+                 └─ this.withSessionEntry()         session-manager.ts:444-500
+                      └─ ensureFreshCache()         session-manager.ts:502-525
+                      └─ session.mutex.runExclusive()  ← THE BOTTLENECK
+                           └─ fn(session)
+                           └─ publishVersionIfDirty()  session-manager.ts:527-573
+```
+
+**Key files:**
+- `src/api/routes/exec.ts:128-348` — three route handlers (`/exec-sync`, `/exec`, `/exec-sync-batch`)
+- `src/api/session-manager.ts:444-500` — `withSessionEntry` — the central gating function
+- `src/api/session-manager.ts:439-442` — `withExecLock` — wraps in distributed Redis lock
+- `src/api/session-manager.ts:575-596` — `withSession` / `withExistingSession` — public entry points
+- `src/api/ownership.ts:27-44` — `withOwnedSessionOrRehydrate` — adds ownership check under lock
+
+### 2. The `session.mutex` — What it Protects
+
+`session.mutex: Mutex` (from `async-mutex`, imported at `session-manager.ts:15`) is **exclusive**:
+
+```typescript
+// session-manager.ts:457-499
+return session.mutex.runExclusive(async () => {
+    // 1. Guard against closing sessions
+    // 2. Increment session.inFlight
+    // 3. Run fn(session) — the actual bash.exec
+    // 4. publishVersionIfDirty (Redis version INCR)
+    // 5. Decrement session.inFlight
+    // 6. Refresh pathCacheBytes if dirty
+});
+```
+
+Everything inside is serialized — one caller at a time per sandbox. There is no shared/exclusive split, so even 10 concurrent `cat` calls wait in a FIFO queue.
+
+### 3. `ensureFreshCache` — the Cache Reload Point
+
+`src/api/session-manager.ts:502-525` — Called **before** `session.mutex.runExclusive()` in `withSessionEntry`. It:
+1. Reads the Redis version counter (`vfs:{tenantId}:ver:{sandboxId}`)
+2. If `session.lastSeenVersion !== current`, calls `coherent.reload()` (full pathCache scan from Postgres)
+3. Updates `session.lastSeenVersion`
+
+For parallel readers, all N callers would trigger N separate version probes and potentially N parallel `coherent.reload()` calls on the same `SqlFs` — inefficient and potentially racy. The fix: single-flight this call so all concurrent readers share one reload Promise.
+
+### 4. `execWithRuntimeThrottle` — the actual bash.exec wrapper
+
+`src/api/session-manager.ts:912-952` — Called inside the mutex by all exec handlers:
+
+```typescript
+async execWithRuntimeThrottle(session, script, opts) {
+    // Uses session.scriptTx (SessionScopedFs) if available
+    // Acquires Python/JS semaphore if script uses those runtimes
+    // Calls session.bash.exec(script, opts)
+}
+```
+
+This is called from inside the existing mutex, and will be called from inside the new shared-mode path too. The Python/JS semaphores (`pythonSem`, `jsSem`) are already designed for concurrent use across sessions — they apply globally, not per-session.
+
+### 5. The Three Exec Routes
+
+| Route | File:Line | Session Entry | Locks |
+|---|---|---|---|
+| `POST /exec-sync` | `exec.ts:132` | `withOwnedSessionOrRehydrate` | Redis exec lock + exclusive mutex |
+| `POST /exec` (SSE) | `exec.ts:221` | `withOwnedSessionOrRehydrate` then `withExistingSession` | Redis exec lock + exclusive mutex |
+| `POST /exec-sync-batch` | `exec.ts:301` | `withOwnedSessionOrRehydrate` | Redis exec lock + exclusive mutex |
+
+All three will need a `readOnly` branch routing to the new `withSessionRead` path.
+
+### 6. MCP `bash_exec` Tool
+
+`src/api/mcp/tools.ts:151-242` — Uses `withOwnedSessionOrRehydrate` (same exclusive path). The tool schema at line 154-159 currently has no `readOnly` field. The fix adds `readOnly: z.boolean().optional()`.
+
+### 7. `ownership.ts` — Single Wrapper Point
+
+`src/api/ownership.ts:27-44` — `withOwnedSessionOrRehydrate` is the single choke point that adds the owner check before delegating to `sessionManager.withSessionOrRehydrate`. A new `withOwnedSessionOrRehydrateRead` function here is the right place to add the read path, keeping exec.ts and tools.ts clean.
+
+### 8. `SqlFs` Write Methods — What Needs to be Guarded
+
+`src/fs/sql-fs/sql-fs.ts` — The class implements `ICoherentFs` (and `IScriptTxFs`). Write operations to guard with a `#readOnly` flag:
+
+- `writeFile` / `writeFileBuffer` 
+- `mkdir`
+- `unlink`
+- `rmdir`
+- `rename`
+- `symlink` (already EPERM by default, but still needs EREADONLY in read-only mode)
+- `chmod`
+- `bulkIngest`
+
+The `SqlFs` class already has a `#dirty` flag pattern (`wasDirty`, `clearDirty`, `session-manager.ts:473`) — adding `#readOnly: boolean` and `setReadOnly(v: boolean)` follows the same pattern. The guard is: throw `EROFS`/`EREADONLY` immediately at the top of each write method when `#readOnly === true`.
+
+**Critical point:** Since all concurrent readers share the same `SqlFs` instance, setting `sqlFs.readOnly = true` once before the first reader begins (and clearing when the last reader exits) is safe. The RW lock ensures no writer runs during this period. The lifecycle ties to shared-lock entry/exit.
+
+### 9. `SessionScopedFs` and `IScriptTxFs`
+
+`src/fs/sql-fs/session-scoped-fs.ts` — Wraps `IScriptTxFs` with `beginScope/endScope/abortScope`. For read-only execs, `SessionScopedFs.beginScope()` must NOT open a write transaction. Two options:
+- Skip `scriptTx` entirely for read-only execs (simpler)
+- Add a `beginReadScope()` that does nothing (or a no-tx read scope)
+
+**Recommendation:** For `readOnly` execs, skip `scriptTx` entirely (don't call `session.scriptTx.beginScope()`). The scriptTx scope exists to atomically commit writes; read-only execs produce no writes so a scope is unnecessary and skipping it avoids complications.
+
+### 10. `async-mutex` Import — What Changes
+
+`session-manager.ts:15`: `import { Mutex } from "async-mutex";`
+
+The `async-mutex` package only provides an exclusive `Mutex`. It does NOT provide a shared/exclusive RW lock. The issue explicitly says to hand-roll this. The import can stay (used by `session.mutex` until refactored) or be dropped after the RW lock is in place.
+
+### 11. `scripts/stress-test.ts` — Existing Scenario Structure
+
+The stress harness already runs four scenarios (lifecycle, concurrent exec, idle reap, batch) and produces `tasks/stress-test-results.md`. The parallel readOnly scenario needs to:
+- Create a sandbox
+- Fire N concurrent `readOnly` exec requests via HTTP
+- Assert wall time ≈ `max(per-op latency)` rather than `sum(per-op latency)` (i.e., the ops ran in parallel, not serialized)
+
+---
+
+## Architecture Insights
+
+### RW Lock Contract (to hand-roll)
+
+Node.js is single-threaded, so all state transitions happen atomically between `await` points. The lock state machine:
+
+```
+State: { readers: number, writerActive: boolean, pendingWriters: number }
+
+acquireRead():
+  if (writerActive || pendingWriters > 0) → queue reader (writer-priority)
+  else → readers++
+
+releaseRead():
+  readers--
+  if (readers === 0 && pendingWriters > 0) → wake next writer
+
+acquireWrite():
+  if (writerActive || readers > 0) → queue writer (increment pendingWriters)
+  else → writerActive = true
+
+releaseWrite():
+  pendingWriters-- (if it was queued)
+  writerActive = false
+  if (pendingWriters > 0) → wake next writer
+  else → wake all queued readers
+```
+
+Writer-priority: new readers are blocked when `pendingWriters > 0`, preventing reader starvation of writers (since writers are rarer and more important than reads).
+
+### Session Interface Changes
+
+Current `Session` shape (relevant fields, `session-manager.ts:85-112`):
+```typescript
+interface Session {
+  mutex: Mutex;  // ← replace with rwLock
+  inFlight: number;
+  // ...
+}
+```
+
+New shape:
+```typescript
+interface Session {
+  rwLock: AsyncRwLock;         // replaces mutex
+  reloadInFlight?: Promise<void>; // single-flight cache reload
+  inFlight: number;
+  // ... unchanged
+}
+```
+
+The `destroy()` method at `session-manager.ts:661-725` calls `session.mutex.runExclusive(...)` — this becomes `session.rwLock.acquireWrite()` / `releaseWrite()` in the exclusive path.
+
+The `shutdown()` method at `session-manager.ts:751-797` calls `session.mutex.runExclusive(...)` to drain — this needs to drain both readers and writers.
+
+### Single-Flight `ensureFreshCache` for Readers
+
+The simplest implementation: store `session.reloadInFlight?: Promise<void>`. When a reader enters:
+
+```typescript
+private async ensureFreshCacheShared(tenantId, sandboxId, session): Promise<void> {
+    if (this.redis === undefined) return;
+    const coherent = asCoherentFs(session.fs);
+    if (coherent === undefined) return;
+
+    // Check version — if fresh, no reload needed
+    let current: number;
+    try {
+        const raw = await this.redis.get(versionKey(tenantId, sandboxId));
+        current = raw === null ? 0 : Number(raw) || 0;
+    } catch {
+        // Redis down: reload unconditionally, single-flight
+        if (session.reloadInFlight === undefined) {
+            session.reloadInFlight = coherent.reload().finally(() => {
+                session.reloadInFlight = undefined;
+            });
+        }
+        await session.reloadInFlight;
+        return;
+    }
+
+    if (session.lastSeenVersion === current) return; // cache is fresh
+
+    // Need reload — single-flight: all concurrent readers share one Promise
+    if (session.reloadInFlight === undefined) {
+        session.reloadInFlight = coherent.reload().then(() => {
+            session.lastSeenVersion = current;
+            coherent.clearDirty();
+        }).finally(() => {
+            session.reloadInFlight = undefined;
+        });
+    }
+    await session.reloadInFlight;
+}
+```
+
+### Read-Only Mode Lifecycle in `withSessionReadEntry`
+
+```typescript
+private async withSessionReadEntry<T>(
+    tenantId, sandboxId, session, fn,
+): Promise<T> {
+    if (session.state === "closing") throw ESESSIONCLOSING;
+
+    // Single-flight cache refresh
+    await this.ensureFreshCacheShared(tenantId, sandboxId, session);
+
+    // Acquire shared lock
+    await session.rwLock.acquireRead();
+    session.inFlight++;
+    session.lastUsed = Date.now();
+
+    // Enable read-only guard on the FS
+    const readOnlyFs = asReadOnlyFs(session.fs); // if it supports setReadOnly
+    readOnlyFs?.setReadOnly(true);
+
+    try {
+        if (session.state === "closing") throw ESESSIONCLOSING;
+        return await fn(session);
+    } finally {
+        session.inFlight--;
+        // Only clear readOnly when the last reader exits
+        // (rwLock.releaseRead() decrements internally; we read the count before)
+        session.rwLock.releaseRead();
+        // When readers == 0, the next acquireWrite caller will proceed;
+        // the readOnly flag is cleared in the exclusive path naturally
+        // OR: clear here only if this was the last reader
+        if (!session.rwLock.hasReaders) {
+            readOnlyFs?.setReadOnly(false);
+        }
+    }
+}
+```
+
+**Note:** The exact lifecycle of `setReadOnly(false)` must be tied to the last reader exiting, not each reader's exit. The RW lock's `releaseRead()` can expose an `onLastReaderReleased` callback, or the read-entry code can check `rwLock.readers === 0` after decrement.
+
+### The `publishVersionIfDirty` Question for Readers
+
+`publishVersionIfDirty` (`session-manager.ts:527-573`) increments the Redis version counter when the SqlFs was mutated. For `readOnly` execs:
+- The SqlFs is in read-only mode → no writes → `wasDirty()` will be false
+- So `publishVersionIfDirty` is a no-op for readers
+
+But: should we call it at all in the read path? No — it's not needed. The read path skips `publishVersionIfDirty` entirely. This is safe because:
+1. Reads don't mutate state → `wasDirty()` is always false
+2. Even if a lying script somehow bypassed the EREADONLY guard (it can't with option a), the dirty flag would be set and we'd attempt publish — but since we're in shared mode, the write would have already thrown.
+
+### HTTP Error Mapping
+
+For a `readOnly: true` exec that contains a write (lying script):
+- Option (a): `SqlFs` throws `EROFS` (or a custom `EREADONLY` code) when the bash command tries to write
+- The script exits with a non-zero code (the write command failed)
+- The bash.exec result has `exitCode != 0` and `stderr` contains the EROFS message
+- No explicit HTTP 409/422 is needed at the route level — the error surfaces as a script failure
+
+However, the issue says "surfaces a hard error" — this means logging the violation and optionally returning a structured error. Using option (a), the EROFS propagates through bash's stderr. The route handler can inspect the error code if needed.
+
+---
+
+## Code References
+
+| File | Lines | Description |
+|---|---|---|
+| `src/api/session-manager.ts` | 15 | `import { Mutex } from "async-mutex"` — replace with RW lock |
+| `src/api/session-manager.ts` | 85-112 | `Session` interface — add `rwLock`, `reloadInFlight` |
+| `src/api/session-manager.ts` | 393-412 | Session construction — replace `new Mutex()` with `new AsyncRwLock()` |
+| `src/api/session-manager.ts` | 444-500 | `withSessionEntry` — adapt to exclusive write path |
+| `src/api/session-manager.ts` | 502-525 | `ensureFreshCache` — keep for write path; add single-flight variant for reads |
+| `src/api/session-manager.ts` | 575-596 | `withSession` / `withExistingSession` — add `withSessionRead` alongside |
+| `src/api/session-manager.ts` | 661-725 | `destroy()` — uses `session.mutex.runExclusive` → adapt to exclusive write path |
+| `src/api/session-manager.ts` | 751-797 | `shutdown()` — drain logic needs RW lock awareness |
+| `src/api/routes/exec.ts` | 23-29 | `execBodySchema` — add `readOnly?: z.boolean().optional()` |
+| `src/api/routes/exec.ts` | 132-218 | `/exec-sync` handler — branch on `body.readOnly` |
+| `src/api/routes/exec.ts` | 221-299 | `/exec` SSE handler — branch on `body.readOnly` |
+| `src/api/routes/exec.ts` | 301-345 | `/exec-sync-batch` handler — branch on `body.readOnly` |
+| `src/api/ownership.ts` | 27-44 | `withOwnedSessionOrRehydrate` — add `withOwnedSessionOrRehydrateRead` |
+| `src/api/mcp/tools.ts` | 154-159 | `bash_exec` tool schema — add `readOnly: z.boolean().optional()` |
+| `src/api/mcp/tools.ts` | 160-242 | `bash_exec` handler — branch on `args.readOnly` |
+| `src/fs/sql-fs/sql-fs.ts` | 122+ | `SqlFs` class — add `#readOnly`, `setReadOnly()`, guard write methods |
+| `src/fs/sql-fs/errors.ts` | — | Add `erofs(path)` / `EREADONLY` error constructor |
+| `scripts/stress-test.ts` | — | Add parallel readOnly scenario |
+
+---
+
+## Proposed Implementation Phases
+
+### Phase 1 — RW Lock Primitive
+Create `src/api/rw-lock.ts`:
+- `AsyncRwLock` class with `acquireRead(signal?)`, `releaseRead()`, `acquireWrite(signal?)`, `releaseWrite()`
+- Writer-priority invariant
+- `AbortSignal` support (reject waiting readers/writers on abort)
+- `hasReaders: boolean` getter (or `readerCount: number`)
+- Unit tests: ≥6 covering shared/exclusive ordering, writer starvation prevention, abort cancellation, single-flight reload simulation
+
+### Phase 2 — SqlFs Read-Only Guard
+In `src/fs/sql-fs/sql-fs.ts`:
+- Add `#readOnly = false` private field
+- Add `setReadOnly(v: boolean): void`
+- Guard all write methods: throw `EROFS` (code `EROFS`) immediately when `#readOnly === true`
+- Add `erofs(path: string)` to `src/fs/sql-fs/errors.ts`
+- Expose `setReadOnly` via a new interface `IReadOnlyToggle` or extend `ICoherentFs`
+
+### Phase 3 — SessionManager Read Path
+In `src/api/session-manager.ts`:
+- Replace `mutex: Mutex` in `Session` with `rwLock: AsyncRwLock`
+- Add `reloadInFlight?: Promise<void>` to `Session`
+- Keep `withSessionEntry` as the exclusive (write) path — adapts to `rwLock.acquireWrite()`
+- Add `withSessionReadEntry<T>` — shared path with single-flight cache refresh
+- Add `withSessionRead<T>(tenantId, sandboxId, fn, runtimeOptions?)` — public read entry point
+- Update `destroy()` and `shutdown()` to use exclusive path
+- Skip `publishVersionIfDirty` and `scriptTx` scope in the read path
+
+### Phase 4 — API Surface
+- `exec.ts`: add `readOnly?: boolean` to schemas; route to `withOwnedSessionOrRehydrateRead`
+- `ownership.ts`: add `withOwnedSessionOrRehydrateRead`  
+- `mcp/tools.ts`: add `readOnly` to `bash_exec`; route read-only calls to read path
+- HTTP error mapping: `EROFS` → 409 (`EREADONLY_VIOLATION`)
+
+### Phase 5 — Tests
+- Unit: RW lock fairness, abort, shared/exclusive ordering, single-flight reload (≥6 tests)
+- Integration: 4 concurrent readOnly execs → wall time ≈ `max(latency)`
+- Integration: readOnly exec containing a write → fails with EROFS / exitCode ≠ 0
+- Integration: writer waits for in-flight readers; new readers wait for queued writer
+- Cache-freshness regression: alternating write+read sequence — readers see writer's published state
+- Stress: add parallel readOnly scenario to `scripts/stress-test.ts`
+
+---
+
+## Open Questions
+
+1. **Is `Bash.exec()` safe for concurrent calls on the same instance?**  
+   The current design assumes `session.bash.exec()` can be called concurrently by multiple readers. If just-bash's `Bash` internally serializes via its own queue, parallel reads are safe but won't be faster. If it uses shared mutable state (e.g., a persistent bash process with shared cwd/env), concurrent calls could corrupt shell state. **This must be verified against the just-bash source before implementing.**
+
+2. **`setReadOnly` interface location** — Should `setReadOnly` be added to `ICoherentFs`, a new `IReadOnlyToggle` interface, or accessed via duck-typing (similar to `asCoherentFs`)? Duck-typing (`asReadOnlyFs`) keeps the `ICoherentFs` interface stable.
+
+3. **`session.lastSeenVersion` update in single-flight read** — The version is read before acquiring the shared lock, updated inside the single-flight promise. If two readers both see a stale version and race on `reloadInFlight`, the second reader's version check needs to account for the first reader having already updated `lastSeenVersion`. The single-flight promise handles this: both await the same Promise; by the time the second reader checks the result, `lastSeenVersion` is already current.
+
+4. **`exec-sync-batch` in read-only mode** — A batch of scripts with `readOnly: true` would hold the shared lock for the duration of the entire batch, blocking writers for longer. Is this the desired behavior? The alternative is to acquire/release shared mode per script in the batch, but that introduces version-staleness gaps between scripts.
+
+5. **openapi-spec.ts** — The `readOnly` field needs to be added to the OpenAPI spec at `src/api/openapi-spec.ts` for documentation completeness.
+
+---
+
+## Historical Context (from thoughts/)
+
+- `2026-05-02_11-24-37_remote-bash-latency-scaling.md` — Prior research on bash exec latency; the serialized mutex was already identified as a bottleneck for exploration-heavy workloads.
+- `2026-04-24_21-16-55_session-rehydration-gap.md` — Session rehydration patterns; `withSessionOrRehydrate` is the path that needs a read-only equivalent.
+
+---
+
+## Related Research
+
+- `thoughts/shared/research/2026-05-05_22-26-54_defense-in-depth-postgres-interaction.md` — Defense-in-depth wrapping patterns (relevant because read-only mode changes how SqlFs write methods behave and must not conflict with defense-in-depth boxing of Postgres I/O)


### PR DESCRIPTION
## Summary

Multiple `bash.exec` calls against the same sandbox can now run concurrently when the caller opts in via `readOnly: true`. ReadOnly execs route through a new shared-mode path (`SessionManager.withSessionRead`) that takes a per-session async readers-writer lock in shared mode, skips the distributed exec lock, and shares one single-flighted `ensureFreshCache` probe across the cohort. Writes still hold the lock exclusively with writer-priority.

- New `RWLock` primitive (`src/api/rw-lock.ts`) replaces `async-mutex` on `Session`. Drop-in `runExclusive` plus a new `runShared` with AbortSignal support.
- Read-only safety net on `SqlFs`: every mutating syscall throws `EREADONLY` before any DB work while the scope is active. Scope is **reference-counted** so concurrent readers share the FS safely. Violation attribution uses `AsyncLocalStorage` so a lying script in one reader never falsely flags innocent concurrent readers — the originating call surfaces `EREADONLY_VIOLATION` (HTTP **422**).
- `readOnly: true` plumbed through `/exec-sync`, `/exec` (SSE), `/exec-sync-batch`, MCP `bash_exec` / `bash_exec_batch`, OpenAPI spec.
- Bug fixed in this PR (final commit): a raw `EREADONLY` rejection escaping `bash.exec` (shell redirections like `echo x > /file`) is now remapped to `EREADONLY_VIOLATION` so the route layer consistently returns 422 instead of 500.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 725/725 passing (added 1 unit test for the EREADONLY remap)
- [x] Live concurrency probe against **Neon Postgres + local Redis (docker)** — **20/20** scenarios pass, including:
  - 4 parallel readers wall=820ms vs serial=3200ms; 20 parallel readers wall=430ms vs serial=8000ms (true parallelism)
  - just-bash shell-state isolation (env/cwd) across concurrent readers
  - Every bash mutation (`>` / `>>` / `mkdir` / `rm` / `cp` / `mv` / `chmod` / `touch`) blocked with FS unchanged
  - Lying reader does not poison concurrent siblings
  - Writer-priority + cache freshness across W→R→W→R sequences
  - Owner enforcement, ENOENT routing, abort propagation on queued reader, no Redis version bump on read traffic
  - SSE readOnly streams stdout/exit; violation surfaces in error event
  - Batch readOnly with mid-batch mutation → 422
- [x] Pre-existing integration test failures verified unrelated to this PR (same failures reproduce on baseline)

## Files

- `src/api/rw-lock.ts` (new) — async readers-writer primitive
- `src/api/read-only-context.ts` (new) — per-call AsyncLocalStorage attribution
- `src/api/session-manager.ts` — `Session.lock: RWLock`, `withSessionRead{,Entry}`, single-flight `ensureFreshCache`, EREADONLY remap
- `src/api/ownership.ts` — `withOwnedSessionRead`
- `src/api/routes/exec.ts` — `readOnly` schema field + read-path routing for sync/SSE/batch
- `src/api/mcp/tools.ts` — `readOnly` on `bash_exec` / `bash_exec_batch`
- `src/fs/sql-fs/sql-fs.ts` — ref-counted read-only scope + `#assertWritable` guards on every write op
- `src/fs/sql-fs/errors.ts` — `createEreadonly`
- Unit tests: `rw-lock.test.ts`, `session-manager.read-only.test.ts`, `sql-fs.read-only.test.ts`, route tests
- OpenAPI spec + CHANGELOG + version bump to **0.3.1**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readOnly execution mode for sandbox runs to allow parallel read-only requests.
  * Added a dev script to run the server on stable localhost URLs.

* **Bug Fixes**
  * Read-only mutation attempts now surface a dedicated error and return HTTP 422 instead of HTTP 500.

* **Documentation**
  * OpenAPI and developer docs updated to describe readOnly behavior and 422 responses.

* **Tests**
  * New unit tests covering read-only behavior, parallel readers, and lock semantics.

* **Chores**
  * Package version bumped to v0.3.3.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/63)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->