### PR TITLE
fix(python-sdk): expose read_only on exec_batch for parallel execution

### DIFF
--- a/.changeset/python-sdk-exec-batch-read-only.md
+++ b/.changeset/python-sdk-exec-batch-read-only.md
@@ -1,0 +1,5 @@
+---
+"virtualfs-api": patch
+---
+
+Python SDK: expose `read_only` parameter on `Sandbox.exec_batch()`. When `read_only=True`, the request forwards `readOnly: true` to the server, activating parallel script execution under a shared read-lock. Defaults to `False` (sequential, write-lock) for full backward compatibility.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Mounted at `/mcp`. Streamable HTTP transport per MCP 2025-03-26 spec. Tool names
 | `sandbox_list` | List all sandboxes owned by the current user |
 | `sandbox_delete` | Delete a sandbox and all its files |
 | `bash_exec` | Execute a bash script, return buffered output |
-| `bash_exec_batch` | Execute multiple scripts sequentially — collapses N round-trips into 1 |
+| `bash_exec_batch` | Execute multiple scripts in one round-trip; `readOnly:false` → sequential under one write-lock, `readOnly:true` → parallel under a shared read-lock |
 | `fs_ingest` | Bulk-upload files into a sandbox |
 | `fs_export` | Download sandbox files as a JSON map |
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -77,7 +77,7 @@ fs = Client(base_url="...", token="eyJhbGciOi...")
 | Method | HTTP |
 |---|---|
 | `sb.exec(script, cwd=, env=, timeout_ms=, debug=) -> ExecResult` | `POST /exec-sync` |
-| `sb.exec_batch([{id, script}, ...], timeout_ms=) -> list[BatchExecResult]` | `POST /exec-sync-batch` |
+| `sb.exec_batch([{id, script}, ...], timeout_ms=, read_only=) -> list[BatchExecResult]` | `POST /exec-sync-batch` |
 | `for ev in sb.exec_stream(script, ...)` | `POST /exec` (SSE) |
 
 #### Ingest / Export
@@ -106,6 +106,30 @@ All exceptions derive from `VirtualFSError`. HTTP status codes map to:
 | network | `TransportError` |
 
 Each error exposes `.code` (server error code, e.g. `ENOENT`), `.status`, and `.details`.
+
+## Performance patterns
+
+`exec_batch` is for collapsing many round-trips, not for parallelising
+CPU-bound work. The lock model determines what runs in parallel:
+
+| Goal | Recommended call | Notes |
+|---|---|---|
+| Many cheap independent reads (find/grep/cat/stat) | `sb.exec_batch([...], read_only=True)` | Parallel under shared read-lock, ordered results. |
+| Atomic multi-step write | `sb.exec_batch([...])` (default) | Sequential inside one write-lock. Scripts share shell state. |
+| Multi-pattern grep over the same file set | `sb.exec("grep -E 'pat1\|pat2\|pat3' ...")` | One filesystem traversal beats N. |
+| One-shot read or write | `sb.exec("...")` | Holds the lock for the whole script — bundle logic into one script. |
+
+Benchmark snapshot (951-file repo, 8 grep patterns):
+
+| Approach | Wall-clock |
+|---|---|
+| `exec_batch` of 8 scripts (default, sequential) | ~1100ms |
+| `exec_batch` of 8 scripts, `read_only=True` (parallel) | faster, varies with vCPU count |
+| Single `grep -E 'pat1\|pat2\|...'` (alternation) | ~420ms |
+
+The sandbox container is typically single-core; bash `&`/`wait`
+parallelism beyond ~2 jobs is usually slower than sequential on CPU-bound
+work.
 
 ## Streaming exec
 

--- a/clients/python/src/virtualfs/sandbox.py
+++ b/clients/python/src/virtualfs/sandbox.py
@@ -213,23 +213,50 @@ class Sandbox:
         scripts: List[Mapping[str, str]],
         *,
         timeout_ms: int = 30_000,
+        read_only: bool = False,
     ) -> List[BatchExecResult]:
-        """`POST /exec-sync-batch` — run up to 50 scripts sequentially in one request.
+        """`POST /exec-sync-batch` — run up to 50 scripts in one HTTP request.
 
         `scripts` is a list of `{"id": "...", "script": "..."}` dicts. The
         single `timeout_ms` budget covers all scripts; if it is exhausted,
         the remaining results carry `exit_code=-1` and `error="timeout"`.
 
-        The lock is acquired once for the entire batch — all scripts in the
-        batch are atomic relative to other callers. Use this for exploration
-        (find, grep, cat) to collapse N round-trips into 1.
+        Execution mode (important — agents please read):
 
