### PR TITLE
feat(api): cross-replica RW exec lock for parallel reads

### DIFF
--- a/.changeset/grumpy-planes-enter.md
+++ b/.changeset/grumpy-planes-enter.md
@@ -1,0 +1,5 @@
+---
+"virtualfs-api": patch
+---
+
+add distributed lock for R-W so strong consistency is enforced

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,0 +1,38 @@
+name: Version Packages PR
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: version-pr
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version:
+    name: Open / update Version Packages PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: changesets/action@v1
+        with:
+          # Runs our full version script: changeset version + sync openapi + lockfile regen
+          version: pnpm changeset:version
+          title: "chore: version packages"
+          commit: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-05-13
+
+### Added
+
+- Cross-replica reader-writer exec lock (`withDistributedRWLock`, `src/api/distributed-rw-lock.ts`). Parallel `readOnly` execs now run concurrently across replicas while writers maintain strong cross-replica consistency: writers take an exclusive Redis flag, readers register a TTL'd entry in a per-sandbox ZSET, and writer-priority prevents reader starvation. `SessionManager.withSessionRead` acquires the new shared lock; `withSession` / `withExistingSession` / `withSessionOrRehydrate` use the exclusive path. New env vars: `REDIS_RWLOCK_ENABLED` (default `true`, deploy-window flag) and `REDIS_RWLOCK_READER_LEASE_MS` (default `60000`). Issue #61.
+- Integration suite `cross-replica-rw-lock.integration.test.ts` covering parallel cross-replica readers, writer/reader blocking both directions, writer-priority under continuous readers, crashed-reader reaping, and version visibility after writes.
+
+### Changed
+
+- `rwLockKeys()` now wraps the sandbox id in a Redis Cluster hash tag (`vfs:{tenant}:rwlock:{<sandboxId>}:writer` / `…:readers`) so the two-key Lua scripts route to the same slot under Redis Cluster.
+
+### Fixed
+
+- `DistributedRWLockOptions` validation now requires `renewMs < readerLeaseMs` in addition to `renewMs < leaseMs`. Without this, a misconfigured `REDIS_RWLOCK_READER_LEASE_MS` shorter than `REDIS_EXEC_LOCK_RENEW_MS` could let a writer reap a live reader's ZSET entry between heartbeats and enter the critical section while a read was still in flight.
+
 ## [0.3.3] - 2026-05-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,16 +263,19 @@ tasks/
 
 ## Changelog & Version Bump Requirement
 
-**Always update `CHANGELOG.md` AND bump the version before pushing any branch.** Rules:
+This project uses **Changesets** (`@changesets/cli`) to manage versions and changelogs. Do not manually edit `CHANGELOG.md` or bump versions in `package.json` / `openapi-spec.ts`.
 
-- **Never use `[Unreleased]`** — always use a concrete version number.
-- **Always auto-increment** from the current topmost version: patch bump (`0.1.0` → `0.1.1`) for fixes/chores/docs; minor bump (`0.1.x` → `0.2.0`) for new features; major bump for breaking changes.
-- Add a dated section header: `## [x.y.z] - YYYY-MM-DD` and one or more bullets under `Added` / `Changed` / `Fixed` / `Removed`.
-- **Bump the version in ALL of these places** (they must all match the new CHANGELOG version):
-  - `package.json` → `"version"` field
-  - `pnpm-lock.yaml` → run `pnpm install --lockfile-only` after updating package.json
-  - `src/api/openapi-spec.ts` → `info.version` field
-- The release pipeline reads the topmost versioned section to determine whether to cut a new GitHub Release — if the tag already exists it skips; a new version triggers a release automatically on merge to `main`.
+**Workflow:**
+
+1. After making changes on a branch, run `pnpm changeset` and describe what changed. This creates a `.changeset/*.md` file — commit it with the rest of the PR.
+2. On release (after merging to `main`), run `pnpm changeset:version`. This reads all pending `.changeset/*.md` files and automatically:
+   - Bumps the version in `package.json` (patch / minor / major based on the changeset kind you chose)
+   - Writes `CHANGELOG.md` from the changeset descriptions
+   - Syncs `src/api/openapi-spec.ts` `info.version` via `scripts/sync-openapi-version.mjs`
+   - Regenerates `pnpm-lock.yaml`
+   - Deletes the consumed changeset files
+
+The release pipeline cuts a GitHub Release on merge to `main` when the version has changed.
 
 ## Implementation Guidance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,8 @@ const TABLE = Object.assign(Object.create(null) as Record<string, string>, {
 | `REDIS_BLOB_CACHE_ENABLED` | No (default: true) | Set to `false` to disable the Redis blob cache. Blob reads always fall through to Postgres when disabled. |
 | `REDIS_BLOB_CACHE_TTL_MS` | No (default: 86400000) | TTL for blob cache entries (ms, default 24h). |
 | `REDIS_BLOB_MAX_BYTES` | No (default: 8388608) | Max blob size cached in Redis (bytes, default 8 MB). Blobs larger than this bypass Redis entirely. |
+| `REDIS_RWLOCK_ENABLED` | No (default: true) | Feature flag for the distributed RW lock keyspace. Set to `false` during rolling deploys when some replicas still run the old exclusive-only lock. When `false`, writers use the legacy SET-NX path and readers skip the distributed lock. Remove after all replicas are on the new code. |
+| `REDIS_RWLOCK_READER_LEASE_MS` | No (default: 60000) | TTL (ms) for reader entries in the distributed RW lock ZSET. Bounds the time a writer must wait for a crashed reader to be reaped. |
 | `REDIS_PATH_SNAPSHOT_ENABLED` | No (default: false) | Set to `true` to enable the Redis path snapshot cache. When enabled, cold-start pathCache is loaded from Redis instead of a full Postgres `loadAllPaths` scan. Requires `REDIS_URL`. |
 | `REDIS_PATH_SNAPSHOT_TTL_MS` | No (default: 3600000) | TTL for path snapshot entries (ms, default 1h). |
 | `JUST_BASH_DEFENSE_IN_DEPTH` | No (default: `false`) | Enables just-bash's defense-in-depth security layer (monkey-patches `setTimeout`, `eval`, `Function`, dynamic `import`, etc. for the duration of `bash.exec`). All Postgres I/O is wrapped in `DefenseInDepthBox.runTrustedAsync` to remain compatible. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/stress-test.ts
+++ b/scripts/stress-test.ts
@@ -510,6 +510,172 @@ async function scenarioInProc(): Promise<ScenarioResult> {
 	};
 }
 
+// ── Scenario 5: cross-replica RW lock ─────────────────────────────────────────
+
+/**
+ * Two SessionManagers (simulating two replicas) share one Redis client, drive
+ * mixed readOnly + write traffic against the same sandbox for `--duration` ms,
+ * and assert:
+ *   - Zero EREADONLY_VIOLATION rejections from readers.
+ *   - Zero LockLostError rejections.
+ *   - Reader p99 latency < writer p99 (readers parallelise across replicas).
+ */
+async function scenarioCrossReplicaRw(durationMs: number): Promise<ScenarioResult> {
+	const name = "Cross-replica RW lock (mixed read/write)";
+	log(`▶ ${name} (duration=${durationMs}ms)`);
+	const errors: string[] = [];
+	const notes: string[] = [];
+	const before = await snapshot();
+	const t0 = Date.now();
+
+	const readerWorkers = Number(process.env.STRESS_RW_READERS ?? "8");
+	const writerWorkers = Number(process.env.STRESS_RW_WRITERS ?? "2");
+
+	const redis = new Redis(REDIS_URL!, { lazyConnect: false, maxRetriesPerRequest: 1 });
+	await new Promise<void>((resolve, reject) => {
+		redis.once("ready", resolve);
+		redis.once("error", reject);
+		setTimeout(() => reject(new Error("redis connect timeout")), 10_000);
+	});
+
+	const lockOpts = { leaseMs: 30_000, renewMs: 10_000, acquireTimeoutMs: 30_000, acquireRetryMs: 25 };
+	const mkSm = (): SessionManager =>
+		new SessionManager({
+			createFs: async (_t, sandboxId) => {
+				const { fs } = await createPostgresSandboxFs(
+					{ connectionString: PG_URL!, tenantId: "stress", redis },
+					sandboxId,
+				);
+				return fs;
+			},
+			destroySandboxFn: async (_t, sandboxId) => destroyPostgresSandbox(PG_URL!, sandboxId),
+			idleMs: 120_000,
+			redis,
+			execLockOptions: lockOpts,
+		});
+	const smA = mkSm();
+	const smB = mkSm();
+	const sandboxId = uid("crrw");
+
+	const readerLatencies: number[] = [];
+	const writerLatencies: number[] = [];
+	let readonlyViolations = 0;
+	let lockLost = 0;
+	let otherErrors = 0;
+
+	try {
+		// Seed the sandbox + a baseline file from A.
+		await smA.withSession("stress", sandboxId, async (s) => {
+			await s.fs.writeFile("/seed.txt", "0");
+		});
+		// Warm B's pool.
+		await smB.withSession("stress", sandboxId, async () => {});
+
+		const deadline = Date.now() + durationMs;
+		let writeCounter = 0;
+
+		const reader = async (sm: SessionManager, label: string): Promise<void> => {
+			while (Date.now() < deadline) {
+				const t = Date.now();
+				try {
+					await sm.withSessionRead("stress", sandboxId, async (s) => {
+						// Pure read — no mutation. Touches both fs and bash paths.
+						await s.fs.readFile("/seed.txt");
+					});
+					readerLatencies.push(Date.now() - t);
+				} catch (e) {
+					const code = (e as { code?: string; name?: string }).code;
+					const ename = (e as { name?: string }).name;
+					if (code === "EREADONLY_VIOLATION") readonlyViolations++;
+					else if (code === "ELOCKLOST" || ename === "LockLostError") lockLost++;
+					else otherErrors++;
+					notes.push(`reader ${label} error: ${(e as Error).message.slice(0, 100)}`);
+				}
+			}
+		};
+
+		const writer = async (sm: SessionManager, label: string): Promise<void> => {
+			while (Date.now() < deadline) {
+				const t = Date.now();
+				const n = ++writeCounter;
+				try {
+					await sm.withSession("stress", sandboxId, async (s) => {
+						// Real bash exec — durable mutation that goes through the
+						// publish path so the version counter advances. The brief
+						// sleep models realistic write turn time and gives readers
+						// room to demonstrate parallelism against the writer.
+						await s.bash.exec(`sleep 0.05 && echo ${n} > /w-${label}-${n}.txt`);
+					});
+					writerLatencies.push(Date.now() - t);
+				} catch (e) {
+					const code = (e as { code?: string }).code;
+					const ename = (e as { name?: string }).name;
+					if (code === "ELOCKLOST" || ename === "LockLostError") lockLost++;
+					else otherErrors++;
+					notes.push(`writer ${label} error: ${(e as Error).message.slice(0, 100)}`);
+				}
+				// Throttle writes slightly to give readers room to demonstrate parallelism.
+				await new Promise((r) => setTimeout(r, 25));
+			}
+		};
+
+		const workers: Promise<void>[] = [];
+		for (let i = 0; i < readerWorkers; i++) {
+			workers.push(reader(i % 2 === 0 ? smA : smB, `r${i}`));
+		}
+		for (let i = 0; i < writerWorkers; i++) {
+			workers.push(writer(i % 2 === 0 ? smA : smB, `w${i}`));
+		}
+		await Promise.all(workers);
+	} finally {
+		try {
+			await smA.destroy("stress", sandboxId);
+		} catch {
+			/* ignore */
+		}
+		await smA.shutdown({ drainTimeoutMs: 10_000 });
+		await smB.shutdown({ drainTimeoutMs: 10_000 });
+		await redis.quit().catch(() => {});
+	}
+
+	const pct = (arr: number[], p: number): number => {
+		if (arr.length === 0) return Number.POSITIVE_INFINITY;
+		const sorted = [...arr].sort((a, b) => a - b);
+		const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * p));
+		return sorted[idx] ?? Number.POSITIVE_INFINITY;
+	};
+	const readerP50 = pct(readerLatencies, 0.5);
+	const readerP99 = pct(readerLatencies, 0.99);
+	const writerP50 = pct(writerLatencies, 0.5);
+	const writerP99 = pct(writerLatencies, 0.99);
+
+	notes.push(`readers: count=${readerLatencies.length} p50=${readerP50}ms p99=${readerP99}ms`);
+	notes.push(`writers: count=${writerLatencies.length} p50=${writerP50}ms p99=${writerP99}ms`);
+	notes.push(`EREADONLY_VIOLATION=${readonlyViolations} LockLostError=${lockLost} otherErrors=${otherErrors}`);
+
+	if (readonlyViolations > 0) errors.push(`expected 0 EREADONLY_VIOLATION; got ${readonlyViolations}`);
+	if (lockLost > 0) errors.push(`expected 0 LockLostError; got ${lockLost}`);
+	if (readerLatencies.length === 0) errors.push("no reader iterations completed");
+	if (writerLatencies.length === 0) errors.push("no writer iterations completed");
+	// Typical-case reader latency must be lower than typical-case writer latency.
+	// p50 isolates the parallelism signal; p99 reader is dominated by writer-priority
+	// tail (a reader queued behind a writer-drain) which is expected behaviour.
+	if (readerLatencies.length > 0 && writerLatencies.length > 0 && readerP50 >= writerP50) {
+		errors.push(`reader p50 (${readerP50}ms) should be < writer p50 (${writerP50}ms) — readers did not parallelise`);
+	}
+
+	const after = await snapshot();
+	return {
+		name,
+		durationMs: Date.now() - t0,
+		before,
+		after,
+		notes,
+		errors,
+		pass: errors.length === 0,
+	};
+}
+
 // ── Migration bootstrap ───────────────────────────────────────────────────────
 
 /**
@@ -550,17 +716,62 @@ async function ensureMigrations(): Promise<void> {
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
+interface CliArgs {
+	scenario?: string;
+	durationMs: number;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+	let scenario: string | undefined;
+	let durationMs = 60_000;
+	for (const a of argv) {
+		const m = /^--([^=]+)=(.*)$/.exec(a);
+		if (!m) continue;
+		const key = m[1];
+		const value = m[2] ?? "";
+		if (key === "scenario") scenario = value;
+		else if (key === "duration") {
+			const trimmed = value.endsWith("s")
+				? Number(value.slice(0, -1)) * 1000
+				: value.endsWith("ms")
+					? Number(value.slice(0, -2))
+					: Number(value);
+			if (!Number.isFinite(trimmed) || trimmed <= 0) {
+				throw new Error(`invalid --duration=${value} (use e.g. 60s, 1500ms, or 60000)`);
+			}
+			durationMs = trimmed;
+		}
+	}
+	return { scenario, durationMs };
+}
+
 async function main(): Promise<void> {
 	const overallStart = Date.now();
+	const cli = parseArgs(process.argv.slice(2));
 	log(`starting stress run: PG=${PG_URL!.split("@")[1]?.split("?")[0]} REDIS=${REDIS_URL!.split("@")[1]}`);
+	if (cli.scenario) log(`scenario filter: ${cli.scenario}`);
 
 	await ensureMigrations();
 	if (process.env.STRESS_CLEANUP === "true") {
 		await cleanupAll();
 	}
 
-	const scenarios = [scenarioDestroyFailures, scenarioPoolPressure, scenarioRedisFlakiness, scenarioInProc];
-	for (const fn of scenarios) {
+	const scenarioRegistry: { key: string; fn: () => Promise<ScenarioResult> }[] = [
+		{ key: "destroy-failures", fn: scenarioDestroyFailures },
+		{ key: "pool-pressure", fn: scenarioPoolPressure },
+		{ key: "redis-flakiness", fn: scenarioRedisFlakiness },
+		{ key: "in-proc", fn: scenarioInProc },
+		{ key: "cross-replica-rw", fn: () => scenarioCrossReplicaRw(cli.durationMs) },
+	];
+	const selected = cli.scenario
+		? scenarioRegistry.filter((s) => s.key === cli.scenario)
+		: scenarioRegistry.filter((s) => s.key !== "cross-replica-rw");
+	if (selected.length === 0) {
+		throw new Error(
+			`unknown --scenario=${cli.scenario}. Available: ${scenarioRegistry.map((s) => s.key).join(", ")}`,
+		);
+	}
+	for (const { key, fn } of selected) {
 		try {
 			const r = await fn();
 			allResults.push(r);
@@ -569,7 +780,7 @@ async function main(): Promise<void> {
 			for (const e of r.errors) log(`    ! ${e}`);
 		} catch (err) {
 			allResults.push({
-				name: fn.name,
+				name: key,
 				durationMs: 0,
 				before: await snapshot(),
 				after: await snapshot(),
@@ -577,7 +788,7 @@ async function main(): Promise<void> {
 				errors: [`scenario crashed: ${(err as Error).message}`],
 				pass: false,
 			});
-			log(`  ✗ ${fn.name} crashed: ${(err as Error).message}`);
+			log(`  ✗ ${key} crashed: ${(err as Error).message}`);
 		}
 	}
 

--- a/src/api/distributed-rw-lock.ts
+++ b/src/api/distributed-rw-lock.ts
@@ -109,9 +109,12 @@ export interface RWLockKeys {
 }
 
 export function rwLockKeys(tenantId: string, sandboxId: string): RWLockKeys {
+	// The `{${sandboxId}}` braces are a Redis Cluster hash tag: every key that
+	// shares the same `{…}` substring hashes to the same slot, so the two-key
+	// EVAL scripts (writer + readers) below remain valid under Cluster routing.
 	return {
-		writer: `vfs:${tenantId}:rwlock:${sandboxId}:writer`,
-		readers: `vfs:${tenantId}:rwlock:${sandboxId}:readers`,
+		writer: `vfs:${tenantId}:rwlock:{${sandboxId}}:writer`,
+		readers: `vfs:${tenantId}:rwlock:{${sandboxId}}:readers`,
 	};
 }
 
@@ -130,6 +133,10 @@ function assertOptions(opts: DistributedRWLockOptions): void {
 		throw new Error(`DistributedRWLockOptions.acquireRetryMs must be > 0 (got ${opts.acquireRetryMs})`);
 	if (opts.readerLeaseMs <= 0)
 		throw new Error(`DistributedRWLockOptions.readerLeaseMs must be > 0 (got ${opts.readerLeaseMs})`);
+	if (opts.renewMs >= opts.readerLeaseMs)
+		throw new Error(
+			`DistributedRWLockOptions.renewMs (${opts.renewMs}) must be strictly less than readerLeaseMs (${opts.readerLeaseMs}); otherwise a live reader's ZSET entry can be reaped between heartbeats and a writer could enter while the read is still in flight`,
+		);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/api/distributed-rw-lock.ts
+++ b/src/api/distributed-rw-lock.ts
@@ -25,7 +25,7 @@ import { LockAcquireTimeoutError, LockLostError } from "./distributed-lock.js";
  * Returns 1 on success, 0 when writer flag is present.
  */
 const ACQUIRE_SHARED_SCRIPT = `
-redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", "(" .. ARGV[2])
+redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", ARGV[2])
 if redis.call("EXISTS", KEYS[1]) == 1 then return 0 end
 redis.call("ZADD", KEYS[2], ARGV[3], ARGV[1])
 return 1`;
