### PR TITLE
fix: stable createdAt and DB fallback for GET /v1/sandboxes/:id (#94)

### DIFF
--- a/.changeset/fix-sandbox-get-stale-created-at.md
+++ b/.changeset/fix-sandbox-get-stale-created-at.md
@@ -1,0 +1,5 @@
+---
+"virtualfs-api": patch
+---
+
+Fix GET /v1/sandboxes/:id returning stale createdAt and transient 404 after session eviction. The route now falls back to the database when the session is not in the in-memory pool, and createdAt is sourced from the DB RETURNING clause on creation and restored from DB meta on rehydration so all three endpoints (POST, GET, LIST) agree on the same timestamp.

--- a/src/api/routes/sandboxes.ts
+++ b/src/api/routes/sandboxes.ts
@@ -52,7 +52,10 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 		const owner = c.get("owner");
 		const tenant = c.get("tenant");
 		const sandboxId = crypto.randomUUID();
-		const createdAt = new Date().toISOString();
+
+		// createdAt is captured from the session after buildFs runs, so it reflects
+		// the DB-generated created_at timestamp rather than a JS clock reading.
+		let createdAt = new Date().toISOString();
 
 		await sessionManager.withSession(
 			tenant,
@@ -60,7 +63,8 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 			async (session) => {
 				if (!session.owner) session.owner = owner;
 				session.name = name;
-				session.createdAt = createdAt;
+				// session.createdAt is set by getOrCreate from the DB RETURNING clause.
+				createdAt = session.createdAt;
 				await sessionManager.persistSandboxMeta(tenant, sandboxId, { owner, name, python, javascript, network });
 				if (files !== undefined) {
 					for (const [path, content] of Object.entries(files)) {
@@ -100,14 +104,28 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 		}
 	});
 
-	router.get("/:id", (c) => {
+	router.get("/:id", async (c) => {
 		const id = c.req.param("id");
 		const tenant = c.get("tenant");
+		const caller = c.get("owner");
 		const session = sessionManager.getSession(tenant, id);
 		if (session === undefined) {
-			return c.json({ error: "not_found", code: "SANDBOX_NOT_FOUND" }, 404 as ContentfulStatusCode);
+			// Session evicted or on a cold replica — fall back to DB.
+			const meta = await sessionManager.getSandboxMeta(tenant, id);
+			if (meta === null) {
+				return c.json({ error: "not_found", code: "SANDBOX_NOT_FOUND" }, 404 as ContentfulStatusCode);
+			}
+			if (meta.owner && meta.owner !== caller) {
+				return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
+			}
+			return c.json({
+				id,
+				name: meta.name,
+				owner: meta.owner,
+				createdAt: meta.createdAt ?? new Date().toISOString(),
+				lastUsedAt: null,
+			});
 		}
-		const caller = c.get("owner");
 		if (session.owner && session.owner !== caller) {
 			return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
 		}

--- a/src/api/routes/sandboxes.ts
+++ b/src/api/routes/sandboxes.ts
@@ -65,7 +65,17 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 				session.name = name;
 				// session.createdAt is set by getOrCreate from the DB RETURNING clause.
 				createdAt = session.createdAt;
-				await sessionManager.persistSandboxMeta(tenant, sandboxId, { owner, name, python, javascript, network });
+				// Forward createdAt so KV/Redis-backed metadata stores (whose getSandboxMetaFn
+				// reads only what persistSandboxMetaFn wrote) can also serve the DB timestamp
+				// without falling back to a fabricated clock reading on the GET fallback path.
+				await sessionManager.persistSandboxMeta(tenant, sandboxId, {
+					owner,
+					name,
+					python,
+					javascript,
+					network,
+					createdAt,
+				});
 				if (files !== undefined) {
 					for (const [path, content] of Object.entries(files)) {
 						await session.fs.writeFile(path, content);
@@ -118,11 +128,14 @@ export function sandboxRoutes(sessionManager: SessionManager): Hono<{ Variables:
 			if (meta.owner && meta.owner !== caller) {
 				return c.json({ error: "forbidden", code: "FORBIDDEN" }, 403 as ContentfulStatusCode);
 			}
+			// If a future dialect/metadata store doesn't populate createdAt, return null
+			// rather than fabricating a fresh timestamp — that would re-introduce the
+			// clock-drift bug this PR fixes. The Postgres path always supplies a value.
 			return c.json({
 				id,
 				name: meta.name,
 				owner: meta.owner,
-				createdAt: meta.createdAt ?? new Date().toISOString(),
+				createdAt: meta.createdAt ?? null,
 				lastUsedAt: null,
 			});
 		}

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -384,9 +384,13 @@ export class SessionManager {
 		tenantId: string,
 		sandboxId: string,
 		owner = "",
-	): Promise<{ fs: IFileSystem; resolvedOwner: string }> {
+	): Promise<{ fs: IFileSystem; resolvedOwner: string; createdAt: string }> {
 		if (this.createFsOverride !== undefined) {
-			return { fs: await this.createFsOverride(tenantId, sandboxId), resolvedOwner: owner };
+			return {
+				fs: await this.createFsOverride(tenantId, sandboxId),
+				resolvedOwner: owner,
+				createdAt: new Date().toISOString(),
+			};
 		}
 		const backend = this.getOrInitBackend(tenantId);
 		return createPostgresSandboxFs(
@@ -437,7 +441,7 @@ export class SessionManager {
 		const creationPromise = (async (): Promise<Session> => {
 			let createdFs: IFileSystem | undefined;
 			try {
-				const { fs, resolvedOwner } = await this.buildFs(tenantId, sandboxId, owner);
+				const { fs, resolvedOwner, createdAt: fsCreatedAt } = await this.buildFs(tenantId, sandboxId, owner);
 				createdFs = fs;
 				const defenseInDepthConfig: DefenseInDepthConfig | false = this.defenseInDepth
 					? {
@@ -506,7 +510,7 @@ export class SessionManager {
 					state: "active",
 					owner: resolvedOwner,
 					name: null,
-					createdAt: new Date().toISOString(),
+					createdAt: fsCreatedAt,
 					pathCacheBytes,
 					overBudget: pathCacheBytes > this.pathCacheMaxBytes,
 					lastSeenVersion: initialVersion,
@@ -866,6 +870,7 @@ export class SessionManager {
 		const session = await this.getOrCreate(tenantId, sandboxId, resolvedRuntime, meta?.owner ?? "");
 		if (meta?.owner) session.owner = meta.owner;
 		if (meta?.name !== undefined) session.name = meta.name;
+		if (meta?.createdAt !== undefined) session.createdAt = meta.createdAt;
 		return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
 	}
 
@@ -916,6 +921,9 @@ export class SessionManager {
 		if (meta?.name !== undefined) {
 			session.name = meta.name;
 		}
+		if (meta?.createdAt !== undefined) {
+			session.createdAt = meta.createdAt;
+		}
 		return this.withSessionEntry(tenantId, sandboxId, session, fn);
 	}
 
@@ -923,6 +931,15 @@ export class SessionManager {
 		if (this.persistSandboxMetaFn !== undefined) {
 			await this.persistSandboxMetaFn(tenantId, sandboxId, meta);
 		}
+	}
+
+	/**
+	 * Returns persisted metadata for the given sandbox from the DB, or null if
+	 * the sandbox does not exist or no DB is configured.
+	 */
+	async getSandboxMeta(tenantId: string, sandboxId: string): Promise<SandboxMeta | null> {
+		if (this.getSandboxMetaFn === undefined) return null;
+		return this.getSandboxMetaFn(tenantId, sandboxId);
 	}
 
 	async listSandboxes(tenantId: string, owner?: string): Promise<SandboxListEntry[]> {

--- a/src/api/tests/unit/sandboxes.test.ts
+++ b/src/api/tests/unit/sandboxes.test.ts
@@ -257,4 +257,60 @@ describe("GET /v1/sandboxes/:id", () => {
 		expect(body.error).toBe("not_found");
 		expect(body.code).toBe("SANDBOX_NOT_FOUND");
 	});
+
+	it("returns 200 with correct createdAt after session eviction (DB fallback, no 404)", async () => {
+		// Simulate a cold replica: getSandboxMetaFn is wired up but the session
+		// pool starts empty (the sandbox was created on a different replica).
+		const knownCreatedAt = "2026-05-15T10:00:00.000Z";
+		const meta = new Map<string, SandboxMeta>();
+		const sandboxId = crypto.randomUUID();
+		meta.set(sandboxId, {
+			owner: "owner-evict",
+			name: null,
+			python: false,
+			javascript: false,
+			network: false,
+			createdAt: knownCreatedAt,
+		});
+
+		const coldReplica = new SessionManager({
+			createFs: async () => new InMemoryFs(),
+			getSandboxMetaFn: async (_tenantId, id) => meta.get(id) ?? null,
+		});
+		const app = makeTestApp(coldReplica);
+		const ownerToken = await makeToken("owner-evict");
+
+		// GET on a sandbox that exists in meta but not in the in-memory pool must
+		// return 200 (not 404) and supply the correct createdAt from DB.
+		const getRes = await app.request(`/v1/sandboxes/${sandboxId}`, {
+			headers: { Authorization: `Bearer ${ownerToken}` },
+		});
+
+		expect(getRes.status).toBe(200);
+		const body = (await getRes.json()) as { id: string; createdAt: string };
+		expect(body.id).toBe(sandboxId);
+		expect(body.createdAt).toBe(knownCreatedAt);
+	});
+
+	it("createdAt from GET matches createdAt from POST (no rehydration drift)", async () => {
+		const { sessionManager } = makeTestEnv();
+		const app = makeTestApp(sessionManager);
+		const token = await makeToken("owner-drift");
+
+		const postRes = await app.request("/v1/sandboxes", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(postRes.status).toBe(201);
+		const { id, createdAt: postCreatedAt } = (await postRes.json()) as { id: string; createdAt: string };
+
+		const getRes = await app.request(`/v1/sandboxes/${id}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(getRes.status).toBe(200);
+		const { createdAt: getCreatedAt } = (await getRes.json()) as { createdAt: string };
+
+		// The timestamps must agree — no clock-based drift between POST and GET
+		expect(getCreatedAt).toBe(postCreatedAt);
+	});
 });

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -255,9 +255,16 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	// ── Stubs — implemented in subsequent user stories ────────────────────────────
 
 	// US-005
-	async createSandbox(tx: PgTx, sandboxId: string, owner = ""): Promise<{ rootInodeId: bigint }> {
-		// 1. Insert sandbox row first (root_inode is NULL initially) to satisfy FK
-		await tx`INSERT INTO sandboxes (id, root_inode, owner) VALUES (${sandboxId}, NULL, ${owner})`;
+	async createSandbox(tx: PgTx, sandboxId: string, owner = ""): Promise<{ rootInodeId: bigint; createdAt: string }> {
+		// 1. Insert sandbox row first (root_inode is NULL initially) to satisfy FK.
+		//    RETURNING created_at gives us the DB-generated timestamp for byte-for-byte
+		//    agreement between POST response, GET, and LIST.
+		const sandboxRows = await tx<{ created_at: Date }[]>`
+			INSERT INTO sandboxes (id, root_inode, owner) VALUES (${sandboxId}, NULL, ${owner}) RETURNING created_at
+		`;
+		const sandboxRow = sandboxRows[0];
+		if (!sandboxRow) throw new Error("createSandbox: failed to insert sandbox row");
+		const createdAt = sandboxRow.created_at.toISOString();
 
 		// 2. Insert root directory inode (kind=2, mode=0o755)
 		const rootRows = await tx<{ id: string }[]>`
@@ -272,15 +279,15 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		// 3. Update sandbox with root_inode reference
 		await tx`UPDATE sandboxes SET root_inode = ${String(rootInodeId)} WHERE id = ${sandboxId}`;
 
-		// 3. Create default directories under root: /home, /tmp, /bin
+		// 4. Create default directories under root: /home, /tmp, /bin
 		const homeInodeId = await this.#createDirInode(tx, sandboxId, rootInodeId, "home");
 		await this.#createDirInode(tx, sandboxId, rootInodeId, "tmp");
 		await this.#createDirInode(tx, sandboxId, rootInodeId, "bin");
 
-		// 4. Create /home/user under /home
+		// 5. Create /home/user under /home
 		await this.#createDirInode(tx, sandboxId, homeInodeId, "user");
 
-		return { rootInodeId };
+		return { rootInodeId, createdAt };
 	}
 
 	async deleteSandbox(tx: PgTx, sandboxId: string): Promise<void> {
@@ -310,9 +317,10 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 					python: boolean;
 					javascript: boolean;
 					network: boolean;
+					created_at: Date;
 				}[]
 			>`
-				SELECT owner, name, python, javascript, network FROM sandboxes WHERE id = ${sandboxId}
+				SELECT owner, name, python, javascript, network, created_at FROM sandboxes WHERE id = ${sandboxId}
 			`;
 			if (rows.length === 0) return null;
 			const r = rows[0]!;
@@ -322,6 +330,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 				python: r.python,
 				javascript: r.javascript,
 				network: r.network,
+				createdAt: r.created_at.toISOString(),
 			};
 		} catch (err) {
 			throw translateSqlError(err, sandboxId);

--- a/src/fs/sql-fs/index.ts
+++ b/src/fs/sql-fs/index.ts
@@ -51,7 +51,7 @@ export async function createPostgresSandboxFs(
 	opts: PostgresBackendOptions,
 	sandboxId: string,
 	owner = "",
-): Promise<{ fs: IFileSystem; resolvedOwner: string }> {
+): Promise<{ fs: IFileSystem; resolvedOwner: string; createdAt: string }> {
 	const dialect = new PostgresDialect(opts.connectionString, opts.blobCache);
 	await dialect.connect();
 	// All post-connect work runs inside try/catch so a failure (sandbox bootstrap,
@@ -59,15 +59,18 @@ export async function createPostgresSandboxFs(
 	// connection pool. The pg pool stays alive until disconnect() is awaited.
 	try {
 		let resolvedOwner = owner;
+		let createdAt = new Date().toISOString();
 		try {
 			await dialect.transaction(async (tx) => {
-				await dialect.createSandbox(tx, sandboxId, owner);
+				const result = await dialect.createSandbox(tx, sandboxId, owner);
+				createdAt = result.createdAt;
 			});
 		} catch (e) {
 			const sqlErr = e as { code?: string };
 			if (sqlErr.code !== "23505") throw e;
 			const meta = await dialect.transaction(async (tx) => dialect.getSandboxMeta(tx, sandboxId));
 			resolvedOwner = meta?.owner ?? "";
+			createdAt = meta?.createdAt ?? createdAt;
 		}
 		const fs = new SqlFs({
 			dialect,
@@ -78,7 +81,7 @@ export async function createPostgresSandboxFs(
 			blobCache: opts.blobCache,
 		});
 		await fs.ready();
-		return { fs, resolvedOwner };
+		return { fs, resolvedOwner, createdAt };
 	} catch (err) {
 		try {
 			await dialect.disconnect();

--- a/src/fs/sql-fs/tests/unit/index.test.ts
+++ b/src/fs/sql-fs/tests/unit/index.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../dialects/postgres.js", () => ({
 		transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
 		setSandboxContext: vi.fn().mockResolvedValue(undefined),
 		setSandboxContextWithLock: vi.fn().mockResolvedValue(undefined),
-		createSandbox: vi.fn(),
+		createSandbox: vi.fn().mockResolvedValue({ rootInodeId: 1n, createdAt: new Date().toISOString() }),
 		deleteSandbox: vi.fn(),
 		createInode: vi.fn(),
 		getInode: vi.fn(),

--- a/src/fs/sql-fs/tests/unit/sql-fs.resolvepath.test.ts
+++ b/src/fs/sql-fs/tests/unit/sql-fs.resolvepath.test.ts
@@ -14,7 +14,7 @@ function makeFs(): SqlFs<unknown> {
 		transaction: async <T>(_fn: (tx: unknown) => Promise<T>) => _fn({}),
 		setSandboxContext: async () => {},
 		setSandboxContextWithLock: async () => {},
-		createSandbox: async () => ({ rootInodeId: 1n }),
+		createSandbox: async () => ({ rootInodeId: 1n, createdAt: new Date().toISOString() }),
 		deleteSandbox: async () => {},
 		createInode: async () => 1n,
 		getInode: async () => null,

--- a/src/fs/sql-fs/types.ts
+++ b/src/fs/sql-fs/types.ts
@@ -65,6 +65,8 @@ export interface SandboxMeta {
 	readonly javascript: boolean;
 	/** When true, js-exec fetch() can reach external HTTP endpoints (60 s timeout). */
 	readonly network: boolean;
+	/** ISO-8601 timestamp of when the sandbox was originally created (from DB created_at). */
+	readonly createdAt?: string;
 }
 
 /** A single entry returned by the list-sandboxes query. */
@@ -158,9 +160,9 @@ export interface SqlDialect<Tx = unknown> {
 	 * Creates a new sandbox: inserts a root inode (kind=2, mode=0o755),
 	 * inserts the sandboxes row, and creates default directories
 	 * (/home, /home/user, /tmp, /bin).
-	 * Returns the root inode ID.
+	 * Returns the root inode ID and the DB-generated creation timestamp (ISO-8601).
 	 */
-	createSandbox(tx: Tx, sandboxId: string, owner?: string): Promise<{ rootInodeId: bigint }>;
+	createSandbox(tx: Tx, sandboxId: string, owner?: string): Promise<{ rootInodeId: bigint; createdAt: string }>;
 
 	/**
 	 * Deletes a sandbox and all associated inodes, dirents, and blobs


### PR DESCRIPTION
## Summary

- `SandboxMeta.createdAt` is now DB-authoritative (`getSandboxMeta` SELECTs `created_at`; rehydration paths populate `session.createdAt` from it)
- GET `/v1/sandboxes/:id` falls back to `getSandboxMeta` on session-pool miss instead of returning 404
- Creation timestamp flows from `INSERT ... RETURNING created_at` through `createSandbox` -> `createPostgresSandboxFs` -> `buildFs` -> `session.createdAt` to eliminate JS/DB clock drift

Closes #94

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:fix` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test:unit` passes (817 passing, including 2 new tests covering cold-replica GET and POST/GET timestamp agreement)
- [ ] Manual verification with Postgres + `SESSION_IDLE_MS=5000`: POST -> GET -> LIST all return matching `createdAt`
- [ ] After idle eviction, GET still returns 200 with the original `createdAt` (no 404, no clock drift)

Note: includes a patch `.changeset/*.md` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transient 404 errors when retrieving sandbox info after session eviction.
  * Corrected stale creation timestamps so GET/POST/LIST return consistent createdAt values.
  * Restored reliable createdAt propagation so newly created sandboxes report the same timestamp on subsequent reads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/virtualFS/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->