### PR TITLE
fix(node-alias): replace help-wall stub with translating node command

### DIFF
--- a/.changeset/khaki-plants-notice.md
+++ b/.changeset/khaki-plants-notice.md
@@ -1,0 +1,5 @@
+---
+"virtualfs-api": patch
+---
+
+just-bash's built-in nodeStubCommand (registered alongside js-exec when javascript=true) ignores all arguments and unconditionally prints the full 60-line js-exec --help page to stderr before exiting 1. Added src/api/commands/node-command.ts — a custom Command that replaces the built-in stub via BashOptions.customCommands (which takes precedence over built-ins with the same name). Custom commands are only injected when javascript: true; non-JS sandboxes are unaffected.

--- a/src/api/commands/node-command.ts
+++ b/src/api/commands/node-command.ts
@@ -51,7 +51,10 @@ export const nodeCommand = defineCommand("node", async (args: string[], ctx: Com
 		return hintResult(127);
 	}
 
-	const first = args[0];
+	// args.length === 0 guard above ensures args[0] is present; the non-null
+	// assertion is required because noUncheckedIndexedAccess types it as
+	// `string | undefined` even after the length check.
+	const first = args[0]!;
 
 	// --help / -h — print the hint with a success exit so callers can detect
 	// that the command exists and the user explicitly asked for help.
@@ -80,7 +83,8 @@ export const nodeCommand = defineCommand("node", async (args: string[], ctx: Com
 
 		if (ctx.exec !== undefined) {
 			// Build: js-exec -c CODE [extra-args…]
-			const code = args[1];
+			// args.length >= 2 is guaranteed by the `args.length < 2` guard above.
+			const code = args[1]!;
 			const extraArgs = args.slice(2);
 			const cmd = ["js-exec", "-c", shellQuote(code), ...extraArgs.map(shellQuote)].join(" ");
 			return ctx.exec(cmd, { cwd: ctx.cwd });

--- a/src/api/commands/node-command.ts
+++ b/src/api/commands/node-command.ts
@@ -1,0 +1,108 @@
+/**
+ * Custom `node` command — replaces just-bash's built-in nodeStubCommand.
+ *
+ * The built-in stub ignores all arguments and always prints the full js-exec
+ * help page (60+ lines) before exiting 1.  This trips up agents that reach for
+ * `node -e …` / `node script.js` and CI scripts that rely on exit 127 for
+ * "command not found" semantics.
+ *
+ * This replacement:
+ *   - `node --help`             → concise hint, exit 0
+ *   - `node` (bare)             → same concise hint, exit 127
+ *   - `node -e CODE [args…]`    → delegates to `js-exec -c CODE [args…]`
+ *   - `node FILE [args…]`       → delegates to `js-exec FILE [args…]`
+ *   - `node --version`          → reports the js-exec QuickJS version, exit 0
+ *   - any other flag            → "unrecognized option" hint, exit 127
+ *
+ * Delegation via ctx.exec means the real js-exec command handles all of its
+ * own flag parsing, runtime throttling, and error reporting — we never
+ * duplicate that logic here.
+ *
+ * Fixes: https://github.com/Hazzng/virtualFS/issues/76
+ */
+
+import { defineCommand } from "just-bash";
+import type { CommandContext, ExecResult } from "just-bash";
+
+const HINT = `\
+'node' is not available in this sandbox. Use 'js-exec' instead:
+  js-exec -c 'CODE'             # inline code  (replaces: node -e 'CODE')
+  js-exec FILE.js               # run a file   (replaces: node FILE.js)
+  js-exec --strip-types FILE.ts # TypeScript with type stripping
+Run 'js-exec --help' for full options.
+`;
+
+function hintResult(exitCode: number): ExecResult {
+	return { stdout: "", stderr: HINT, exitCode };
+}
+
+/**
+ * Shell-quote a single token so it is safe to embed in a `js-exec …` command
+ * string.  We use single-quote wrapping and escape any literal single quotes
+ * inside the value (the classic `'...' → '\''...'\''` technique).
+ */
+function shellQuote(token: string): string {
+	return `'${token.replace(/'/g, "'\\''")}'`;
+}
+
+export const nodeCommand = defineCommand("node", async (args: string[], ctx: CommandContext): Promise<ExecResult> => {
+	// Bare invocation — no arguments.
+	if (args.length === 0) {
+		return hintResult(127);
+	}
+
+	const first = args[0];
+
+	// --help / -h — print the hint with a success exit so callers can detect
+	// that the command exists and the user explicitly asked for help.
+	if (first === "--help" || first === "-h") {
+		return hintResult(0);
+	}
+
+	// --version / -v — forward to js-exec so the version string is consistent.
+	if (first === "--version" || first === "-v") {
+		if (ctx.exec !== undefined) {
+			return ctx.exec("js-exec --version", { cwd: ctx.cwd });
+		}
+		// Fallback: cannot delegate, emit a hint.
+		return hintResult(127);
+	}
+
+	// -e CODE [args…]  →  js-exec -c CODE [args…]
+	if (first === "-e") {
+		if (args.length < 2) {
+			return {
+				stdout: "",
+				stderr: "node: -e requires an argument\nUse: js-exec -c 'CODE'\n",
+				exitCode: 127,
+			};
+		}
+
+		if (ctx.exec !== undefined) {
+			// Build: js-exec -c CODE [extra-args…]
+			const code = args[1];
+			const extraArgs = args.slice(2);
+			const cmd = ["js-exec", "-c", shellQuote(code), ...extraArgs.map(shellQuote)].join(" ");
+			return ctx.exec(cmd, { cwd: ctx.cwd });
+		}
+		return hintResult(127);
+	}
+
+	// Any other flag (starts with '-') that we don't recognise.
+	if (first.startsWith("-")) {
+		return {
+			stdout: "",
+			stderr: `node: unrecognized option '${first}'\n${HINT}`,
+			exitCode: 127,
+		};
+	}
+
+	// FILE [args…]  →  js-exec FILE [args…]
+	if (ctx.exec !== undefined) {
+		const cmd = ["js-exec", ...args.map(shellQuote)].join(" ");
+		return ctx.exec(cmd, { cwd: ctx.cwd });
+	}
+
+	// ctx.exec is undefined (e.g., during unit tests without a full shell context).
+	return hintResult(127);
+});

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -15,6 +15,7 @@
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
 import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
+import { nodeCommand } from "./commands/node-command.js";
 import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/index.js";
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
@@ -396,6 +397,12 @@ export class SessionManager {
 					python: resolvedRuntime.python || undefined,
 					javascript: resolvedRuntime.javascript || undefined,
 					defenseInDepth: defenseInDepthConfig,
+					// Override just-bash's built-in nodeStubCommand with a smarter
+					// version that translates `node -e CODE` → `js-exec -c CODE` and
+					// `node FILE` → `js-exec FILE` instead of dumping a help wall.
+					// Only registered when the javascript runtime is enabled so that
+					// non-JS sandboxes keep the default "command not found" behaviour.
+					customCommands: resolvedRuntime.javascript ? [nodeCommand] : undefined,
 				});
 				const pathCacheBytes = this.estimatePathCacheBytes(fs);
 				const scriptTxFs = asScriptTxFs(fs);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -15,13 +15,13 @@
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
 import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
-import { nodeCommand } from "./commands/node-command.js";
 import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/index.js";
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
 import { SessionScopedFs } from "../fs/sql-fs/session-scoped-fs.js";
 import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../fs/sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../fs/sql-fs/types.js";
+import { nodeCommand } from "./commands/node-command.js";
 import { execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { type DistributedRWLockOptions, rwLockKeys, withDistributedRWLock } from "./distributed-rw-lock.js";
 import { logAudit } from "./lib/audit.js";

--- a/src/api/tests/unit/node-command.test.ts
+++ b/src/api/tests/unit/node-command.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the custom `node` command — issue #76.
+ *
+ * Verifies that the `node` alias registered in JS-enabled sandboxes:
+ *   - translates `node -e CODE` → executes via `js-exec -c CODE`
+ *   - translates `node FILE`    → executes via `js-exec FILE`
+ *   - prints a concise hint (not a 60-line help wall) on bare `node` / `node --help`
+ *   - exits 127 for "command not found" cases (bare, unknown flag)
+ *   - exits 0 for --help
+ *   - does NOT touch non-JS sandboxes
+ */
+
+import { Bash, InMemoryFs } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { nodeCommand } from "../../commands/node-command.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Bash instance with the real js-exec runtime + our node override. */
+function makeJsBash(files?: Record<string, string>): Bash {
+	const fs = new InMemoryFs(files);
+	return new Bash({ fs, javascript: true, customCommands: [nodeCommand] });
+}
+
+/** Build a Bash instance WITHOUT javascript (node should be absent entirely). */
+function makeNoJsBash(): Bash {
+	const fs = new InMemoryFs();
+	// Do NOT pass customCommands — this simulates a non-JS sandbox.
+	return new Bash({ fs });
+}
+
+// ---------------------------------------------------------------------------
+// Direct command unit tests (no Bash shell; test the Command object directly)
+// ---------------------------------------------------------------------------
+
+describe("nodeCommand — direct execution (no shell context)", () => {
+	/** Minimal stub CommandContext without exec (simulates missing ctx.exec). */
+	function stubCtx() {
+		const fs = new InMemoryFs();
+		return {
+			fs,
+			cwd: "/",
+			env: new Map<string, string>(),
+			stdin: "",
+		};
+	}
+
+	it("bare node (no args) returns exit 127 with hint on stderr", async () => {
+		const result = await nodeCommand.execute([], stubCtx());
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("js-exec");
+		expect(result.stderr).toContain("js-exec -c");
+		// Must NOT be a 60-line wall — keep it short
+		expect(result.stderr.split("\n").length).toBeLessThan(15);
+	});
+
+	it("node --help returns exit 0 with hint on stderr", async () => {
+		const result = await nodeCommand.execute(["--help"], stubCtx());
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain("js-exec");
+	});
+
+	it("node -h returns exit 0 with hint on stderr", async () => {
+		const result = await nodeCommand.execute(["-h"], stubCtx());
+		expect(result.exitCode).toBe(0);
+	});
+
+	it("node --unknown-flag returns exit 127 with hint", async () => {
+		const result = await nodeCommand.execute(["--unknown-flag"], stubCtx());
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("unrecognized option");
+		expect(result.stderr).toContain("js-exec");
+	});
+
+	it("node -e with no following CODE returns exit 127 with hint", async () => {
+		const result = await nodeCommand.execute(["-e"], stubCtx());
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("-e requires an argument");
+	});
+
+	it("without ctx.exec delegation, node -e falls back to hint (exit 127)", async () => {
+		// ctx without .exec — simulates minimal environment
+		const result = await nodeCommand.execute(["-e", "console.log(1)"], stubCtx());
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("js-exec");
+	});
+
+	it("without ctx.exec delegation, node file.js falls back to hint (exit 127)", async () => {
+		const result = await nodeCommand.execute(["script.js"], stubCtx());
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("js-exec");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — via a real Bash instance with js-exec + our node override
+// ---------------------------------------------------------------------------
+
+describe("nodeCommand — via Bash with javascript runtime", () => {
+	it("node -e 'console.log(42)' executes and prints 42", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node -e 'console.log(42)'");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("42");
+	});
+
+	it("node -e 'process.exit(3)' propagates the exit code", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node -e 'process.exit(3)'");
+		expect(result.exitCode).toBe(3);
+	});
+
+	it("node script.js executes a file on the virtual filesystem", async () => {
+		const bash = makeJsBash({
+			"/hello.js": "console.log('hello from file')",
+		});
+		const result = await bash.exec("node /hello.js");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("hello from file");
+	});
+
+	it("node script.js with non-existent file returns non-zero exit", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node /does-not-exist.js");
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("does-not-exist.js");
+	});
+
+	it("bare node prints hint and exits 127", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node");
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("js-exec");
+		// Must stay short — not a help wall
+		expect(result.stderr.split("\n").length).toBeLessThan(15);
+	});
+
+	it("node --help exits 0 with brief hint", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node --help");
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain("js-exec");
+	});
+
+	it("node --unknown returns exit 127 with message on stderr", async () => {
+		const bash = makeJsBash();
+		const result = await bash.exec("node --unknown");
+		expect(result.exitCode).toBe(127);
+		expect(result.stderr).toContain("unrecognized option");
+	});
+
+	it("exit code from node -e is visible to subsequent shell commands", async () => {
+		const bash = makeJsBash();
+		// If node -e exits 0, the `&&` branch executes.
+		const result = await bash.exec("node -e 'console.log(\"ok\")' && echo 'after'");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("after");
+	});
+
+	it("node -e passes extra positional args as process.argv", async () => {
+		const bash = makeJsBash();
+		// process.argv[0] is typically 'node', argv[1] is '-e', argv[2+] are extra args.
+		// In js-exec, argv is available via process.argv.
+		const result = await bash.exec("node -e 'console.log(process.argv.length > 0)' myarg");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("true");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Non-JS sandbox — node should not be present as our custom command
+// ---------------------------------------------------------------------------
+
+describe("nodeCommand — NOT registered in non-JS sandbox", () => {
+	it("non-JS sandbox has no 'node' command (command not found)", async () => {
+		const bash = makeNoJsBash();
+		// Without javascript:true, just-bash does not register js-exec/node at all.
+		const result = await bash.exec("node -e 'console.log(1)'");
+		// Should be some non-zero exit — exact message differs by shell impl.
+		expect(result.exitCode).not.toBe(0);
+	});
+});


### PR DESCRIPTION
## Root Cause

`just-bash`'s built-in `nodeStubCommand` (registered alongside `js-exec` when `javascript=true`) ignores **all** arguments and unconditionally prints the full 60-line `js-exec --help` page to stderr before exiting 1. This behaviour trips up agents that have learned `node -e …` / `node script.js` from training data and CI scripts that rely on exit 127 for "command not found" semantics.

Registration site confirmed at:
`node_modules/just-bash/dist/bundle/chunks/js-exec-VXN6TZ7U.js` line 94-96 — the `fe` export (`nodeStubCommand`).

## Fix

Added `src/api/commands/node-command.ts` — a custom `Command` that replaces the built-in stub via `BashOptions.customCommands` (which takes precedence over built-ins with the same name). Custom commands are only injected when `javascript: true`; non-JS sandboxes are unaffected.

The command translates common Node CLI patterns to `js-exec` via `ctx.exec`, rather than duplicating any execution logic:

| Invocation | Behaviour | Exit |
|---|---|---|
| `node -e 'CODE' [args…]` | Delegates to `js-exec -c 'CODE' [args…]` | from js-exec |
| `node FILE [args…]` | Delegates to `js-exec FILE [args…]` | from js-exec |
| `node --version` / `-v` | Delegates to `js-exec --version` | 0 |
| `node --help` / `-h` | Prints 5-line hint | 0 |
| `node` (bare) | Prints 5-line hint | 127 |
| `node --unknown-flag` | "unrecognized option" + hint | 127 |
| `node -e` (no code arg) | "-e requires an argument" hint | 127 |

## Test plan

- [x] 17 new tests in `src/api/tests/unit/node-command.test.ts` covering all branches above (direct command unit tests + Bash integration tests)
- [x] Full unit suite (378 tests) passes: `pnpm vitest run src/api/tests/unit/`
- [x] `node -e 'console.log(42)'` → stdout `42`, exit 0
- [x] `node script.js` → executes file from virtual FS
- [x] `node` bare → 5-line hint, exit 127 (not 60-line help wall)
- [x] `node --help` → exit 0
- [x] non-JS sandbox unchanged

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `node` is available in JavaScript-enabled sandboxes: run files (`node FILE`) or inline code (`node -e CODE`).
* **Bug Fixes**
  * Improved help/error messages and correct exit codes for help, missing args, and unrecognized options.
  * Falls back gracefully when execution delegation isn’t available; non-JS sandboxes retain default behavior.
* **Tests**
  * Added unit and integration tests covering behavior, delegation, and exit-code propagation.
* **Chores**
  * Release metadata updated for a patch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->