@@ -64,21 +64,21 @@ return redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "NX")`;
  */
 const CHECK_READERS_DRAINED_SCRIPT = `
 if redis.call("GET", KEYS[1]) ~= ARGV[1] then return -1 end
-redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", "(" .. ARGV[2])
+redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", ARGV[2])
 return redis.call("ZCARD", KEYS[2])`;
 
 /** Token-checked renew for the writer flag. */
 const RENEW_EXCLUSIVE_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("pexpire", KEYS[1], ARGV[2])
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
 else
   return 0
 end`;
 
 /** Token-checked release for the writer flag. */
 const RELEASE_EXCLUSIVE_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("del", KEYS[1])
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
 else
   return 0
 end`;

--- a/src/api/distributed-rw-lock.ts
+++ b/src/api/distributed-rw-lock.ts
@@ -1,0 +1,401 @@
+/**
+ * Redis-backed distributed readers-writer lock.
+ *
+ * Mirrors the in-process RWLock semantics across replicas:
+ *  - Shared (reader) acquisitions coexist freely across replicas.
+ *  - Exclusive (writer) acquisition blocks all new readers and all other writers.
+ *  - Writer-priority: once a writer sets the flag, new readers spin until it clears.
+ *  - Reader entries carry a TTL score in a ZSET; a crashed reader cannot deadlock
+ *    a writer because expired entries are reaped on every poll.
+ */
+
+import crypto from "node:crypto";
+import type { Redis } from "ioredis";
+export { LockAcquireTimeoutError, LockLostError } from "./distributed-lock.js";
+import { LockAcquireTimeoutError, LockLostError } from "./distributed-lock.js";
+
+// ── Lua scripts ──────────────────────────────────────────────────────────────
+
+/**
+ * Atomic shared acquire. Reaps expired readers, refuses if writer flag is set,
+ * otherwise registers the reader token in the ZSET.
+ *
+ * KEYS[1]=writer  KEYS[2]=readers
+ * ARGV[1]=token  ARGV[2]=now_ms  ARGV[3]=expire_at_ms
+ * Returns 1 on success, 0 when writer flag is present.
+ */
+const ACQUIRE_SHARED_SCRIPT = `
+redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", "(" .. ARGV[2])
+if redis.call("EXISTS", KEYS[1]) == 1 then return 0 end
+redis.call("ZADD", KEYS[2], ARGV[3], ARGV[1])
+return 1`;
+
+/**
+ * Remove reader token from ZSET.
+ * KEYS[1]=readers  ARGV[1]=token
+ */
+const RELEASE_SHARED_SCRIPT = `
+return redis.call("ZREM", KEYS[1], ARGV[1])`;
+
+/**
+ * Bump reader ZSET score iff token still present (no zombie revival).
+ * KEYS[1]=readers  ARGV[1]=token  ARGV[2]=expire_at_ms
+ * Returns 1 if renewed, 0 if token already gone.
+ */
+const RENEW_SHARED_SCRIPT = `
+if redis.call("ZSCORE", KEYS[1], ARGV[1]) then
+  redis.call("ZADD", KEYS[1], ARGV[2], ARGV[1])
+  return 1
+end
+return 0`;
+
+/**
+ * Set writer flag NX. Gates new shared acquires immediately.
+ * KEYS[1]=writer  ARGV[1]=token  ARGV[2]=lease_ms
+ * Returns "OK" on success, nil when another writer holds.
+ */
+const ACQUIRE_EXCLUSIVE_FLAG_SCRIPT = `
+return redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "NX")`;
+
+/**
+ * Verify flag is still ours and count live readers (reaping expired first).
+ * KEYS[1]=writer  KEYS[2]=readers  ARGV[1]=token  ARGV[2]=now_ms
+ * Returns -1 if flag lost, otherwise live reader count (0 = drained).
+ */
+const CHECK_READERS_DRAINED_SCRIPT = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then return -1 end
+redis.call("ZREMRANGEBYSCORE", KEYS[2], "-inf", "(" .. ARGV[2])
+return redis.call("ZCARD", KEYS[2])`;
+
+/** Token-checked renew for the writer flag. */
+const RENEW_EXCLUSIVE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("pexpire", KEYS[1], ARGV[2])
+else
+  return 0
+end`;
+
+/** Token-checked release for the writer flag. */
+const RELEASE_EXCLUSIVE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end`;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export type RWLockMode = "shared" | "exclusive";
+
+export interface DistributedRWLockOptions {
+	readonly leaseMs: number;
+	readonly renewMs: number;
+	readonly acquireTimeoutMs: number;
+	readonly acquireRetryMs: number;
+	readonly readerLeaseMs: number;
+}
+
+const DEFAULTS: DistributedRWLockOptions = {
+	leaseMs: 60_000,
+	renewMs: 20_000,
+	acquireTimeoutMs: 300_000,
+	acquireRetryMs: 50,
+	readerLeaseMs: 60_000,
+};
+
+export interface RWLockKeys {
+	readonly writer: string;
+	readonly readers: string;
+}
+
+export function rwLockKeys(tenantId: string, sandboxId: string): RWLockKeys {
+	return {
+		writer: `vfs:${tenantId}:rwlock:${sandboxId}:writer`,
+		readers: `vfs:${tenantId}:rwlock:${sandboxId}:readers`,
+	};
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function assertOptions(opts: DistributedRWLockOptions): void {
+	if (opts.leaseMs <= 0) throw new Error(`DistributedRWLockOptions.leaseMs must be > 0 (got ${opts.leaseMs})`);
+	if (opts.renewMs <= 0) throw new Error(`DistributedRWLockOptions.renewMs must be > 0 (got ${opts.renewMs})`);
+	if (opts.renewMs >= opts.leaseMs)
+		throw new Error(
+			`DistributedRWLockOptions.renewMs (${opts.renewMs}) must be strictly less than leaseMs (${opts.leaseMs})`,
+		);
+	if (opts.acquireTimeoutMs < 0)
+		throw new Error(`DistributedRWLockOptions.acquireTimeoutMs must be >= 0 (got ${opts.acquireTimeoutMs})`);
+	if (opts.acquireRetryMs <= 0)
+		throw new Error(`DistributedRWLockOptions.acquireRetryMs must be > 0 (got ${opts.acquireRetryMs})`);
+	if (opts.readerLeaseMs <= 0)
+		throw new Error(`DistributedRWLockOptions.readerLeaseMs must be > 0 (got ${opts.readerLeaseMs})`);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Shared acquire path ───────────────────────────────────────────────────────
+
+async function acquireShared(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+): Promise<void> {
+	const { acquireTimeoutMs, acquireRetryMs, readerLeaseMs } = opts;
+	const deadline = Date.now() + acquireTimeoutMs;
+
+	while (true) {
+		const now = Date.now();
+		const expireAt = now + readerLeaseMs;
+		let acquired = false;
+		try {
+			const res = await redis.eval(
+				ACQUIRE_SHARED_SCRIPT,
+				2,
+				keys.writer,
+				keys.readers,
+				token,
+				String(now),
+				String(expireAt),
+			);
+			acquired = res === 1;
+		} catch {
+			acquired = false;
+		}
+		if (acquired) return;
+		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(keys.readers);
+		await sleep(acquireRetryMs);
+	}
+}
+
+function startSharedHeartbeat(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+	onLost: () => void,
+): () => void {
+	const { renewMs, readerLeaseMs } = opts;
+	let stopped = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const schedule = (): void => {
+		if (stopped) return;
+		timer = setTimeout(async () => {
+			if (stopped) return;
+			try {
+				const expireAt = Date.now() + readerLeaseMs;
+				const renewPromise = redis.eval(RENEW_SHARED_SCRIPT, 1, keys.readers, token, String(expireAt));
+				const timeoutPromise = new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error("renew_timeout")), renewMs),
+				);
+				const res = await Promise.race([renewPromise, timeoutPromise]);
+				if (res !== 1) {
+					onLost();
+					return;
+				}
+			} catch {
+				onLost();
+				return;
+			}
+			if (!stopped) schedule();
+		}, renewMs);
+	};
+
+	schedule();
+	return () => {
+		stopped = true;
+		if (timer !== undefined) clearTimeout(timer);
+	};
+}
+
+// ── Exclusive acquire path ────────────────────────────────────────────────────
+
+async function acquireExclusive(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+): Promise<void> {
+	const { leaseMs, acquireTimeoutMs, acquireRetryMs } = opts;
+	const deadline = Date.now() + acquireTimeoutMs;
+
+	// Phase A — set writer flag (blocks new readers immediately)
+	while (true) {
+		let flagAcquired = false;
+		try {
+			const res = await redis.eval(ACQUIRE_EXCLUSIVE_FLAG_SCRIPT, 1, keys.writer, token, String(leaseMs));
+			flagAcquired = res === "OK";
+		} catch {
+			flagAcquired = false;
+		}
+		if (flagAcquired) break;
+		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(keys.writer);
+		await sleep(acquireRetryMs);
+	}
+}
+
+async function waitReadersDrained(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+	deadline: number,
+): Promise<void> {
+	const { acquireRetryMs } = opts;
+	while (true) {
+		const now = Date.now();
+		let count: number;
+		try {
+			const res = await redis.eval(CHECK_READERS_DRAINED_SCRIPT, 2, keys.writer, keys.readers, token, String(now));
+			count = res as number;
+		} catch {
+			// Treat Redis error like readers still present; will surface timeout if deadline exceeded
+			count = 1;
+		}
+		if (count === -1) throw new LockLostError(keys.writer);
+		if (count === 0) return;
+		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(keys.writer);
+		await sleep(acquireRetryMs);
+	}
+}
+
+function startExclusiveHeartbeat(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+	onLost: () => void,
+): () => void {
+	const { renewMs, leaseMs } = opts;
+	let stopped = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const schedule = (): void => {
+		if (stopped) return;
+		timer = setTimeout(async () => {
+			if (stopped) return;
+			try {
+				const renewPromise = redis.eval(RENEW_EXCLUSIVE_SCRIPT, 1, keys.writer, token, String(leaseMs));
+				const timeoutPromise = new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error("renew_timeout")), renewMs),
+				);
+				const res = await Promise.race([renewPromise, timeoutPromise]);
+				if (res !== 1) {
+					onLost();
+					return;
+				}
+			} catch {
+				onLost();
+				return;
+			}
+			if (!stopped) schedule();
+		}, renewMs);
+	};
+
+	schedule();
+	return () => {
+		stopped = true;
+		if (timer !== undefined) clearTimeout(timer);
+	};
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Runs `fn` while holding a distributed readers-writer lock.
+ *
+ * - `mode='shared'`: multiple callers (across replicas) may hold concurrently.
+ *   Blocked while a writer flag is set.
+ * - `mode='exclusive'`: sets writer flag (halting new readers), then waits for
+ *   all live readers to drain before entering the critical section.
+ *
+ * Throws `LockAcquireTimeoutError` if acquisition exceeds `acquireTimeoutMs`.
+ * Throws `LockLostError` if the heartbeat detects ownership was lost.
+ */
+export async function withDistributedRWLock<T>(
+	redis: Redis,
+	keys: RWLockKeys,
+	mode: RWLockMode,
+	fn: () => Promise<T>,
+	opts: Partial<DistributedRWLockOptions> = {},
+): Promise<T> {
+	const merged: DistributedRWLockOptions = { ...DEFAULTS, ...opts };
+	assertOptions(merged);
+	const token = crypto.randomUUID();
+
+	if (mode === "shared") {
+		return runShared(redis, keys, token, merged, fn);
+	}
+	return runExclusive(redis, keys, token, merged, fn);
+}
+
+async function runShared<T>(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+	fn: () => Promise<T>,
+): Promise<T> {
+	await acquireShared(redis, keys, token, opts);
+
+	let lost = false;
+	const stopHeartbeat = startSharedHeartbeat(redis, keys, token, opts, () => {
+		lost = true;
+	});
+
+	try {
+		const result = await fn();
+		if (lost) throw new LockLostError(keys.readers);
+		return result;
+	} finally {
+		stopHeartbeat();
+		try {
+			await redis.eval(RELEASE_SHARED_SCRIPT, 1, keys.readers, token);
+		} catch (err) {
+			console.error(
+				JSON.stringify({ event: "rw_lock_reader_release_error", key: keys.readers, error: (err as Error).message }),
+			);
+		}
+	}
+}
+
+async function runExclusive<T>(
+	redis: Redis,
+	keys: RWLockKeys,
+	token: string,
+	opts: DistributedRWLockOptions,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const deadline = Date.now() + opts.acquireTimeoutMs;
+
+	await acquireExclusive(redis, keys, token, opts);
+
+	// Start heartbeat immediately after acquiring flag so it doesn't expire
+	// while we wait for readers to drain.
+	let lost = false;
+	const stopHeartbeat = startExclusiveHeartbeat(redis, keys, token, opts, () => {
+		lost = true;
+	});
+
+	try {
+		await waitReadersDrained(redis, keys, token, opts, deadline);
+		if (lost) throw new LockLostError(keys.writer);
+
+		const result = await fn();
+		if (lost) throw new LockLostError(keys.writer);
+		return result;
+	} finally {
+		stopHeartbeat();
+		try {
+			await redis.eval(RELEASE_EXCLUSIVE_SCRIPT, 1, keys.writer, token);
+		} catch (err) {
+			console.error(
+				JSON.stringify({ event: "rw_lock_writer_release_error", key: keys.writer, error: (err as Error).message }),
+			);
+		}
+	}
+}

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.3",
+		version: "0.3.4",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.4",
+		version: "0.3.5",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -43,8 +43,10 @@ const execLockOptions = redisClient
 			leaseMs: parseNonNegativeInt("REDIS_EXEC_LOCK_LEASE_MS", 60_000),
 			renewMs: parseNonNegativeInt("REDIS_EXEC_LOCK_RENEW_MS", 20_000),
 			acquireTimeoutMs: parseNonNegativeInt("REDIS_EXEC_LOCK_ACQUIRE_TIMEOUT_MS", 300_000),
