### PR TITLE
chore: release v0.3.7

### DIFF
--- a/.changeset/neat-mails-cough.md
+++ b/.changeset/neat-mails-cough.md
@@ -1,5 +1,0 @@
----
-"virtualfs-api": patch
----
-
-Parallel readOnly batch execution. POST /exec-sync-batch and MCP bash_exec_batch now run scripts in parallel when readOnly: true, bounded at 16 concurrent workers. Result order is preserved. Write-path batches are unchanged (sequential, exclusive lock). MCP client disconnects now propagate into in-flight scripts via extra.signal forwarding.

--- a/.changeset/parallel-readonly-batch.md
+++ b/.changeset/parallel-readonly-batch.md
@@ -1,5 +1,0 @@
----
-"virtualfs-api": minor
----
-
-Parallel readOnly batch execution. POST /exec-sync-batch and MCP bash_exec_batch now run scripts in parallel when readOnly:true, capped at 16 concurrent. Mixed and write-path batches are unchanged (sequential, exclusive lock). Result order preserved. MCP client disconnect now propagates into in-flight scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.7
+
+### Patch Changes
+
+- [#69](https://github.com/Hazzng/virtualFS/pull/69) Thanks [@Hazzng](https://github.com/Hazzng)! - Parallel readOnly batch execution. POST /exec-sync-batch and MCP bash_exec_batch now run scripts in parallel when readOnly: true, bounded at 16 concurrent workers. Result order is preserved. Write-path batches are unchanged (sequential, exclusive lock). MCP client disconnects now propagate into in-flight scripts via extra.signal forwarding.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.3.6-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.3.7-blue" alt="Version" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?logo=node.js&logoColor=white" alt="Node.js" />
   <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/MCP-2025--03--26-8b5cf6" alt="MCP" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtualfs-api",
-	"version": "0.3.6",
+	"version": "0.3.7",
 	"description": "Persistent filesystem backend (Postgres) + HTTP/MCP API for just-bash sandboxes",
 	"type": "module",
 	"license": "MIT",

--- a/src/api/openapi-spec.ts
+++ b/src/api/openapi-spec.ts
@@ -83,7 +83,7 @@ export const openapiSpec = {
 	openapi: "3.0.0",
 	info: {
 		title: "VirtualFS API",
-		version: "0.3.6",
+		version: "0.3.7",
 		description: "Persistent filesystem backend + HTTP/MCP API for just-bash sandboxes. Backed by Postgres.",
 	},
 	servers: [{ url: "/v1", description: "API v1" }],


### PR DESCRIPTION
## Summary
- Bumps version from `0.3.6` → `0.3.7` (patch)
- Consumes `.changeset/neat-mails-cough.md` (the duplicate minor changeset was dropped)
- Updates `CHANGELOG.md`, `README.md` badge, `package.json`, and `src/api/openapi-spec.ts`

## Testing
- Not run (version/changelog bump only)