-        Atomicity caveat: the same read-modify-write rule applies. If your
-        batch reads state in script 1 and writes in script 50, that is safe
-        (same lock acquisition). If you need to do Python computation between
-        a read and a write, that logic must live inside a single script string.
+        * `read_only=False` (default): scripts run **SEQUENTIALLY** inside a
+          single write-lock acquisition. They share shell state and are
+          atomic relative to other callers. This collapses N HTTP round-trips
+          into 1 but does **not** parallelise CPU-bound work — each script
+          waits for the previous to finish.
+        * `read_only=True`: scripts run **IN PARALLEL** (bounded fan-out)
+          under a shared read-lock. Any mutating filesystem op is rejected
+          with `EREADONLY_VIOLATION`. Use this for independent reads
+          (find / grep / cat) when you want parallel execution.
+
+        Performance patterns:
+
+        * For multi-pattern grep over the same file set, prefer a single
+          `sb.exec("grep -E 'pat1|pat2|pat3' ...")` over batching separate
+          greps — one filesystem traversal beats N. See the SDK README for
+          benchmark numbers.
+        * For many cheap independent scripts (echo / stat / small cat),
+          `exec_batch` with up to 50 scripts has flat ~42ms overhead and is
+          the fastest path.
+        * The sandbox container is typically single-core; bash `& + wait`
+          parallelism degrades past ~2 jobs on CPU-bound work.
+
+        Atomicity caveat (write batches): the same read-modify-write rule as
+        `exec` applies. If your batch reads state in script 1 and writes in
+        script 50, that is safe (same lock). If you need Python computation
+        between a read and a write, that logic must live inside a single
+        script string.
         """
-        body = {"scripts": [dict(s) for s in scripts], "timeoutMs": timeout_ms}
+        body: Dict[str, Any] = {
+            "scripts": [dict(s) for s in scripts],
+            "timeoutMs": timeout_ms,
+        }
+        if read_only:
+            body["readOnly"] = True
         client_timeout = max(timeout_ms / 1000.0 + 5.0, 35.0)
         resp = self._t.request(
             "POST",

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -285,6 +285,30 @@ def test_exec_batch():
 
 
 @respx.mock
+def test_exec_batch_read_only_forwards_flag():
+    captured: dict = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={"results": [{"id": "a", "stdout": "ok", "stderr": "", "exitCode": 0}]},
+        )
+
+    respx.post(f"{BASE_URL}/v1/sandboxes/sb/exec-sync-batch").mock(side_effect=_record)
+
+    sb = make_client().sandboxes.attach("sb")
+    sb.exec_batch([{"id": "a", "script": "ls"}], read_only=True)
+    assert captured["body"].get("readOnly") is True
+
+    # Default (read_only=False) must not send the flag, preserving the
+    # existing sequential-atomic write semantics.
+    captured.clear()
+    sb.exec_batch([{"id": "a", "script": "ls"}])
+    assert "readOnly" not in captured["body"]
+
+
+@respx.mock
 def test_exec_stream_yields_events_until_exit():
     sse_body = (
         'event: stdout\ndata: {"t":0.1,"data":"hello\\n"}\n\n'


### PR DESCRIPTION
## Root cause

The server-side parallel `exec_batch` path (shipped in #69) requires callers to pass `readOnly: true` in the HTTP body to activate it. The Python SDK's `Sandbox.exec_batch()` had no `read_only` parameter, so Python callers had no way to opt into parallel execution — they always got the default sequential path regardless of intent.

This meant agents hitting the pattern from issue #71 (batching independent grep/find scripts) would silently receive sequential execution even after the server was upgraded.

## Fix

Add `read_only: bool = False` to `Sandbox.exec_batch()`. When `True`, `readOnly: true` is forwarded in the request body. When `False` (default), the key is omitted entirely — preserving exact backward compatibility for all existing callers.

Updated docstring clearly explains:
- Default path: sequential, write-lock, scripts share shell state
- `read_only=True` path: parallel (bounded fan-out), shared read-lock, ordered results, mutating ops rejected with `EREADONLY_VIOLATION`
- Performance guidance: grep alternation beats batching for multi-pattern search; bash `& + wait` degrades past 2 jobs on single-core sandboxes

## Tests

- `test_exec_batch_read_only_forwards_flag` (new): asserts `read_only=True` sends `readOnly: true` in the request body, and that default call omits the key entirely
- All 25 existing Python SDK tests pass
- All 761 existing TypeScript unit tests pass

## Documentation

Added "Performance patterns" table to `clients/python/README.md` with benchmark data from the issue, covering all four usage patterns (cheap independent reads, atomic multi-step writes, multi-pattern grep, one-shot ops).

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch execution API adds a read-only mode to run many independent read workloads in parallel; default mode remains sequential for atomic multi-step writes.

* **Documentation**
  * Added a "Performance patterns" section with usage recommendations and benchmark notes for batch vs single-shot execution.

* **Tests**
  * Added unit tests covering the new read-only batch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->