+			readerLeaseMs: parseNonNegativeInt("REDIS_RWLOCK_READER_LEASE_MS", 60_000),
 		}
 	: undefined;
+const rwlockEnabled = process.env.REDIS_RWLOCK_ENABLED !== "false";
 const pathSnapshotEnabled = redisClient && process.env.REDIS_PATH_SNAPSHOT_ENABLED === "true";
 const pathSnapshot =
 	pathSnapshotEnabled && redisClient
@@ -140,6 +142,7 @@ const sessionManager = new SessionManager({
 	tenantConfig,
 	redis: redisClient,
 	execLockOptions,
+	rwlockEnabled,
 	pathSnapshot,
 	blobCacheFactory:
 		redisClient && blobCacheOptions

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -21,7 +21,8 @@ import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snap
 import { SessionScopedFs } from "../fs/sql-fs/session-scoped-fs.js";
 import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
-import { type DistributedLockOptions, execLockKey, withDistributedLock } from "./distributed-lock.js";
+import { execLockKey, withDistributedLock } from "./distributed-lock.js";
+import { type DistributedRWLockOptions, rwLockKeys, withDistributedRWLock } from "./distributed-rw-lock.js";
 import { logAudit } from "./lib/audit.js";
 import { type ReadOnlyContext, readOnlyContext } from "./read-only-context.js";
 import { RWLock } from "./rw-lock.js";
@@ -153,7 +154,9 @@ export interface SessionManagerOptions {
 	readonly maxConcurrentPython?: number;
 	readonly maxConcurrentJs?: number;
 	readonly redis?: Redis;
-	readonly execLockOptions?: Partial<DistributedLockOptions>;
+	readonly execLockOptions?: Partial<DistributedRWLockOptions>;
+	/** Feature flag: use the distributed RW lock keyspace. Set to false during rolling deploys. Defaults to true. */
+	readonly rwlockEnabled?: boolean;
 	readonly pathSnapshot?: RedisPathSnapshot;
 	/** Factory constructing a per-tenant RedisBlobCache. Called at most once per tenant on first access (lazy). */
 	readonly blobCacheFactory?: (tenantId: string) => RedisBlobCache | undefined;
@@ -224,7 +227,8 @@ export class SessionManager {
 	private readonly pathCacheMaxBytes: number;
 	private reaperTimer: ReturnType<typeof setInterval> | undefined;
 	private readonly redis: Redis | undefined;
-	private readonly execLockOptions: Partial<DistributedLockOptions> | undefined;
+	private readonly execLockOptions: Partial<DistributedRWLockOptions> | undefined;
+	private readonly rwlockEnabled: boolean;
 	private readonly pathSnapshot: RedisPathSnapshot | undefined;
 	private readonly blobCacheFactory: ((tenantId: string) => RedisBlobCache | undefined) | undefined;
 	private readonly getSandboxMetaFn?: (tenantId: string, sandboxId: string) => Promise<SandboxMeta | null>;
@@ -247,6 +251,7 @@ export class SessionManager {
 		maxConcurrentJs,
 		redis,
 		execLockOptions,
+		rwlockEnabled,
 		pathSnapshot,
 		blobCacheFactory,
 		getSandboxMetaFn,
@@ -268,6 +273,7 @@ export class SessionManager {
 		this.pathCacheMaxBytes = pathCacheMaxBytes ?? 50 * 1024 * 1024;
 		this.redis = redis;
 		this.execLockOptions = execLockOptions;
+		this.rwlockEnabled = rwlockEnabled ?? true;
 		this.pathSnapshot = pathSnapshot;
 		this.blobCacheFactory = blobCacheFactory;
 		this.getSandboxMetaFn = getSandboxMetaFn;
@@ -457,9 +463,18 @@ export class SessionManager {
 		return this.sessions.get(this.sessionKey(tenantId, sandboxId));
 	}
 
-	private async withExecLock<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
+	private async withExecLockExclusive<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
 		if (this.redis === undefined) return fn();
-		return withDistributedLock(this.redis, execLockKey(tenantId, sandboxId), fn, this.execLockOptions);
+		if (!this.rwlockEnabled) {
+			return withDistributedLock(this.redis, execLockKey(tenantId, sandboxId), fn, this.execLockOptions);
+		}
+		return withDistributedRWLock(this.redis, rwLockKeys(tenantId, sandboxId), "exclusive", fn, this.execLockOptions);
+	}
+
+	private async withExecLockShared<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
+		if (this.redis === undefined) return fn();
+		if (!this.rwlockEnabled) return fn();
+		return withDistributedRWLock(this.redis, rwLockKeys(tenantId, sandboxId), "shared", fn, this.execLockOptions);
 	}
 
 	/** Shared entry logic for all exclusive (write) session wrappers. */
@@ -521,14 +536,12 @@ export class SessionManager {
 	}
 
 	/**
-	 * Shared entry logic for the readOnly path. Holds the per-session RWLock
-	 * in shared mode so multiple readers run in parallel, and skips the
-	 * distributed exec lock + script-tx (no writes are permitted). The
-	 * session FS is put into read-only scope before fn runs and restored on
-	 * exit so any mutating syscall throws EREADONLY.
-	 *
-	 * Single-replica only: cross-replica visibility relies on the eventual
-	 * version-probe done by `ensureFreshCache` on the next op, same as today.
+	 * Inner entry logic for the readOnly path. Called from within the
+	 * distributed shared lock held by `withSessionRead`. Holds the per-session
+	 * RWLock in shared mode so multiple readers run in parallel, and skips
+	 * script-tx (no writes are permitted). The session FS is put into
+	 * read-only scope before fn runs and restored on exit so any mutating
+	 * syscall throws EREADONLY.
 	 */
 	private async withSessionReadEntry<T>(
 		tenantId: string,
@@ -713,14 +726,14 @@ export class SessionManager {
 		runtimeOptions?: RuntimeOptions,
 		owner = "",
 	): Promise<T> {
-		return this.withExecLock(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
 			const session = await this.getOrCreate(tenantId, sandboxId, runtimeOptions, owner);
 			return this.withSessionEntry(tenantId, sandboxId, session, fn);
 		});
 	}
 
 	async withExistingSession<T>(tenantId: string, sandboxId: string, fn: (session: Session) => Promise<T>): Promise<T> {
-		return this.withExecLock(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
 			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
 			if (session === undefined) {
 				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
@@ -730,10 +743,10 @@ export class SessionManager {
 	}
 
 	/**
-	 * readOnly entry point. Acquires the per-session RWLock in shared mode so
-	 * multiple readers run in parallel, skips the distributed exec lock, and
-	 * activates a read-only scope on the session FS so any mutating syscall
-	 * throws EREADONLY at the offending command.
+	 * readOnly entry point. Acquires the distributed shared exec lock (so readers
+	 * across replicas run in parallel while writers are excluded), then the
+	 * per-session RWLock in shared mode, and activates a read-only scope on the
+	 * session FS so any mutating syscall throws EREADONLY.
 	 *
 	 * Falls back to Postgres rehydrate (like withSessionOrRehydrate) when the
 	 * session was evicted from the in-memory pool but the sandbox still
@@ -745,11 +758,13 @@ export class SessionManager {
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
-		if (session !== undefined && session.state !== "closing") {
-			return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
-		}
-		return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions);
+		return this.withExecLockShared(tenantId, sandboxId, async () => {
+			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
+			if (session !== undefined && session.state !== "closing") {
+				return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
+			}
+			return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions);
+		});
 	}
 
 	private async rehydrateAndExecRead<T>(
@@ -789,7 +804,7 @@ export class SessionManager {
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		return this.withExecLock(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
 			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
 			if (session !== undefined && session.state !== "closing") {
 				return this.withSessionEntry(tenantId, sandboxId, session, fn);
@@ -840,7 +855,7 @@ export class SessionManager {
 	}
 
 	async destroy(tenantId: string, sandboxId: string): Promise<boolean> {
-		return this.withExecLock(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
 			const key = this.sessionKey(tenantId, sandboxId);
 			const session = this.sessions.get(key);
 

--- a/src/api/tests/integration/concurrency.pg.test.ts
+++ b/src/api/tests/integration/concurrency.pg.test.ts
@@ -96,9 +96,10 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to the same path", () => {
 	});
 
 	it(`all ${N} writes return 204 — DB handles upsert serially`, async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		const results = await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -116,9 +117,10 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to the same path", () => {
 	});
 
 	it("final GET returns one of the written values — pathCache and DB in sync", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -153,9 +155,10 @@ describe.skipIf(!DB_URL)("Postgres: N concurrent PUTs to distinct paths", () => 
 	});
 
 	it(`all ${N} writes succeed and tree lists exactly ${N} files`, async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		await Promise.all(
 			Array.from({ length: N }, (_, i) =>
@@ -189,9 +192,10 @@ describe.skipIf(!DB_URL)("Postgres: write-delete-read — pathCache cleared afte
 	});
 
 	it("N concurrent reads after delete all return 404 — no stale pathCache", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		await app.request(`/v1/sandboxes/${sbId}/files/home/user/gone.txt`, {
 			method: "PUT",
@@ -217,9 +221,10 @@ describe.skipIf(!DB_URL)("Postgres: write-delete-read — pathCache cleared afte
 	});
 
 	it("tree after deleting half of N files shows exactly the remaining N/2", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 		const total = 10;
 		const keep = 5;
 
@@ -264,9 +269,10 @@ describe.skipIf(!DB_URL)("Postgres: overwrite consistency — contentCache stays
 	});
 
 	it("sequential overwrites: each read returns the just-written value", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		for (let i = 0; i < 10; i++) {
 			await app.request(`/v1/sandboxes/${sbId}/files/home/user/v.txt`, {
@@ -283,9 +289,10 @@ describe.skipIf(!DB_URL)("Postgres: overwrite consistency — contentCache stays
 	});
 
 	it("N concurrent overwrites then read — no stale content from contentCache", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbId = newId();
+		await sm.withSession("default", sbId, () => Promise.resolve());
 
 		// Initial write
 		await app.request(`/v1/sandboxes/${sbId}/files/home/user/counter.txt`, {
@@ -327,10 +334,14 @@ describe.skipIf(!DB_URL)("Postgres: cross-sandbox isolation — writes in A not 
 	});
 
 	it("concurrent writes to same path in two sandboxes — each reads its own value", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbA = newId();
 		const sbB = newId();
+		await Promise.all([
+			sm.withSession("default", sbA, () => Promise.resolve()),
+			sm.withSession("default", sbB, () => Promise.resolve()),
+		]);
 
 		await Promise.all([
 			app.request(`/v1/sandboxes/${sbA}/files/home/user/shared.txt`, {
@@ -361,10 +372,14 @@ describe.skipIf(!DB_URL)("Postgres: cross-sandbox isolation — writes in A not 
 	});
 
 	it("delete in sandbox A does not affect sandbox B", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 		const sbA = newId();
 		const sbB = newId();
+		await Promise.all([
+			sm.withSession("default", sbA, () => Promise.resolve()),
+			sm.withSession("default", sbB, () => Promise.resolve()),
+		]);
 
 		await Promise.all([
 			app.request(`/v1/sandboxes/${sbA}/files/home/user/common.txt`, {
@@ -412,13 +427,14 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 	// ── S1 ──────────────────────────────────────────────────────────────────────
 
 	it("S1 HTTP API: PUT auto-creates parents — mkdir || write both always succeed", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 
 		// HTTP PUT route calls mkdir(parent, {recursive:true}) before writeFile,
 		// so the write always succeeds regardless of whether mkdir ran first.
 		for (const label of ["mkdir-first", "write-first"] as const) {
 			const sbId = newId();
+			await sm.withSession("default", sbId, () => Promise.resolve());
 			const ops =
 				label === "mkdir-first"
 					? ([
@@ -540,11 +556,12 @@ describe.skipIf(!DB_URL)("Postgres ordering scenarios — SqlFs POSIX semantics 
 	});
 
 	it("S2 HTTP: whichever runs first, file is gone after both ops, delete is always 204", async () => {
-		const { app } = makePgEnv();
+		const { app, sm } = makePgEnv();
 		const token = await makeToken();
 
 		for (const label of ["delete-first", "read-first"] as const) {
 			const sbId = newId();
+			await sm.withSession("default", sbId, () => Promise.resolve());
 			await app.request(`/v1/sandboxes/${sbId}/files/home/user/f.txt`, {
 				method: "PUT",
 				headers: { Authorization: `Bearer ${token}` },

--- a/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
+++ b/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
@@ -9,6 +9,9 @@
  *   4. Writer-priority: a continuous reader stream on B doesn't starve a writer on A.
  *   5. A crashed reader (stale ZSET entry) cannot deadlock a writer — TTL reaper recovers.
  *   6. After a write on A commits + publishes, B's next withSessionRead sees the data.
+ *   7. Parallel readers from both replicas each read the latest committed data.
+ *   8. Reader on A reads fresh data after writer on B (symmetric of #6).
+ *   9. Concurrent writers from different replicas serialize — no lost updates.
  *
  * Skipped unless DATABASE_URL and REDIS_URL are both set.
  */
@@ -308,5 +311,121 @@ describe.skipIf(SKIP)("Phase 3 — cross-replica RW lock integration", () => {
 
 		// B's session lastSeenVersion now matches A's published version.
 		expect(smB.getSession(TENANT, sandboxId)?.lastSeenVersion).toBe(versionAfterA);
+	});
+
+	it("parallel readers from both replicas each read the latest committed data", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		// Commit a known value before the readers start.
+		await timed(
+			"seed-write",
+			smA.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo latest-value > /shared.txt");
+			}),
+		);
+
+		// Four parallel readers — 2 from each replica. Every single one must
+		// see the committed content, not a stale cache snapshot.
+		const results: string[] = [];
+		const reader = (sm: SessionManager): Promise<void> =>
+			sm.withSessionRead(TENANT, sandboxId, async (s) => {
+				const content = await s.fs.readFile("/shared.txt");
+				results.push(String(content).trim());
+				// Hold briefly to maximise overlap window.
+				await new Promise((r) => setTimeout(r, 100));
+			});
+
+		await timed(
+			"parallel-reads-with-content-check",
+			Promise.all([reader(smA), reader(smB), reader(smA), reader(smB)]),
+		);
+
+		// All four readers must have seen the same latest-committed value.
+		expect(results).toHaveLength(4);
+		for (const v of results) {
+			expect(v).toBe("latest-value");
+		}
+	});
+
+	it("reader on A reads fresh data after writer on B (symmetric freshness)", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		// B is the writer this time.
+		await timed(
+			"B-write",
+			smB.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo from-b > /b-visible.txt");
+			}),
+		);
+
+		const versionAfterB = Number(await redis.get(versionKey(sandboxId)));
+		expect(versionAfterB).toBeGreaterThanOrEqual(1);
+
+		// A's ensureFreshCache must detect the version bump that B published
+		// and reload before running fn — so A sees B's file.
+		await timed(
+			"A-read",
+			smA.withSessionRead(TENANT, sandboxId, async (s) => {
+				const content = await s.fs.readFile("/b-visible.txt");
+				expect(String(content).trim()).toBe("from-b");
+				expect(s.fs.getAllPaths()).toContain("/b-visible.txt");
+			}),
+		);
+
+		expect(smA.getSession(TENANT, sandboxId)?.lastSeenVersion).toBe(versionAfterB);
+	});
+
+	it("concurrent writers from different replicas serialize — no lost updates", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		// Seed a counter file.
+		await timed(
+			"seed",
+			smA.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo 0 > /counter.txt");
+			}),
+		);
+
+		// Each replica increments the counter 5 times. Because withSession
+		// holds the distributed exclusive lock for the duration of fn, the
+		// read-increment-write is atomic cross-replica. If two writers ever
+		// ran concurrently the last-write-wins semantics would cause lost
+		// updates and the final value would be < 10.
+		const increments = 5;
+		const increment = (sm: SessionManager): Promise<void> =>
+			(async () => {
+				for (let i = 0; i < increments; i++) {
+					await sm.withSession(TENANT, sandboxId, async (s) => {
+						await s.bash.exec(
+							`val=$(cat /counter.txt | tr -d '\\n'); echo $((val + 1)) > /counter.txt`,
+						);
+					});
+				}
+			})();
+
+		// Both replicas run their increment loops concurrently.
+		await timed("concurrent-increments", Promise.all([increment(smA), increment(smB)]), 30_000);
+
+		// Read the final counter value from a fresh reader perspective.
+		let finalValue = -1;
+		await timed(
+			"read-final",
+			smA.withSessionRead(TENANT, sandboxId, async (s) => {
+				const content = await s.fs.readFile("/counter.txt");
+				finalValue = Number(String(content).trim());
+			}),
+		);
+
+		// Exactly 10 increments must have landed — no lost updates.
+		expect(finalValue).toBe(increments * 2);
 	});
 });

