### PR TITLE
fix(js-exec): patch Buffer.from/toString to honour encoding argument

### DIFF
--- a/.changeset/fix-js-exec-buffer-encoding.md
+++ b/.changeset/fix-js-exec-buffer-encoding.md
@@ -1,0 +1,7 @@
+---
+"virtualfs-api": patch
+---
+
+fix(js-exec): patch Buffer.from/toString in QuickJS sandbox to honour encoding argument (base64, base64url, hex, latin1)
+
+The just-bash Buffer shim ignored the encoding argument on both `Buffer.from(str, enc)` and `buf.toString(enc)`, making every encoding a silent no-op. A bootstrap snippet is now injected at session creation time that patches those methods with correct base64, base64url, hex, and latin1 implementations. Regression tests cover round-trip encode/decode for all four encodings plus the original no-op bug.

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -14,7 +14,14 @@
 
 import type { Redis } from "ioredis";
 import { Bash } from "just-bash";
-import type { BashExecResult, DefenseInDepthConfig, ExecOptions, IFileSystem, SecurityViolation } from "just-bash";
+import type {
+	BashExecResult,
+	DefenseInDepthConfig,
+	ExecOptions,
+	IFileSystem,
+	JavaScriptConfig,
+	SecurityViolation,
+} from "just-bash";
 import { createPostgresSandboxFs, destroyPostgresSandbox } from "../fs/sql-fs/index.js";
 import type { RedisBlobCache } from "../fs/sql-fs/redis-blob-cache.js";
 import { type RedisPathSnapshot, versionKey } from "../fs/sql-fs/redis-path-snapshot.js";
@@ -27,6 +34,155 @@ import { logAudit } from "./lib/audit.js";
 import { type ReadOnlyContext, readOnlyContext } from "./read-only-context.js";
 import { RWLock } from "./rw-lock.js";
 import type { TenantConfig } from "./tenants.js";
