### PR TITLE
fix(ci): match Changesets "## X.Y.Z" headings in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,22 @@ jobs:
             exit 1
           fi
 
+          # Accept both heading styles, in this order of preference:
+          #   - Changesets default:    "## 0.3.6"
+          #   - Keep a Changelog:      "## [0.3.4] - 2026-05-13"
           VERSION=$(awk '
             /^## \[Unreleased\]/ { next }
             /^## \[[^]]+\]/ {
               line = $0
               sub(/^## \[/, "", line)
               sub(/\].*/, "", line)
+              print line
+              exit
+            }
+            /^## [0-9]/ {
+              line = $0
+              sub(/^## /, "", line)
+              sub(/[[:space:]].*/, "", line)
               print line
               exit
             }
@@ -66,10 +76,19 @@ jobs:
         run: |
           VERSION="${{ steps.detect.outputs.VERSION }}"
 
+          # Match either heading style for this version:
+          #   - Changesets:           "## 0.3.6"            (exact, or followed by whitespace)
+          #   - Keep a Changelog:     "## [0.3.6]" / "## [0.3.6] - 2026-..."
+          # Stop at the next "## " heading of either style.
           CONTENT=$(awk -v ver="$VERSION" '
-            BEGIN { header = "## [" ver "]" }
-            index($0, header) == 1 { found=1; next }
-            found && /^## \[/ { exit }
+            BEGIN {
+              header_old = "## [" ver "]"
+              header_new = "## " ver
+            }
+            !found && (index($0, header_old) == 1 || $0 == header_new || index($0, header_new " ") == 1) {
+              found=1; next
+            }
+            found && /^## (\[|[0-9])/ { exit }
             found { print }
           ' CHANGELOG.md | sed '/^$/d')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 0.3.6
 
 ### Patch Changes
 
 - 8d50059: add distributed lock for R-W so strong consistency is enforced
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.4] - 2026-05-13
 


### PR DESCRIPTION
## Summary

The release pipeline (`.github/workflows/release.yml`) was hard-coded to the Keep-a-Changelog `## [X.Y.Z]` heading style. After switching to Changesets (which writes `## X.Y.Z` — no brackets), the awk scripts in **Detect topmost version** and **Extract CHANGELOG section** silently skipped the new `## 0.3.6` entry, picked up the legacy `## [0.3.4]` instead, found the existing tag, and set `RELEASE=false`. Result for v0.3.6: no `v*` tag, no `:v0.3.6` Docker tag, no GitHub Release — only `:latest` + `:sha-...` were pushed.

Two-part fix:

- **Awk: accept both heading styles.** The detect step now recognises `## X.Y.Z` in addition to `## [X.Y.Z]`. The extract step matches either shape for the target version and treats either shape as a section boundary when scanning forward. Legacy bracketed entries still parse identically.
- **CHANGELOG layout.** `pnpm changeset version` inserted `## 0.3.6` *above* the Keep-a-Changelog preamble (`All notable changes…` / `The format is based on…`), so the preamble ended up *inside* the 0.3.6 section. Hoisted the preamble back to the top of the file so this release and every future Changesets release have a clean section.

## Test plan

- [x] Local dry-run of the patched **detect** awk against the current `CHANGELOG.md` returns `0.3.6`
- [x] Local dry-run of the patched **extract** awk for `0.3.6` returns only the patch-changes block (no preamble bleed)
- [ ] After merge to `main`, confirm the `Release` workflow run for this commit sets `RELEASE=true`, tags `v0.3.6`, pushes the `:v0.3.6` Docker tag, and creates the GitHub Release with the patch-changes body
- [ ] Confirm older legacy versions (e.g. `0.3.4`) would still detect and extract correctly if re-run (not needed in practice, but proves no regression for the bracket style)

## Notes

- This release won't auto-tag `v0.3.6` because the merge for 0.3.6 already happened (5cee8e5) — the GitHub Release for v0.3.6 will need to be cut manually with the body from the new `## 0.3.6` section, **or** wait until the next release (which will now Just Work).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow to recognize multiple changelog heading formats, improving compatibility with different changelog conventions.
  * Reorganized changelog documentation structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/67)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->