--- a/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
+++ b/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
@@ -338,10 +338,7 @@ describe.skipIf(SKIP)("Phase 3 — cross-replica RW lock integration", () => {
 				await new Promise((r) => setTimeout(r, 100));
 			});
 
-		await timed(
-			"parallel-reads-with-content-check",
-			Promise.all([reader(smA), reader(smB), reader(smA), reader(smB)]),
-		);
+		await timed("parallel-reads-with-content-check", Promise.all([reader(smA), reader(smB), reader(smA), reader(smB)]));
 
 		// All four readers must have seen the same latest-committed value.
 		expect(results).toHaveLength(4);
@@ -405,9 +402,7 @@ describe.skipIf(SKIP)("Phase 3 — cross-replica RW lock integration", () => {
 			(async () => {
 				for (let i = 0; i < increments; i++) {
 					await sm.withSession(TENANT, sandboxId, async (s) => {
-						await s.bash.exec(
-							`val=$(cat /counter.txt | tr -d '\\n'); echo $((val + 1)) > /counter.txt`,
-						);
+						await s.bash.exec(`val=$(cat /counter.txt | tr -d '\\n'); echo $((val + 1)) > /counter.txt`);
 					});
 				}
 			})();

--- a/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
+++ b/src/api/tests/integration/cross-replica-rw-lock.integration.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Phase 3 — cross-replica distributed RW lock integration tests.
+ *
+ * Two SessionManager instances against one real Postgres + one real Redis
+ * exercise the invariants from issue Hazzng/virtualFS#61:
+ *   1. Readers from different replicas overlap (peak >= 2).
+ *   2. An exclusive writer on A blocks new shared readers on B.
+ *   3. A live reader on A blocks an exclusive writer on B (writer waits for drain).
+ *   4. Writer-priority: a continuous reader stream on B doesn't starve a writer on A.
+ *   5. A crashed reader (stale ZSET entry) cannot deadlock a writer — TTL reaper recovers.
+ *   6. After a write on A commits + publishes, B's next withSessionRead sees the data.
+ *
+ * Skipped unless DATABASE_URL and REDIS_URL are both set.
+ */
+
+import { Redis } from "ioredis";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { destroySandbox } from "../../../fs/sql-fs/index.js";
+import { rwLockKeys } from "../../distributed-rw-lock.js";
+import { SessionManager } from "../../session-manager.js";
+import { loadTenantConfig } from "../../tenants.js";
+
+const TENANT = "default";
+
+const SKIP = !process.env.DATABASE_URL || !process.env.REDIS_URL;
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+function timed<T>(label: string, p: Promise<T>, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+	return Promise.race([
+		p,
+		new Promise<never>((_, reject) => {
+			setTimeout(() => reject(new Error(`${label}: timeout after ${timeoutMs}ms`)), timeoutMs);
+		}),
+	]);
+}
+
+function versionKey(sandboxId: string): string {
+	return `vfs:${TENANT}:ver:${sandboxId}`;
+}
+
+const ACQUIRE_TIMEOUT_MS = 10_000;
+
+describe.skipIf(SKIP)("Phase 3 — cross-replica RW lock integration", () => {
+	let redis: Redis;
+	const cleanup: string[] = [];
+
+	beforeAll(async () => {
+		redis = new Redis(process.env.REDIS_URL!, { lazyConnect: true, maxRetriesPerRequest: 1 });
+		await redis.connect();
+	});
+
+	beforeEach(() => {
+		cleanup.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const id of cleanup) {
+			try {
+				await destroySandbox("postgres", id);
+			} catch {
+				/* ignore */
+			}
+			const { writer, readers } = rwLockKeys(TENANT, id);
+			await redis.del(writer, readers, versionKey(id));
+		}
+	});
+
+	function makeSm(): SessionManager {
+		return new SessionManager({
+			tenantConfig: loadTenantConfig(),
+			redis,
+			execLockOptions: {
+				leaseMs: 5_000,
+				renewMs: 1_500,
+				acquireTimeoutMs: ACQUIRE_TIMEOUT_MS,
+				acquireRetryMs: 50,
+				readerLeaseMs: 5_000,
+			},
+		});
+	}
+
+	function newId(): string {
+		const id = `phase3-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		cleanup.push(id);
+		return id;
+	}
+
+	/** Pre-warm both replicas so withSessionRead can find an in-process session. */
+	async function warm(smA: SessionManager, smB: SessionManager, sandboxId: string): Promise<void> {
+		await smA.withSession(TENANT, sandboxId, async () => {
+			/* create + warm A */
+		});
+		await smB.withSession(TENANT, sandboxId, async () => {
+			/* warm B */
+		});
+	}
+
+	it("parallel readers across replicas overlap (peak in-flight >= 2 with start spread <= 200ms)", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		const starts: number[] = [];
+		let active = 0;
+		let peak = 0;
+		const reader = (sm: SessionManager): Promise<void> =>
+			sm.withSessionRead(TENANT, sandboxId, async () => {
+				starts.push(Date.now());
+				active++;
+				peak = Math.max(peak, active);
+				// Hold long enough to overlap (well beyond Redis RTT).
+				await new Promise((r) => setTimeout(r, 200));
+				active--;
+			});
+
+		await timed("parallel-readers", Promise.all([reader(smA), reader(smB), reader(smA), reader(smB)]));
+
+		expect(peak).toBeGreaterThanOrEqual(2);
+		// All four readers should have started within a tight window — proves they
+		// did not serialize on the distributed lock.
+		const spread = Math.max(...starts) - Math.min(...starts);
+		expect(spread).toBeLessThan(200);
+	});
+
+	it("exclusive on A blocks shared on B until A commits + publishes", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		const order: string[] = [];
+		const writerHoldMs = 200;
+		const writer = smA.withSession(TENANT, sandboxId, async (s) => {
+			order.push("w-start");
+			await s.bash.exec(`sleep ${writerHoldMs / 1000} && echo gate > /gate.txt`);
+			order.push("w-end");
+		});
+
+		// Give A a head-start to acquire the writer flag.
+		await new Promise((r) => setTimeout(r, 50));
+
+		const reader = smB.withSessionRead(TENANT, sandboxId, async (s) => {
+			order.push("r-start");
+			const content = await s.fs.readFile("/gate.txt");
+			expect(String(content).trim()).toBe("gate");
+		});
+
+		await timed("writer", writer);
+		// Capture the version A published — used to assert B saw the latest.
+		const versionAfterWrite = Number(await redis.get(versionKey(sandboxId)));
+		await timed("reader", reader);
+
+		expect(order).toEqual(["w-start", "w-end", "r-start"]);
+		expect(versionAfterWrite).toBeGreaterThanOrEqual(1);
+
+		// B's session must now reflect the version A published — proves the
+		// publishVersionIfDirty-before-release ordering.
+		const sessionB = smB.getSession(TENANT, sandboxId);
+		expect(sessionB?.lastSeenVersion).toBe(versionAfterWrite);
+	});
+
+	it("shared on A blocks exclusive on B until reader drains", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		const order: string[] = [];
+		let releaseReader!: () => void;
+		const readerGate = new Promise<void>((r) => {
+			releaseReader = r;
+		});
+
+		const reader = smA.withSessionRead(TENANT, sandboxId, async () => {
+			order.push("r-start");
+			await readerGate;
+			order.push("r-end");
+		});
+
+		// Let the reader acquire.
+		await new Promise((r) => setTimeout(r, 50));
+
+		const writer = smB.withSession(TENANT, sandboxId, async (s) => {
+			order.push("w-start");
+			await s.bash.exec("echo done > /after-reader.txt");
+		});
+
+		// Writer must be blocked behind the live reader.
+		await new Promise((r) => setTimeout(r, 100));
+		expect(order).toEqual(["r-start"]);
+
+		releaseReader();
+		await timed("reader", reader);
+		await timed("writer", writer);
+
+		expect(order).toEqual(["r-start", "r-end", "w-start"]);
+	});
+
+	it("writer is not starved by a continuous reader stream (writer-priority)", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		// Continuous reader stream on B. Each reader holds briefly so the writer
+		// has to wait for in-flight readers to drain — but writer-priority means
+		// new readers won't be admitted once A's flag is set.
+		let stop = false;
+		let readersCompleted = 0;
+		const readerLoop = (async (): Promise<void> => {
+			while (!stop) {
+				await smB
+					.withSessionRead(TENANT, sandboxId, async () => {
+						await new Promise((r) => setTimeout(r, 30));
+					})
+					.then(() => {
+						readersCompleted++;
+					})
+					.catch(() => {
+						/* writer may be blocking; that's fine */
+					});
+			}
+		})();
+
+		// Let a few readers fire before queueing the writer.
+		await new Promise((r) => setTimeout(r, 150));
+
+		const writerStart = Date.now();
+		await timed(
+			"writer-under-reader-pressure",
+			smA.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo w > /writer-priority.txt");
+			}),
+			ACQUIRE_TIMEOUT_MS / 2,
+		);
+		const writerElapsed = Date.now() - writerStart;
+
+		stop = true;
+		await readerLoop;
+
+		// Plan requirement: writer completes in well under acquireTimeoutMs / 2.
+		expect(writerElapsed).toBeLessThan(ACQUIRE_TIMEOUT_MS / 2);
+		// And at least one reader had fired before the writer (otherwise the
+		// "starvation" wasn't actually being exercised).
+		expect(readersCompleted).toBeGreaterThan(0);
+	});
+
+	it("crashed reader (stale ZSET entry) does not deadlock a writer — reaped within one poll cycle", async () => {
+		const sandboxId = newId();
+		const sm = makeSm();
+		await sm.withSession(TENANT, sandboxId, async () => {
+			/* warm */
+		});
+
+		// Plant an expired reader token directly in the ZSET. expireAt < now,
+		// so CHECK_READERS_DRAINED_SCRIPT will ZREMRANGEBYSCORE it on the first
+		// poll and report 0 live readers.
+		const { readers } = rwLockKeys(TENANT, sandboxId);
+		await redis.zadd(readers, String(Date.now() - 1), "dead-reader-token");
+
+		const start = Date.now();
+		await timed(
+			"writer-after-crashed-reader",
+			sm.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo ok > /after-crash.txt");
+			}),
+			2_000,
+		);
+		const elapsed = Date.now() - start;
+
+		// One acquireRetryMs (50ms) reap cycle should be enough; allow generous headroom.
+		expect(elapsed).toBeLessThan(500);
+
+		// And the stale entry is gone.
+		const remaining = await redis.zcard(readers);
+		expect(remaining).toBe(0);
+	});
+
+	it("version visible to B after A's write — lock release waits for publishVersionIfDirty", async () => {
+		const sandboxId = newId();
+		const smA = makeSm();
+		const smB = makeSm();
+		await warm(smA, smB, sandboxId);
+
+		// A writes a file. publishVersionIfDirty bumps the Redis version key
+		// before the exclusive lock is released.
+		await timed(
+			"A-write",
+			smA.withSession(TENANT, sandboxId, async (s) => {
+				await s.bash.exec("echo from-a > /visible.txt");
+			}),
+		);
+
+		const versionAfterA = Number(await redis.get(versionKey(sandboxId)));
+		expect(versionAfterA).toBeGreaterThanOrEqual(1);
+
+		// B's next readOnly turn must see /visible.txt (proves ordering:
+		// publishVersionIfDirty → ensureFreshCache reload → fn runs).
+		await timed(
+			"B-read",
+			smB.withSessionRead(TENANT, sandboxId, async (s) => {
+				const content = await s.fs.readFile("/visible.txt");
+				expect(String(content).trim()).toBe("from-a");
+				expect(s.fs.getAllPaths()).toContain("/visible.txt");
+			}),
+		);
+
+		// B's session lastSeenVersion now matches A's published version.
+		expect(smB.getSession(TENANT, sandboxId)?.lastSeenVersion).toBe(versionAfterA);
+	});
+});

--- a/src/api/tests/integration/multi-replica-coherence.integration.test.ts
+++ b/src/api/tests/integration/multi-replica-coherence.integration.test.ts
@@ -14,7 +14,7 @@
 import { Redis } from "ioredis";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { destroySandbox } from "../../../fs/sql-fs/index.js";
-import { execLockKey } from "../../distributed-lock.js";
+import { rwLockKeys } from "../../distributed-rw-lock.js";
 import { SessionManager } from "../../session-manager.js";
 import { loadTenantConfig } from "../../tenants.js";
 
@@ -56,7 +56,8 @@ describe.skipIf(SKIP)("Phase D — cross-replica cache coherence", () => {
 			} catch {
 				/* ignore */
 			}
-			await redis.del(execLockKey(TENANT, id));
+			const { writer, readers } = rwLockKeys(TENANT, id);
+			await redis.del(writer, readers);
 			await redis.del(versionKey(id));
 		}
 	});

--- a/src/api/tests/integration/multi-replica-exec.integration.test.ts
+++ b/src/api/tests/integration/multi-replica-exec.integration.test.ts
@@ -16,7 +16,7 @@
 import { Redis } from "ioredis";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { destroySandbox } from "../../../fs/sql-fs/index.js";
-import { execLockKey } from "../../distributed-lock.js";
+import { rwLockKeys } from "../../distributed-rw-lock.js";
 import { SessionManager } from "../../session-manager.js";
 import { loadTenantConfig } from "../../tenants.js";
 
@@ -55,7 +55,8 @@ describe.skipIf(SKIP)("Phase C — multi-replica exec lock", () => {
 			} catch {
 				/* ignore */
 			}
-			await redis.del(execLockKey(TENANT, id));
+			const { writer, readers } = rwLockKeys(TENANT, id);
+			await redis.del(writer, readers);
 		}
 	});
 
@@ -162,7 +163,7 @@ describe.skipIf(SKIP)("Phase C — multi-replica exec lock", () => {
 
 		// Simulate a dead replica still holding the lock: plant a foreign token with a short TTL.
 		const leaseMs = 1_500;
-		await redis.set(execLockKey(TENANT, sandboxId), "dead-replica-token", "PX", leaseMs);
+		await redis.set(rwLockKeys(TENANT, sandboxId).writer, "dead-replica-token", "PX", leaseMs);
 
 		const start = Date.now();
 		await timed(

--- a/src/api/tests/unit/distributed-rw-lock.test.ts
+++ b/src/api/tests/unit/distributed-rw-lock.test.ts
@@ -590,6 +590,16 @@ describe("withDistributedRWLock", () => {
 			).rejects.toThrow(/renewMs.*must be strictly less than leaseMs/);
 		});
 
+		it("rejects renewMs >= readerLeaseMs (reader heartbeat must fire before ZSET entry expires)", async () => {
+			await expect(
+				withDistributedRWLock(asRedis(fake()), KEYS, "shared", async () => "ok", {
+					leaseMs: 60_000,
+					renewMs: 20_000,
+					readerLeaseMs: 5_000,
+				}),
+			).rejects.toThrow(/renewMs.*must be strictly less than readerLeaseMs/);
+		});
+
 		it("rejects non-positive readerLeaseMs", async () => {
 			await expect(
 				withDistributedRWLock(asRedis(fake()), KEYS, "shared", async () => "ok", { ...FAST, readerLeaseMs: 0 }),
@@ -607,7 +617,7 @@ describe("withDistributedRWLock", () => {
 
 	it("rwLockKeys generates the expected key namespace", () => {
 		const k = rwLockKeys("acme", "sandbox-1");
-		expect(k.writer).toBe("vfs:acme:rwlock:sandbox-1:writer");
-		expect(k.readers).toBe("vfs:acme:rwlock:sandbox-1:readers");
+		expect(k.writer).toBe("vfs:acme:rwlock:{sandbox-1}:writer");
+		expect(k.readers).toBe("vfs:acme:rwlock:{sandbox-1}:readers");
 	});
 });

--- a/src/api/tests/unit/distributed-rw-lock.test.ts
+++ b/src/api/tests/unit/distributed-rw-lock.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Unit tests for the Redis-backed distributed RW lock.
+ * Uses an in-process fake that honours ZSET semantics + TTL scores so we can
+ * exercise every Lua-script branch without a real Redis.
+ */
+
+import type { Redis } from "ioredis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	LockAcquireTimeoutError,
+	LockLostError,
+	type RWLockKeys,
+	rwLockKeys,
+	withDistributedRWLock,
+} from "../../distributed-rw-lock.js";
+
+// ── FakeRedis ─────────────────────────────────────────────────────────────────
+
+interface StringEntry {
+	value: string;
+	expiresAt: number;
+}
+
+/**
+ * Minimal Redis fake covering only the surface the RW lock uses:
+ *   - SET key value PX ms NX
+ *   - EVAL with the Lua scripts (identified by content keywords)
+ *   - Direct ZADD / ZSCORE / ZREM / ZCARD for test helpers
+ */
+class FakeRedis {
+	strings = new Map<string, StringEntry>();
+	zsets = new Map<string, Map<string, number>>(); // key -> (member -> score)
+
+	/** When truthy, all eval calls throw. */
+	failEval = false;
+	/** When truthy, RENEW_EXCLUSIVE returns 0 (simulates flag lost). */
+	forceExclusiveRenewLost = false;
+	/** When truthy, RENEW_SHARED returns 0. */
+	forceSharedRenewLost = false;
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	private gcStrings(): void {
+		const now = Date.now();
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
+	/** Reap expired entries from a ZSET (score = expireAt). */
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	// ── Redis interface stubs ─────────────────────────────────────────────────
+
+	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
+		this.gcStrings();
+		if (this.strings.has(key)) return null;
+		this.strings.set(key, { value, expiresAt: Date.now() + ms });
+		return "OK";
+	}
+
+	/** Direct ZADD for test helpers only (not used by the lock internally). */
+	async zadd(key: string, score: number, member: string): Promise<number> {
+		const z = this.getZset(key);
+		const existed = z.has(member) ? 0 : 1;
+		z.set(member, score);
+		return existed;
+	}
+
+	/** Direct ZSCORE for test helpers. */
+	async zscore(key: string, member: string): Promise<string | null> {
+		const z = this.zsets.get(key);
+		const score = z?.get(member);
+		return score !== undefined ? String(score) : null;
+	}
+
+	/** Direct ZCARD for test helpers. */
+	async zcard(key: string): Promise<number> {
+		return this.zsets.get(key)?.size ?? 0;
+	}
+
+	/** Evict a string key to simulate expiry. */
+	evict(key: string): void {
+		this.strings.delete(key);
+	}
+
+	// ── eval dispatcher ───────────────────────────────────────────────────────
+
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		if (this.failEval) throw new Error("redis eval failed");
+		this.gcStrings();
+
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		// ACQUIRE_SHARED_SCRIPT — contains ZREMRANGEBYSCORE + EXISTS check
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			const now = Number(nowStr);
+			this.reapZset(readersKey, now);
+			if (this.strings.has(writerKey)) return 0;
+			const z = this.getZset(readersKey);
+			z.set(token, Number(expireAtStr));
+			return 1;
+		}
+
+		// RELEASE_SHARED_SCRIPT — contains ZREM (only)
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
+				return 1;
+			}
+			return 0;
+		}
+
+		// RENEW_SHARED_SCRIPT — contains ZSCORE
+		if (script.includes("ZSCORE")) {
+			if (this.forceSharedRenewLost) return 0;
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
+		}
+
+		// ACQUIRE_EXCLUSIVE_FLAG_SCRIPT — contains SET … NX
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+
+		// CHECK_READERS_DRAINED_SCRIPT — contains GET + ZREMRANGEBYSCORE + ZCARD
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+
+		// RENEW_EXCLUSIVE_SCRIPT — contains pexpire
+		if (script.includes("pexpire")) {
+			if (this.forceExclusiveRenewLost) return 0;
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+
+		// RELEASE_EXCLUSIVE_SCRIPT — contains del
+		if (script.includes("del")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
+	}
+}
+
+function fake(): FakeRedis {
+	return new FakeRedis();
+}
+function asRedis(f: FakeRedis): Redis {
+	return f as unknown as Redis;
+}
+
+const KEYS: RWLockKeys = rwLockKeys("default", "sbx-test");
+const FAST: Partial<Parameters<typeof withDistributedRWLock>[4]> = {
+	leaseMs: 5_000,
+	renewMs: 4_000,
+	acquireTimeoutMs: 3_000,
+	acquireRetryMs: 10,
+	readerLeaseMs: 5_000,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("withDistributedRWLock", () => {
+	beforeEach(() => vi.useRealTimers());
+	afterEach(() => vi.useRealTimers());
+
+	// ── Basic smoke ───────────────────────────────────────────────────────────
+
+	it("shared: acquires, runs fn, releases ZSET entry", async () => {
+		const r = fake();
+		const result = await withDistributedRWLock(asRedis(r), KEYS, "shared", async () => 42, FAST);
+		expect(result).toBe(42);
+		expect(r.zsets.get(KEYS.readers)?.size ?? 0).toBe(0);
+	});
+
+	it("exclusive: acquires, runs fn, releases writer flag", async () => {
+		const r = fake();
+		const result = await withDistributedRWLock(asRedis(r), KEYS, "exclusive", async () => 99, FAST);
+		expect(result).toBe(99);
+		expect(r.strings.has(KEYS.writer)).toBe(false);
+	});
+
+	// ── Parallel readers ──────────────────────────────────────────────────────
+
+	it("two shared acquires on the same keys run concurrently (peak=2)", async () => {
+		const r = fake();
+		let active = 0;
+		let peak = 0;
+
+		const worker = (): Promise<void> =>
+			withDistributedRWLock(
+				asRedis(r),
+				KEYS,
+				"shared",
+				async () => {
+					active++;
+					peak = Math.max(peak, active);
+					await new Promise((res) => setTimeout(res, 40));
+					active--;
+				},
+				FAST,
+			);
+
+		await Promise.all([worker(), worker()]);
+		expect(peak).toBe(2);
+	});
+
+	// ── Mutual exclusion ──────────────────────────────────────────────────────
+
+	it("exclusive blocks shared: reader waits while writer holds flag", async () => {
+		const r = fake();
+		const order: string[] = [];
+
+		let releaseWriter!: () => void;
+		const writer = withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"exclusive",
+			async () => {
+				order.push("w-start");
+				await new Promise<void>((res) => {
+					releaseWriter = res;
+				});
+				order.push("w-end");
+			},
+			FAST,
+		);
+
+		// Let writer acquire the flag
+		await new Promise((res) => setTimeout(res, 30));
+
+		const reader = withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"shared",
+			async () => {
+				order.push("r-start");
+			},
+			{ ...FAST, acquireTimeoutMs: 5_000 },
+		);
+
+		// Reader must be blocked
+		await new Promise((res) => setTimeout(res, 50));
+		expect(order).toEqual(["w-start"]);
+
+		releaseWriter();
+		await Promise.all([writer, reader]);
+		expect(order).toEqual(["w-start", "w-end", "r-start"]);
+	});
+
+	it("shared blocks exclusive: writer waits for reader to drain", async () => {
+		const r = fake();
+		const order: string[] = [];
+
+		let releaseReader!: () => void;
+		const reader = withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"shared",
+			async () => {
+				order.push("r-start");
+				await new Promise<void>((res) => {
+					releaseReader = res;
+				});
+				order.push("r-end");
+			},
+			FAST,
+		);
+
+		await new Promise((res) => setTimeout(res, 30));
+
+		const writer = withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"exclusive",
+			async () => {
+				order.push("w-start");
+			},
+			{ ...FAST, acquireTimeoutMs: 5_000 },
+		);
+
+		await new Promise((res) => setTimeout(res, 50));
+		// Writer flag is set but reader still active — writer blocked in drain wait
+		expect(order).not.toContain("w-start");
+
+		releaseReader();
+		await Promise.all([reader, writer]);
+		expect(order).toEqual(["r-start", "r-end", "w-start"]);
+	});
+
+	// ── Writer-priority ───────────────────────────────────────────────────────
+
+	it("writer-priority: new shared acquire waits while writer flag is held", async () => {
+		const r = fake();
+
+		// Plant writer flag directly (simulates another replica holding it)
+		r.strings.set(KEYS.writer, { value: "foreign-token", expiresAt: Date.now() + 5_000 });
+
+		const started = { reader: false };
+		const readerPromise = withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"shared",
+			async () => {
+				started.reader = true;
+			},
+			{ ...FAST, acquireRetryMs: 10, acquireTimeoutMs: 500 },
+		);
+
+		await new Promise((res) => setTimeout(res, 50));
+		expect(started.reader).toBe(false); // blocked
+
+		r.strings.delete(KEYS.writer); // simulate writer releasing
+		await readerPromise;
+		expect(started.reader).toBe(true);
+	});
+
+	// ── Crashed-reader scenario (TTL reap) ────────────────────────────────────
+
+	it("crashed reader: stale ZSET entry is reaped, exclusive acquires within 1 retry", async () => {
+		const r = fake();
+
+		// Plant an already-expired reader token directly (score = expired timestamp)
+		await r.zadd(KEYS.readers, Date.now() - 1, "dead-token");
+
+		const order: string[] = [];
+		await withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"exclusive",
+			async () => {
+				order.push("w-acquired");
+			},
+			FAST,
+		);
+		expect(order).toEqual(["w-acquired"]);
+	});
+
+	// ── Heartbeat ────────────────────────────────────────────────────────────
+
+	it("shared heartbeat renews ZSET score across at least 2 cycles", async () => {
+		const r = fake();
+		const renewals: number[] = [];
+		const origEval = r.eval.bind(r);
+
+		r.eval = async (script: string, numKeys: number, ...args: string[]) => {
+			if (script.includes("ZSCORE")) renewals.push(Date.now());
+			return origEval(script, numKeys, ...args);
+		};
+
+		await withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"shared",
+			async () => {
+				await new Promise((res) => setTimeout(res, 200));
+			},
+			{ ...FAST, renewMs: 60, leaseMs: 5_000 },
+		);
+
+		expect(renewals.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("exclusive heartbeat renews writer flag PTTL across at least 2 cycles", async () => {
+		const r = fake();
+		const renewals: number[] = [];
+		const origEval = r.eval.bind(r);
+
+		r.eval = async (script: string, numKeys: number, ...args: string[]) => {
+			if (script.includes("pexpire")) renewals.push(Date.now());
+			return origEval(script, numKeys, ...args);
+		};
+
+		await withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"exclusive",
+			async () => {
+				await new Promise((res) => setTimeout(res, 200));
+			},
+			{ ...FAST, renewMs: 60, leaseMs: 5_000 },
+		);
+
+		expect(renewals.length).toBeGreaterThanOrEqual(2);
+	});
+
+	// ── LockLostError ─────────────────────────────────────────────────────────
+
+	it("shared: surfaces LockLostError when renew returns 0 mid-fn", async () => {
+		const r = fake();
+		r.forceSharedRenewLost = true;
+
+		await expect(
+			withDistributedRWLock(
+				asRedis(r),
+				KEYS,
+				"shared",
+				async () => {
+					await new Promise((res) => setTimeout(res, 100));
+					return "never";
+				},
+				{ ...FAST, renewMs: 20, leaseMs: 5_000 },
+			),
+		).rejects.toBeInstanceOf(LockLostError);
+	});
+
+	it("exclusive: surfaces LockLostError when writer flag is force-deleted mid-fn", async () => {
+		const r = fake();
+		// Force the heartbeat to detect loss
+		r.forceExclusiveRenewLost = true;
+
+		await expect(
+			withDistributedRWLock(
+				asRedis(r),
+				KEYS,
+				"exclusive",
+				async () => {
+					await new Promise((res) => setTimeout(res, 100));
+					return "never";
+				},
+				{ ...FAST, renewMs: 20, leaseMs: 5_000 },
+			),
+		).rejects.toBeInstanceOf(LockLostError);
+	});
+
+	// ── LockAcquireTimeoutError ───────────────────────────────────────────────
+
+	it("shared: throws LockAcquireTimeoutError when contended longer than acquireTimeoutMs", async () => {
+		const r = fake();
+		// Plant a permanent writer flag
+		r.strings.set(KEYS.writer, { value: "other", expiresAt: Date.now() + 60_000 });
+
+		await expect(
+			withDistributedRWLock(asRedis(r), KEYS, "shared", async () => "nope", {
+				...FAST,
+				acquireTimeoutMs: 100,
+				acquireRetryMs: 10,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+	});
+
+	it("exclusive: throws LockAcquireTimeoutError when another writer holds the flag", async () => {
+		const r = fake();
+		r.strings.set(KEYS.writer, { value: "other", expiresAt: Date.now() + 60_000 });
+
+		await expect(
+			withDistributedRWLock(asRedis(r), KEYS, "exclusive", async () => "nope", {
+				...FAST,
+				acquireTimeoutMs: 100,
+				acquireRetryMs: 10,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+	});
+
+	it("exclusive: throws LockAcquireTimeoutError when readers never drain", async () => {
+		const r = fake();
+		// Plant a live reader that will never expire within acquireTimeoutMs
+		await r.zadd(KEYS.readers, Date.now() + 60_000, "live-token");
+
+		await expect(
+			withDistributedRWLock(asRedis(r), KEYS, "exclusive", async () => "nope", {
+				...FAST,
+				acquireTimeoutMs: 150,
+				acquireRetryMs: 10,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+
+		// Writer flag must be cleaned up in finally even on timeout
+		expect(r.strings.has(KEYS.writer)).toBe(false);
+	});
+
+	// ── Error handling ────────────────────────────────────────────────────────
+
+	it("exception in fn still releases shared lock", async () => {
+		const r = fake();
+		await expect(
+			withDistributedRWLock(
+				asRedis(r),
+				KEYS,
+				"shared",
+				async () => {
+					throw new Error("boom");
+				},
+				FAST,
+			),
+		).rejects.toThrow("boom");
+		expect(r.zsets.get(KEYS.readers)?.size ?? 0).toBe(0);
+	});
+
+	it("exception in fn still releases exclusive lock", async () => {
+		const r = fake();
+		await expect(
+			withDistributedRWLock(
+				asRedis(r),
+				KEYS,
+				"exclusive",
+				async () => {
+					throw new Error("boom");
+				},
+				FAST,
+			),
+		).rejects.toThrow("boom");
+		expect(r.strings.has(KEYS.writer)).toBe(false);
+	});
+
+	it("release errors are logged but not rethrown", async () => {
+		const r = fake();
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// After fn completes, make the next eval (the release) throw
+		let fnDone = false;
+		const origEval = r.eval.bind(r);
+		r.eval = async (script: string, numKeys: number, ...args: string[]) => {
+			if (fnDone && script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+				throw new Error("release_fail");
+			}
+			return origEval(script, numKeys, ...args);
+		};
+
+		const result = await withDistributedRWLock(
+			asRedis(r),
+			KEYS,
+			"shared",
+			async () => {
+				await new Promise((res) => setTimeout(res, 10));
+				fnDone = true;
+				return "ok";
+			},
+			FAST,
+		);
+		expect(result).toBe("ok");
+		const logged = errSpy.mock.calls.some((c) => String(c[0]).includes("rw_lock_reader_release_error"));
+		expect(logged).toBe(true);
+		errSpy.mockRestore();
+	});
+
+	// ── Option validation ─────────────────────────────────────────────────────
+
+	describe("option validation", () => {
+		it("rejects renewMs >= leaseMs", async () => {
+			await expect(
+				withDistributedRWLock(asRedis(fake()), KEYS, "shared", async () => "ok", { leaseMs: 1000, renewMs: 1000 }),
+			).rejects.toThrow(/renewMs.*must be strictly less than leaseMs/);
+		});
+
+		it("rejects non-positive readerLeaseMs", async () => {
+			await expect(
+				withDistributedRWLock(asRedis(fake()), KEYS, "shared", async () => "ok", { ...FAST, readerLeaseMs: 0 }),
+			).rejects.toThrow(/readerLeaseMs must be > 0/);
+		});
+
+		it("accepts defaults unchanged", async () => {
+			// Defaults satisfy every invariant; should not throw.
+			const result = await withDistributedRWLock(asRedis(fake()), KEYS, "shared", async () => "ok");
+			expect(result).toBe("ok");
+		});
+	});
+
+	// ── rwLockKeys ────────────────────────────────────────────────────────────
+
+	it("rwLockKeys generates the expected key namespace", () => {
+		const k = rwLockKeys("acme", "sandbox-1");
+		expect(k.writer).toBe("vfs:acme:rwlock:sandbox-1:writer");
+		expect(k.readers).toBe("vfs:acme:rwlock:sandbox-1:readers");
+	});
+});

--- a/src/api/tests/unit/distributed-rw-lock.test.ts
+++ b/src/api/tests/unit/distributed-rw-lock.test.ts
@@ -161,7 +161,7 @@ class FakeRedis {
 		}
 
 		// RENEW_EXCLUSIVE_SCRIPT — contains pexpire
-		if (script.includes("pexpire")) {
+		if (script.includes("PEXPIRE")) {
 			if (this.forceExclusiveRenewLost) return 0;
 			const [writerKey] = keys as [string];
 			const [token, leaseMsStr] = argv as [string, string];
@@ -174,7 +174,7 @@ class FakeRedis {
 		}
 
 		// RELEASE_EXCLUSIVE_SCRIPT — contains del
-		if (script.includes("del")) {
+		if (script.includes("DEL")) {
 			const [writerKey] = keys as [string];
 			const [token] = argv as [string];
 			const entry = this.strings.get(writerKey);
@@ -414,7 +414,7 @@ describe("withDistributedRWLock", () => {
 		const origEval = r.eval.bind(r);
 
 		r.eval = async (script: string, numKeys: number, ...args: string[]) => {
-			if (script.includes("pexpire")) renewals.push(Date.now());
+			if (script.includes("PEXPIRE")) renewals.push(Date.now());
 			return origEval(script, numKeys, ...args);
 		};
 

--- a/src/api/tests/unit/session-manager.cross-replica.test.ts
+++ b/src/api/tests/unit/session-manager.cross-replica.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for cross-replica SessionManager RW lock wiring (Phase 2).
+ *
+ * Two SessionManager instances share one in-memory FakeRedis — simulating
+ * two API replicas. Verifies:
+ *   - Two parallel readers (one per manager) run concurrently (peak >= 2).
+ *   - A writer on manager A blocks a reader on manager B until A's exec
+ *     completes (exclusive lock gates new shared acquires).
+ *   - A reader on manager A blocks a writer on manager B until the reader
+ *     exits (shared lock holds off exclusive acquisition until readers drain).
+ *   - withSessionRead falls back to local-only when redis is undefined.
+ *
+ * No real Redis — uses an in-process fake that honours the distributed RW
+ * lock's ZSET + string-key surface.
+ */
+
+import type { Redis } from "ioredis";
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+// ── FakeRedis (ZSET-aware) ────────────────────────────────────────────────────
+
+interface StringEntry {
+	value: string;
+	expiresAt: number;
+}
+
+class FakeRedis {
+	strings = new Map<string, StringEntry>();
+	zsets = new Map<string, Map<string, number>>();
+
+	private gcStrings(): void {
+		const now = Date.now();
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	private getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
+	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
+		this.gcStrings();
+		if (this.strings.has(key)) return null;
+		this.strings.set(key, { value, expiresAt: Date.now() + ms });
+		return "OK";
+	}
+
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		this.gcStrings();
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		if (script.includes("pexpire")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("del")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
+	}
+}
+
+function asRedis(f: FakeRedis): Redis {
+	return f as unknown as Redis;
+}
+
+const T = "default";
+const FAST_OPTS = { leaseMs: 5_000, renewMs: 4_000, acquireTimeoutMs: 3_000, acquireRetryMs: 10, readerLeaseMs: 5_000 };
+
+function makeCreateFs() {
+	return vi.fn((_tenantId: string, _sandboxId: string): Promise<IFileSystem> => Promise.resolve(new InMemoryFs()));
+}
+
+function makePair(): { smA: SessionManager; smB: SessionManager; redis: FakeRedis } {
+	const redis = new FakeRedis();
+	const opts = { redis: asRedis(redis), execLockOptions: FAST_OPTS };
+	const smA = new SessionManager({ createFs: makeCreateFs(), ...opts });
+	const smB = new SessionManager({ createFs: makeCreateFs(), ...opts });
+	return { smA, smB, redis };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("SessionManager cross-replica RW lock", () => {
+	it("two parallel readers across managers run concurrently (peak in-flight >= 2)", async () => {
+		const { smA, smB } = makePair();
+		await Promise.all([smA.getOrCreate(T, "sbx-cr"), smB.getOrCreate(T, "sbx-cr")]);
+
+		let active = 0;
+		let peak = 0;
+		const reader = (sm: SessionManager): Promise<void> =>
+			sm.withSessionRead(T, "sbx-cr", async () => {
+				active++;
+				peak = Math.max(peak, active);
+				await new Promise((r) => setTimeout(r, 40));
+				active--;
+			});
+
+		await Promise.all([reader(smA), reader(smB)]);
+		expect(peak).toBeGreaterThanOrEqual(2);
+	});
+
+	it("exclusive on A blocks shared on B until A's exec completes", async () => {
+		const { smA, smB } = makePair();
+		await Promise.all([smA.getOrCreate(T, "sbx-wb"), smB.getOrCreate(T, "sbx-wb")]);
+
+		const order: string[] = [];
+		let releaseWriter!: () => void;
+		const writerGate = new Promise<void>((r) => {
+			releaseWriter = r;
+		});
+
+		const writer = smA.withSession(T, "sbx-wb", async () => {
+			order.push("w-start");
+			await writerGate;
+			order.push("w-end");
+		});
+
+		// Give writer a moment to acquire
+		await new Promise((r) => setTimeout(r, 10));
+
+		const reader = smB.withSessionRead(T, "sbx-wb", async () => {
+			order.push("r-start");
+		});
+
+		// Let reader attempt acquisition — it should be blocked
+		await new Promise((r) => setTimeout(r, 30));
+		expect(order).toEqual(["w-start"]);
+
+		releaseWriter();
+		await Promise.all([writer, reader]);
+		expect(order).toEqual(["w-start", "w-end", "r-start"]);
+	});
+
+	it("shared on A blocks exclusive on B until reader exits", async () => {
+		const { smA, smB } = makePair();
+		await Promise.all([smA.getOrCreate(T, "sbx-rb"), smB.getOrCreate(T, "sbx-rb")]);
+
+		const order: string[] = [];
+		let releaseReader!: () => void;
+		const readerGate = new Promise<void>((r) => {
+			releaseReader = r;
+		});
+
+		const reader = smA.withSessionRead(T, "sbx-rb", async () => {
+			order.push("r-start");
+			await readerGate;
+			order.push("r-end");
+		});
+
+		// Give reader a moment to acquire
+		await new Promise((r) => setTimeout(r, 10));
+
+		const writer = smB.withSession(T, "sbx-rb", async () => {
+			order.push("w-start");
+		});
+
+		// Let writer attempt acquisition — it should be blocked waiting for readers to drain
+		await new Promise((r) => setTimeout(r, 30));
+		expect(order).toEqual(["r-start"]);
+
+		releaseReader();
+		await Promise.all([reader, writer]);
+		expect(order).toEqual(["r-start", "r-end", "w-start"]);
+	});
+
+	it("withSessionRead falls back to local-only when redis is undefined", async () => {
+		const sm = new SessionManager({ createFs: makeCreateFs() });
+		await sm.getOrCreate(T, "sbx-local");
+		const result = await sm.withSessionRead(T, "sbx-local", async () => "local-ok");
+		expect(result).toBe("local-ok");
+	});
+
+	it("two readers across managers do not block each other (both acquire within 200ms)", async () => {
+		const { smA, smB } = makePair();
+		await Promise.all([smA.getOrCreate(T, "sbx-noblock"), smB.getOrCreate(T, "sbx-noblock")]);
+
+		const starts: number[] = [];
+		const reader = (sm: SessionManager): Promise<void> =>
+			sm.withSessionRead(T, "sbx-noblock", async () => {
+				starts.push(Date.now());
+				await new Promise((r) => setTimeout(r, 60));
+			});
+
+		const t0 = Date.now();
+		await Promise.all([reader(smA), reader(smB)]);
+
+		// Both readers should have started within 200ms of the first (not serialized)
+		const spread = Math.max(...starts) - Math.min(...starts);
+		expect(spread).toBeLessThan(200);
+		// Total elapsed should be closer to 60ms than 120ms (they overlapped)
+		expect(Date.now() - t0).toBeLessThan(150);
+	});
+});

--- a/src/api/tests/unit/session-manager.cross-replica.test.ts
+++ b/src/api/tests/unit/session-manager.cross-replica.test.ts
@@ -106,7 +106,7 @@ class FakeRedis {
 			this.reapZset(readersKey, Number(nowStr));
 			return this.zsets.get(readersKey)?.size ?? 0;
 		}
-		if (script.includes("pexpire")) {
+		if (script.includes("PEXPIRE")) {
 			const [writerKey] = keys as [string];
 			const [token, leaseMsStr] = argv as [string, string];
 			const entry = this.strings.get(writerKey);
@@ -116,7 +116,7 @@ class FakeRedis {
 			}
 			return 0;
 		}
-		if (script.includes("del")) {
+		if (script.includes("DEL")) {
 			const [writerKey] = keys as [string];
 			const [token] = argv as [string];
 			const entry = this.strings.get(writerKey);

--- a/src/api/tests/unit/session-manager.exec-lock.test.ts
+++ b/src/api/tests/unit/session-manager.exec-lock.test.ts
@@ -105,7 +105,7 @@ class FakeRedis {
 			this.reapZset(readersKey, Number(nowStr));
 			return this.zsets.get(readersKey)?.size ?? 0;
 		}
-		if (script.includes("pexpire")) {
+		if (script.includes("PEXPIRE")) {
 			const [writerKey] = keys as [string];
 			const [token, leaseMsStr] = argv as [string, string];
 			const entry = this.strings.get(writerKey);
@@ -115,7 +115,7 @@ class FakeRedis {
 			}
 			return 0;
 		}
-		if (script.includes("del")) {
+		if (script.includes("DEL")) {
 			const [writerKey] = keys as [string];
 			const [token] = argv as [string];
 			const entry = this.strings.get(writerKey);

--- a/src/api/tests/unit/session-manager.exec-lock.test.ts
+++ b/src/api/tests/unit/session-manager.exec-lock.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for SessionManager + distributed exec lock integration (Phase C).
+ * Unit tests for SessionManager + distributed exec lock integration.
  *
  * Exercises:
  *   - withSession/withExistingSession/destroy acquire the Redis lock (by key).
@@ -8,54 +8,124 @@
  *   - Destroy-vs-exec: destroy waits for in-flight exec.
  *   - ELOCKTIMEOUT propagates when the acquire window elapses.
  *
- * No real Redis — uses an in-process fake with SET NX PX + token-aware EVAL.
+ * No real Redis — uses an in-process fake that honours the RW lock's ZSET +
+ * string-key surface (same implementation as distributed-rw-lock.test.ts).
  */
 
 import type { Redis } from "ioredis";
 import { InMemoryFs } from "just-bash";
 import type { IFileSystem } from "just-bash";
 import { describe, expect, it, vi } from "vitest";
-import { execLockKey } from "../../distributed-lock.js";
+import { rwLockKeys } from "../../distributed-rw-lock.js";
 import { SessionManager } from "../../session-manager.js";
 
-interface Entry {
+// ── FakeRedis (ZSET-aware) ────────────────────────────────────────────────────
+
+interface StringEntry {
 	value: string;
 	expiresAt: number;
 }
 
 class FakeRedis {
-	store = new Map<string, Entry>();
+	strings = new Map<string, StringEntry>();
+	zsets = new Map<string, Map<string, number>>();
 
-	private gc(): void {
+	private gcStrings(): void {
 		const now = Date.now();
-		for (const [k, e] of this.store) {
-			if (e.expiresAt <= now) this.store.delete(k);
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
 		}
+		return z;
 	}
 
 	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
-		this.gc();
-		if (this.store.has(key)) return null;
-		this.store.set(key, { value, expiresAt: Date.now() + ms });
+		this.gcStrings();
+		if (this.strings.has(key)) return null;
+		this.strings.set(key, { value, expiresAt: Date.now() + ms });
 		return "OK";
 	}
 
-	async eval(script: string, _n: number, key: string, token: string, ms?: string): Promise<number> {
-		this.gc();
-		if (script.includes("del")) {
-			const e = this.store.get(key);
-			if (e?.value === token) {
-				this.store.delete(key);
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		this.gcStrings();
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
 				return 1;
 			}
 			return 0;
 		}
-		const e = this.store.get(key);
-		if (e?.value === token && ms !== undefined) {
-			e.expiresAt = Date.now() + Number(ms);
-			return 1;
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
 		}
-		return 0;
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		if (script.includes("pexpire")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("del")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
 	}
 }
 
@@ -69,18 +139,20 @@ function makeCreateFs() {
 	return vi.fn((_tenantId: string, _sandboxId: string): Promise<IFileSystem> => Promise.resolve(new InMemoryFs()));
 }
 
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 describe("SessionManager + distributed exec lock", () => {
-	it("withSession takes and releases the Redis lock around fn", async () => {
+	it("withSession takes and releases the Redis writer lock around fn", async () => {
 		const redis = new FakeRedis();
 		const sm = new SessionManager({ createFs: makeCreateFs(), redis: asRedis(redis) });
 
-		let observedLock: Entry | undefined;
+		let observedLock: StringEntry | undefined;
 		await sm.withSession(T, "sbx-A", async () => {
-			observedLock = redis.store.get(execLockKey(T, "sbx-A"));
+			observedLock = redis.strings.get(rwLockKeys(T, "sbx-A").writer);
 		});
 
 		expect(observedLock).toBeDefined();
-		expect(redis.store.has(execLockKey(T, "sbx-A"))).toBe(false);
+		expect(redis.strings.has(rwLockKeys(T, "sbx-A").writer)).toBe(false);
 	});
 
 	it("two SessionManagers sharing the same Redis serialize concurrent withSession", async () => {
@@ -157,8 +229,11 @@ describe("SessionManager + distributed exec lock", () => {
 
 	it("ELOCKTIMEOUT propagates when acquire times out", async () => {
 		const redis = new FakeRedis();
-		// Plant a foreign lock that will never release within the acquire window.
-		redis.store.set(execLockKey(T, "sbx-T"), { value: "owned-by-someone-else", expiresAt: Date.now() + 60_000 });
+		// Plant a foreign writer lock that will never release within the acquire window.
+		redis.strings.set(rwLockKeys(T, "sbx-T").writer, {
+			value: "owned-by-someone-else",
+			expiresAt: Date.now() + 60_000,
+		});
 
 		const sm = new SessionManager({
 			createFs: makeCreateFs(),
@@ -173,5 +248,15 @@ describe("SessionManager + distributed exec lock", () => {
 		const sm = new SessionManager({ createFs: makeCreateFs() });
 		const result = await sm.withSession(T, "sbx-solo", async () => "solo-ok");
 		expect(result).toBe("solo-ok");
+	});
+
+	it("rwlockEnabled=false falls back to exclusive-only path (no reader ZSET)", async () => {
+		const redis = new FakeRedis();
+		const sm = new SessionManager({ createFs: makeCreateFs(), redis: asRedis(redis), rwlockEnabled: false });
+
+		await sm.withSession(T, "sbx-legacy", async () => {});
+
+		// Writer ZSET key must NOT exist (legacy path uses simple SET NX, not RW lock)
+		expect(redis.zsets.has(rwLockKeys(T, "sbx-legacy").readers)).toBe(false);
 	});
 });

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -352,6 +352,9 @@ describe("SessionManager.withSessionRead", () => {
 			}),
 			incr: vi.fn(async () => 1),
 			expire: vi.fn(async () => 1),
+			// eval is needed by withExecLockShared (distributed RW shared lock).
+			// Return 1 so all shared acquire/renew/release ops succeed.
+			eval: vi.fn(async () => 1),
 		};
 
 		const host = new CoherentInMemoryFs();
@@ -366,9 +369,14 @@ describe("SessionManager.withSessionRead", () => {
 		// Five readers in flight before the first GET resolves.
 		const readers = Array.from({ length: 5 }, () => sm.withSessionRead(T, "sb-single-flight", async () => "ok"));
 
-		// Let the readers reach ensureFreshCache.
-		await new Promise((r) => setImmediate(r));
-		await new Promise((r) => setImmediate(r));
+		// Let the readers progress through lock acquisition and reach ensureFreshCache.
+		await new Promise<void>((r) => {
+			const poll = (): void => {
+				if (getCalls.length > initialGets) r();
+				else setImmediate(poll);
+			};
+			setImmediate(poll);
+		});
 		// All five share one in-flight GET (single-flight ensureFreshCache).
 		expect(getCalls.length - initialGets).toBe(1);
 

--- a/src/api/tests/unit/session-manager.version-counter.test.ts
+++ b/src/api/tests/unit/session-manager.version-counter.test.ts
@@ -132,7 +132,7 @@ class FakeRedis {
 			return this.zsets.get(readersKey)?.size ?? 0;
 		}
 		// RENEW_EXCLUSIVE_SCRIPT
-		if (script.includes("pexpire")) {
+		if (script.includes("PEXPIRE")) {
 			const [writerKey] = keys as [string];
 			const [token, leaseMsStr] = argv as [string, string];
 			const entry = this.strings.get(writerKey);
@@ -143,7 +143,7 @@ class FakeRedis {
 			return 0;
 		}
 		// RELEASE_EXCLUSIVE_SCRIPT
-		if (script.includes("del")) {
+		if (script.includes("DEL")) {
 			const [writerKey] = keys as [string];
 			const [token] = argv as [string];
 			const entry = this.strings.get(writerKey);

--- a/src/api/tests/unit/session-manager.version-counter.test.ts
+++ b/src/api/tests/unit/session-manager.version-counter.test.ts
@@ -22,16 +22,31 @@ interface Entry {
 }
 
 class FakeRedis {
-	store = new Map<string, Entry>();
+	store = new Map<string, Entry>(); // version keys (get/incr/expire/del)
+	strings = new Map<string, Entry>(); // lock writer keys (eval-managed)
+	zsets = new Map<string, Map<string, number>>();
 
 	private gc(): void {
 		const now = Date.now();
-		for (const [k, e] of this.store) {
-			if (e.expiresAt <= now) this.store.delete(k);
-		}
+		for (const [k, e] of this.store) if (e.expiresAt <= now) this.store.delete(k);
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
 	}
 
-	// SET key value PX ms NX (for the distributed lock) OR plain set (unused here).
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	private getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
 	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
 		this.gc();
 		if (this.store.has(key)) return null;
@@ -63,22 +78,82 @@ class FakeRedis {
 		return this.store.delete(key) ? 1 : 0;
 	}
 
-	async eval(script: string, _n: number, key: string, token: string, ms?: string): Promise<number> {
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
 		this.gc();
-		if (script.includes("del")) {
-			const e = this.store.get(key);
-			if (e?.value === token) {
-				this.store.delete(key);
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		// ACQUIRE_SHARED_SCRIPT
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		// RELEASE_SHARED_SCRIPT
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
 				return 1;
 			}
 			return 0;
 		}
-		const e = this.store.get(key);
-		if (e?.value === token && ms !== undefined) {
-			e.expiresAt = Date.now() + Number(ms);
-			return 1;
+		// RENEW_SHARED_SCRIPT
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
 		}
-		return 0;
+		// ACQUIRE_EXCLUSIVE_FLAG_SCRIPT
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		// CHECK_READERS_DRAINED_SCRIPT
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		// RENEW_EXCLUSIVE_SCRIPT
+		if (script.includes("pexpire")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		// RELEASE_EXCLUSIVE_SCRIPT
+		if (script.includes("del")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
 	}
 }
 

--- a/src/fs/sql-fs/tests/integration/postgres.test.ts
+++ b/src/fs/sql-fs/tests/integration/postgres.test.ts
@@ -217,7 +217,7 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — inode CRUD", () 
 		expect(inode!.mode).toBe(0o644);
 		expect(inode!.size).toBe(42);
 		expect(inode!.nlink).toBe(1);
-		expect(inode!.contentSha256).toEqual(sha256);
+		expect(new Uint8Array(inode!.contentSha256 as Buffer)).toEqual(sha256);
 		expect(inode!.symlinkTarget).toBeNull();
 	});
 
@@ -1026,7 +1026,7 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — loadAllPaths", (
 		expect(fileEntry!.kind).toBe(1);
 		expect(fileEntry!.mode).toBe(0o644);
 		expect(fileEntry!.size).toBe(fileData.length);
-		expect(fileEntry!.contentSha256).toEqual(sha256);
+		expect(new Uint8Array(fileEntry!.contentSha256 as Buffer)).toEqual(sha256);
 	});
 });
 
@@ -1185,7 +1185,7 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — resolvePath (fs_
 
 		// Apply stored procedure DDL (idempotent via CREATE OR REPLACE)
 		const migrationSql = readFileSync(
-			fileURLToPath(new URL("../migrations/postgres/0001_rls_and_procs.sql", import.meta.url)),
+			fileURLToPath(new URL("../../migrations/postgres/0001_rls_and_procs.sql", import.meta.url)),
 			"utf8",
 		);
 		await dialect.transaction(async (tx) => {


### PR DESCRIPTION
## Summary

- Adds a Redis-backed distributed reader-writer lock (`src/api/distributed-rw-lock.ts`) that lets `readOnly` execs run concurrently across replicas while writers keep strong cross-replica consistency. Writers take an exclusive flag + drain a reader ZSET; readers register a TTL'd entry. Writer-priority prevents reader starvation; TTL'd reader entries prevent crashed-reader deadlock.
- Wires `SessionManager`: `withSessionRead` uses the new shared mode; `withSession` / `withExistingSession` / `withSessionOrRehydrate` use the exclusive mode. `REDIS_RWLOCK_ENABLED` flag preserves the legacy SET-NX path during rolling deploys.
- Integration suite covers parallel cross-replica readers, writer/reader blocking both directions, writer-priority under continuous readers, crashed-reader reaping, version visibility, plus a `--scenario=cross-replica-rw` stress mode.

## Review fixes (last commit)

- `assertOptions` rejects `renewMs >= readerLeaseMs` (otherwise a misconfigured `REDIS_RWLOCK_READER_LEASE_MS` could let a writer reap a live reader between heartbeats).
- `rwLockKeys()` uses a Redis Cluster hash tag (`vfs:{tenant}:rwlock:{<sandbox>}:writer` / `:readers`) so two-key EVAL scripts route to the same slot.
- Version bumped 0.3.3 → 0.3.4 across `package.json`, `pnpm-lock.yaml`, `src/api/openapi-spec.ts`; CHANGELOG entry added.

Closes #61.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint:fix` clean
- [x] `pnpm test:unit` — 754 passed / 4 skipped
- [x] `pnpm test:integration` against local Postgres 16 + Redis 7 (cross-replica suite passes)
- [x] `scripts/stress-test.ts --scenario=cross-replica-rw --duration=60s` — 0 `EREADONLY_VIOLATION`, 0 `LockLostError`, reader p50 ≈ 2 ms vs writer p50 ≈ 88 ms
- [ ] Reviewer to spot-check Redis Cluster routing (the new hash-tag form must hash both keys to the same slot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distributed read-write lock enabling concurrent read-only ops across replicas with writer-priority; session manager supports shared (read) and exclusive (write) execution paths; new env vars REDIS_RWLOCK_ENABLED and REDIS_RWLOCK_READER_LEASE_MS; validation tightened for reader lease/renew ordering.

* **Tests**
  * Extensive unit, integration, and stress scenarios validating cross-replica coherence, recovery, and performance; stress runner adds CLI scenario/duration options.

* **Documentation**
  * CHANGELOG updated, env var docs added, OpenAPI version bumped to 0.3.5, switched to Changesets workflow.

* **Chores**
  * Package version bumped to 0.3.5; CI workflow added to automate versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/65)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->