+
+/**
+ * Bootstrap code injected into every js-exec (QuickJS) session to patch the
+ * broken Buffer encoding shim.  The built-in shim ignores the `encoding`
+ * argument on both `Buffer.from(str, enc)` and `buf.toString(enc)`, making
+ * base64 / hex / latin1 round-trips silent no-ops.  This patch replaces those
+ * two methods with correct implementations while leaving all other Buffer
+ * behaviour untouched.
+ *
+ * Encodings patched:
+ *   • base64 / base64url — encode & decode
+ *   • hex               — encode & decode
+ *   • latin1 / binary   — encode & decode (byte-per-char pass-through)
+ *   • utf8 / utf-8 / ascii / ucs2 / utf16le — delegated to the original shim
+ *
+ * The code runs inside QuickJS where `btoa`/`atob` are not available, so
+ * base64 is implemented with a compact pure-JS lookup table.
+ */
+const JS_EXEC_BUFFER_ENCODING_BOOTSTRAP = /* js */ `
+(function () {
+  var _Buf = globalThis.Buffer;
+  if (!_Buf) return; // safety guard — should never be falsy
+
+  // ─── base64 alphabet ───────────────────────────────────────────────────────
+  var _B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  var _B64U = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+  // Reverse lookup: charCode → 6-bit value (works for both standard and url-safe)
+  var _REV = new Uint8Array(128);
+  for (var _i = 0; _i < 64; _i++) {
+    _REV[_B64.charCodeAt(_i)] = _i;
+    _REV[_B64U.charCodeAt(_i)] = _i; // url-safe aliases overlap, that's fine
+  }
+
+  function _b64Encode(bytes, urlSafe) {
+    var alpha = urlSafe ? _B64U : _B64;
+    var out = '';
+    var len = bytes.length;
+    var i = 0;
+    while (i < len) {
+      var b0 = bytes[i++];
+      var b1 = i < len ? bytes[i++] : 0;
+      var b2 = i < len ? bytes[i++] : 0;  // may be padding
+      out += alpha[b0 >> 2];
+      out += alpha[((b0 & 3) << 4) | (b1 >> 4)];
+      out += alpha[((b1 & 0x0f) << 2) | (b2 >> 6)];
+      out += alpha[b2 & 0x3f];
+    }
+    // Add standard padding (base64url strips it; standard keeps it)
+    var pad = (3 - (len % 3)) % 3;
+    if (!urlSafe && pad > 0) {
+      out = out.slice(0, out.length - pad) + (pad === 1 ? '=' : '==');
+    } else if (urlSafe && pad > 0) {
+      out = out.slice(0, out.length - pad); // no padding for base64url
+    }
+    return out;
+  }
+
+  function _b64Decode(str) {
+    // Strip padding and whitespace
+    str = str.replace(/[\\r\\n\\t ]/g, '').replace(/=+$/, '');
+    var len = str.length;
+    var outLen = (len * 3 / 4) | 0;
+    var out = new Uint8Array(outLen);
+    var j = 0;
+    for (var i = 0; i < len; i += 4) {
+      var c0 = _REV[str.charCodeAt(i)     & 0x7f] || 0;
+      var c1 = _REV[str.charCodeAt(i + 1) & 0x7f] || 0;
+      var c2 = _REV[str.charCodeAt(i + 2) & 0x7f] || 0;
+      var c3 = _REV[str.charCodeAt(i + 3) & 0x7f] || 0;
+      if (j < outLen) out[j++] = (c0 << 2) | (c1 >> 4);
+      if (j < outLen) out[j++] = ((c1 & 0x0f) << 4) | (c2 >> 2);
+      if (j < outLen) out[j++] = ((c2 & 0x03) << 6) | c3;
+    }
+    return out.subarray(0, j);
+  }
+
+  // ─── hex ──────────────────────────────────────────────────────────────────
+  var _HEX = '0123456789abcdef';
+
+  function _hexEncode(bytes) {
+    var out = '';
+    for (var i = 0; i < bytes.length; i++) {
+      out += _HEX[(bytes[i] >> 4) & 0xf] + _HEX[bytes[i] & 0xf];
+    }
+    return out;
+  }
+
+  function _hexDecode(str) {
+    var len = (str.length >> 1);
+    var out = new Uint8Array(len);
+    for (var i = 0; i < len; i++) {
+      out[i] = parseInt(str.substr(i * 2, 2), 16);
+    }
+    return out;
+  }
+
+  // ─── latin1 / binary ──────────────────────────────────────────────────────
+  function _latin1Encode(bytes) {
+    var out = '';
+    for (var i = 0; i < bytes.length; i++) out += String.fromCharCode(bytes[i] & 0xff);
+    return out;
+  }
+
+  function _latin1Decode(str) {
+    var out = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) out[i] = str.charCodeAt(i) & 0xff;
+    return out;
+  }
+
+  // ─── Patch Buffer.from ────────────────────────────────────────────────────
+  var _origFrom = _Buf.from.bind(_Buf);
+  _Buf.from = function (data, encoding) {
+    if (typeof data === 'string' && typeof encoding === 'string') {
+      var enc = encoding.toLowerCase().replace('-', '');
+      if (enc === 'base64')    return new _Buf(_b64Decode(data));
+      if (enc === 'base64url') return new _Buf(_b64Decode(data)); // _REV handles url-safe chars
+      if (enc === 'hex')       return new _Buf(_hexDecode(data));
+      if (enc === 'latin1' || enc === 'binary') return new _Buf(_latin1Decode(data));
+      // utf8 / ascii / ucs2 / utf16le — fall through to original (utf-8 only shim)
+    }
+    return _origFrom(data, encoding);
+  };
+  // Preserve static methods that just-bash copies onto Buffer.from
+  Object.keys(_origFrom).forEach(function (k) {
+    if (!_Buf.from[k]) _Buf.from[k] = _origFrom[k];
+  });
+
+  // ─── Patch Buffer.prototype.toString ─────────────────────────────────────
+  var _origToString = _Buf.prototype.toString;
+  _Buf.prototype.toString = function (encoding, start, end) {
+    var bytes = (start !== undefined || end !== undefined)
+      ? this._data.subarray(start, end)
+      : this._data;
+    if (typeof encoding === 'string') {
+      var enc = encoding.toLowerCase().replace('-', '');
+      if (enc === 'base64')    return _b64Encode(bytes, false);
+      if (enc === 'base64url') return _b64Encode(bytes, true);
+      if (enc === 'hex')       return _hexEncode(bytes);
+      if (enc === 'latin1' || enc === 'binary') return _latin1Encode(bytes);
+      // utf8 / ascii / ucs2 / utf16le — fall through to original
+    }
+    return _origToString.call(this._data === bytes ? this : { _data: bytes }, encoding);
+  };
+
+  // Keep globalThis.Buffer and the jb:buffer symbol in sync
+  globalThis[Symbol.for('jb:buffer')].Buffer = _Buf;
+})();
+`;
 
 type SnapshotWriterFs = ICoherentFs & { _getPathCache(): Map<string, PathCacheEntry> };
 
@@ -391,10 +547,13 @@ export class SessionManager {
 							onViolation: (v: SecurityViolation) => logAudit("defense_in_depth_violation", { sandboxId, ...v }),
 						}
 					: false;
+				const javascriptConfig: JavaScriptConfig | undefined = resolvedRuntime.javascript
+					? { bootstrap: JS_EXEC_BUFFER_ENCODING_BOOTSTRAP }
+					: undefined;
 				const bash = new Bash({
 					fs,
 					python: resolvedRuntime.python || undefined,
-					javascript: resolvedRuntime.javascript || undefined,
+					javascript: javascriptConfig,
 					defenseInDepth: defenseInDepthConfig,
 				});
 				const pathCacheBytes = this.estimatePathCacheBytes(fs);

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -165,6 +165,18 @@ const JS_EXEC_BUFFER_ENCODING_BOOTSTRAP = /* js */ `
   // ─── Patch Buffer.prototype.toString ─────────────────────────────────────
   var _origToString = _Buf.prototype.toString;
   _Buf.prototype.toString = function (encoding, start, end) {
+    // ASSUMPTION: just-bash's Buffer shim stores the backing Uint8Array in
+    // this._data.  We read it directly to support start/end slicing without
+    // copying.  When forwarding utf8/ascii/ucs2 calls back to the original
+    // toString we synthesise a minimal shim object { _data: bytes } so the
+    // original method sees the sliced view instead of the full buffer.
+    //
+    // MAINTENANCE NOTE: if just-bash is upgraded and _data is renamed,
+    // removed, or a required second property is added (e.g. an internal
+    // offset), the utf8/ascii/ucs2 fall-through path will either throw or
+    // silently return wrong data.  Verify after every just-bash upgrade by
+    // running the buffer-encoding unit tests
+    // (src/api/tests/unit/session-manager.js-exec-buffer.test.ts).
     var bytes = (start !== undefined || end !== undefined)
       ? this._data.subarray(start, end)
       : this._data;

--- a/src/api/tests/unit/session-manager.js-exec-buffer.test.ts
+++ b/src/api/tests/unit/session-manager.js-exec-buffer.test.ts
@@ -40,11 +40,7 @@ describe("js-exec Buffer encoding fix (issue #74)", () => {
 
 	it("Buffer.from([0xff,0xfe,0x00]).toString('base64') encodes binary bytes", async () => {
 		const sm = await makeJsSession("buf-b64-bytes");
-		const out = await jsExec(
-			sm,
-			"buf-b64-bytes",
-			`console.log(Buffer.from([0xff,0xfe,0x00]).toString("base64"))`,
-		);
+		const out = await jsExec(sm, "buf-b64-bytes", `console.log(Buffer.from([0xff,0xfe,0x00]).toString("base64"))`);
 		expect(out).toBe("//4A");
 	});
 
@@ -52,11 +48,7 @@ describe("js-exec Buffer encoding fix (issue #74)", () => {
 
 	it("Buffer.from(b64str, 'base64').toString() decodes correctly", async () => {
 		const sm = await makeJsSession("buf-b64-decode");
-		const out = await jsExec(
-			sm,
-			"buf-b64-decode",
-			`console.log(Buffer.from("aGVsbG8=", "base64").toString())`,
-		);
+		const out = await jsExec(sm, "buf-b64-decode", `console.log(Buffer.from("aGVsbG8=", "base64").toString())`);
 		expect(out).toBe("hello");
 	});
 
@@ -77,11 +69,7 @@ describe("js-exec Buffer encoding fix (issue #74)", () => {
 	it("Buffer.from(str).toString('base64url') produces url-safe no-padding encoding", async () => {
 		const sm = await makeJsSession("buf-b64url-enc");
 		// 0xfb=11111011, 0xff=11111111 → base64: '//' → base64url: '--' (idx 62) and '_' (idx 63)
-		const out = await jsExec(
-			sm,
-			"buf-b64url-enc",
-			`console.log(Buffer.from([0xfb, 0xff]).toString("base64url"))`,
-		);
+		const out = await jsExec(sm, "buf-b64url-enc", `console.log(Buffer.from([0xfb, 0xff]).toString("base64url"))`);
 		// Verify no '+', '/', or '=' characters (url-safe, no padding)
 		expect(out).not.toMatch(/[+/=]/);
 		// Verify it decodes back correctly
@@ -117,11 +105,7 @@ describe("js-exec Buffer encoding fix (issue #74)", () => {
 
 	it("Buffer.from([0x00,0xff]).toString('hex') encodes boundary bytes", async () => {
 		const sm = await makeJsSession("buf-hex-bytes");
-		const out = await jsExec(
-			sm,
-			"buf-hex-bytes",
-			`console.log(Buffer.from([0x00,0xff]).toString("hex"))`,
-		);
+		const out = await jsExec(sm, "buf-hex-bytes", `console.log(Buffer.from([0x00,0xff]).toString("hex"))`);
 		expect(out).toBe("00ff");
 	});
 
@@ -129,11 +113,7 @@ describe("js-exec Buffer encoding fix (issue #74)", () => {
 
 	it("Buffer.from('616263', 'hex').toString() decodes from hex", async () => {
 		const sm = await makeJsSession("buf-hex-decode");
-		const out = await jsExec(
-			sm,
-			"buf-hex-decode",
-			`console.log(Buffer.from("616263", "hex").toString())`,
-		);
+		const out = await jsExec(sm, "buf-hex-decode", `console.log(Buffer.from("616263", "hex").toString())`);
 		expect(out).toBe("abc");
 	});
 

--- a/src/api/tests/unit/session-manager.js-exec-buffer.test.ts
+++ b/src/api/tests/unit/session-manager.js-exec-buffer.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression tests for issue #74: Buffer.from().toString('base64') was a no-op.
+ *
+ * The just-bash Buffer shim ignores the `encoding` argument on both
+ * `Buffer.from(str, enc)` and `buf.toString(enc)`.  We patch those methods via
+ * a JavaScriptConfig.bootstrap snippet injected at session creation time.
+ *
+ * These tests exercise the js-exec worker end-to-end (real QuickJS) so they
+ * confirm the patch actually reaches the sandbox, not just that the TypeScript
+ * compiles correctly.
+ */
+
+import { InMemoryFs } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+const T = "default";
+
+async function makeJsSession(sandboxId: string): Promise<SessionManager> {
+	const sm = new SessionManager({ createFs: async () => new InMemoryFs() });
+	await sm.getOrCreate(T, sandboxId, { python: false, javascript: true });
+	return sm;
+}
+
+async function jsExec(sm: SessionManager, sandboxId: string, code: string): Promise<string> {
+	return sm.withExistingSession(T, sandboxId, async (session) => {
+		const result = await session.bash.exec(`js-exec -c ${JSON.stringify(code)}`);
+		return result.stdout.trim();
+	});
+}
+
+describe("js-exec Buffer encoding fix (issue #74)", () => {
+	// ── base64 encode ───────────────────────────────────────────────────────
+
+	it("Buffer.from(str).toString('base64') encodes correctly", async () => {
+		const sm = await makeJsSession("buf-b64-encode");
+		const out = await jsExec(sm, "buf-b64-encode", `console.log(Buffer.from("hello").toString("base64"))`);
+		expect(out).toBe("aGVsbG8=");
+	});
+
+	it("Buffer.from([0xff,0xfe,0x00]).toString('base64') encodes binary bytes", async () => {
+		const sm = await makeJsSession("buf-b64-bytes");
+		const out = await jsExec(
+			sm,
+			"buf-b64-bytes",
+			`console.log(Buffer.from([0xff,0xfe,0x00]).toString("base64"))`,
+		);
+		expect(out).toBe("//4A");
+	});
+
+	// ── base64 decode ───────────────────────────────────────────────────────
+
+	it("Buffer.from(b64str, 'base64').toString() decodes correctly", async () => {
+		const sm = await makeJsSession("buf-b64-decode");
+		const out = await jsExec(
+			sm,
+			"buf-b64-decode",
+			`console.log(Buffer.from("aGVsbG8=", "base64").toString())`,
+		);
+		expect(out).toBe("hello");
+	});
+
+	it("base64 round-trip encode → decode preserves content", async () => {
+		const sm = await makeJsSession("buf-b64-rt");
+		const out = await jsExec(
+			sm,
+			"buf-b64-rt",
+			`var e = Buffer.from("hello world").toString("base64"); ` +
+				`var d = Buffer.from(e, "base64").toString(); ` +
+				`console.log(e + "|" + d)`,
+		);
+		expect(out).toBe("aGVsbG8gd29ybGQ=|hello world");
+	});
+
+	// ── base64url ───────────────────────────────────────────────────────────
+
+	it("Buffer.from(str).toString('base64url') produces url-safe no-padding encoding", async () => {
+		const sm = await makeJsSession("buf-b64url-enc");
+		// 0xfb=11111011, 0xff=11111111 → base64: '//' → base64url: '--' (idx 62) and '_' (idx 63)
+		const out = await jsExec(
+			sm,
+			"buf-b64url-enc",
+			`console.log(Buffer.from([0xfb, 0xff]).toString("base64url"))`,
+		);
+		// Verify no '+', '/', or '=' characters (url-safe, no padding)
+		expect(out).not.toMatch(/[+/=]/);
+		// Verify it decodes back correctly
+		const rt = await jsExec(
+			sm,
+			"buf-b64url-enc",
+			`var e = Buffer.from([0xfb, 0xff]).toString("base64url"); ` +
+				`var d = Buffer.from(e, "base64url"); ` +
+				`console.log(d.readUInt8(0) + "," + d.readUInt8(1))`,
+		);
+		expect(rt).toBe("251,255");
+	});
+
+	it("Buffer.from(b64url, 'base64url') decodes url-safe encoding", async () => {
+		const sm = await makeJsSession("buf-b64url-dec");
+		const out = await jsExec(
+			sm,
+			"buf-b64url-dec",
+			`var e = Buffer.from("hello").toString("base64url"); ` +
+				`var d = Buffer.from(e, "base64url").toString(); ` +
+				`console.log(e + "|" + d)`,
+		);
+		expect(out).toBe("aGVsbG8|hello");
+	});
+
+	// ── hex encode ──────────────────────────────────────────────────────────
+
+	it("Buffer.from(str).toString('hex') encodes to hex", async () => {
+		const sm = await makeJsSession("buf-hex-encode");
+		const out = await jsExec(sm, "buf-hex-encode", `console.log(Buffer.from("abc").toString("hex"))`);
+		expect(out).toBe("616263");
+	});
+
+	it("Buffer.from([0x00,0xff]).toString('hex') encodes boundary bytes", async () => {
+		const sm = await makeJsSession("buf-hex-bytes");
+		const out = await jsExec(
+			sm,
+			"buf-hex-bytes",
+			`console.log(Buffer.from([0x00,0xff]).toString("hex"))`,
+		);
+		expect(out).toBe("00ff");
+	});
+
+	// ── hex decode ──────────────────────────────────────────────────────────
+
+	it("Buffer.from('616263', 'hex').toString() decodes from hex", async () => {
+		const sm = await makeJsSession("buf-hex-decode");
+		const out = await jsExec(
+			sm,
+			"buf-hex-decode",
+			`console.log(Buffer.from("616263", "hex").toString())`,
+		);
+		expect(out).toBe("abc");
+	});
+
+	it("hex round-trip encode → decode preserves content", async () => {
+		const sm = await makeJsSession("buf-hex-rt");
+		const out = await jsExec(
+			sm,
+			"buf-hex-rt",
+			`var e = Buffer.from("hello").toString("hex"); ` +
+				`var d = Buffer.from(e, "hex").toString(); ` +
+				`console.log(e + "|" + d)`,
+		);
+		expect(out).toBe("68656c6c6f|hello");
+	});
+
+	// ── latin1 / binary ─────────────────────────────────────────────────────
+
+	it("Buffer.from([0x41,0xc3]).toString('latin1') gives latin1 string with correct char codes", async () => {
+		const sm = await makeJsSession("buf-latin1-encode");
+		const out = await jsExec(
+			sm,
+			"buf-latin1-encode",
+			// latin1: each byte maps to the char with that code point (0x00–0xFF)
+			`var s = Buffer.from([0x41, 0xc3]).toString("latin1"); ` +
+				`console.log(s.length + "," + s.charCodeAt(0) + "," + s.charCodeAt(1))`,
+		);
+		expect(out).toBe("2,65,195");
+	});
+
+	it("Buffer.from(str, 'latin1') decodes latin1 string to bytes", async () => {
+		const sm = await makeJsSession("buf-latin1-decode");
+		const out = await jsExec(
+			sm,
+			"buf-latin1-decode",
+			`var b = Buffer.from(String.fromCharCode(65, 195), "latin1"); ` +
+				`console.log(b.readUInt8(0) + "," + b.readUInt8(1))`,
+		);
+		expect(out).toBe("65,195");
+	});
+
+	// ── utf8 (default) still works ───────────────────────────────────────────
+
+	it("Buffer.from(str).toString('utf8') still works correctly", async () => {
+		const sm = await makeJsSession("buf-utf8");
+		const out = await jsExec(sm, "buf-utf8", `console.log(Buffer.from("hello").toString("utf8"))`);
+		expect(out).toBe("hello");
+	});
+
+	it("Buffer.from(str).toString() (no encoding) still works correctly", async () => {
+		const sm = await makeJsSession("buf-default");
+		const out = await jsExec(sm, "buf-default", `console.log(Buffer.from("hello").toString())`);
+		expect(out).toBe("hello");
+	});
+
+	// ── the original bug: round-trip was masking both directions being no-ops ──
+
+	it("base64 encode and decode are NOT both no-ops (the original bug)", async () => {
+		const sm = await makeJsSession("buf-noop-regression");
+		const out = await jsExec(
+			sm,
+			"buf-noop-regression",
+			// If encode was a no-op, e === "hello" (not "aGVsbG8=")
+			`var e = Buffer.from("hello").toString("base64"); ` + `console.log(e !== "hello" ? "ok" : "noop")`,
+		);
+		expect(out).toBe("ok");
+	});
+});


### PR DESCRIPTION
## Summary

- **Root cause:** The `just-bash` QuickJS Buffer shim ignores the `encoding` argument on both `Buffer.from(str, enc)` and `buf.toString(enc)`. Since both encode and decode were identity no-ops, `decode(encode(x)) === x` passed — masking the bug until output was consumed by any real base64-aware system.
- **Fix:** Inject a `JavaScriptConfig.bootstrap` snippet at session creation time. The snippet replaces those two shim methods with correct pure-JS implementations before any user code runs. The patch is scoped to sessions created with `javascript: true`.
- **Encodings now correct:** `base64`, `base64url`, `hex`, `latin1`/`binary`. UTF-8 and its aliases continue to use the original shim (no behaviour change).
- **15 new tests** covering encode, decode, and round-trip for each fixed encoding, plus a regression guard that confirms the no-op is gone.

Fixes #74

## Test plan

- [x] `pnpm test:unit` — 776 tests pass (15 new + 761 existing)
- [x] `pnpm typecheck` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)