### PR TITLE
feat: add paths param to fs_ingest for zero-token host file ingestion

### DIFF
--- a/.changeset/green-guests-cry.md
+++ b/.changeset/green-guests-cry.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": minor
+---
+
+Add `paths` param to `fs_ingest` MCP tool. Pass `{ relativePath: absoluteHostPath }` and the server reads bytes directly from the host filesystem — no base64 encoding, no file content generated as output tokens. Matches py-sdk `ingest_files()` performance. `files` (inline base64) is kept for small generated content but is now the exception path.

--- a/src/api/ingest-manifest.ts
+++ b/src/api/ingest-manifest.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared ingest manifest builder used by both the HTTP `/ingest-files` route
+ * and the MCP `fs_ingest` tool. It collapses two ingest modes into a single
+ * `BulkIngestFile[]` ready for `fs.bulkIngest`:
+ *
+ *   - `files`: { relPath: base64 }   — inline bytes
+ *   - `paths`: { relPath: hostPath } — server reads the host filesystem
+ *
+ * Trust model for `paths`: the API process reads whatever the OS allows
+ * the calling host to read. This is fine for the colocated agent ↔ server
+ * topology MCP is designed for, but it MUST NOT be exposed on a multi-tenant
+ * network surface without an additional access boundary. The HTTP route
+ * deliberately does not forward `paths` for that reason; only MCP does.
+ *
+ * The builder returns an array of error messages instead of a single string
+ * so each surface can shape its own response (HTTP `details: string[]`,
+ * MCP `error: string`).
+ */
+
+import { readFile } from "node:fs/promises";
+import type { BulkIngestFile } from "../fs/sql-fs/types.js";
+import { isValidBase64, isValidBasePath, isValidHostPath, isValidRelativePath } from "./ingest-validation.js";
+
+export interface BuildIngestPayloadArgs {
+	readonly basePath: string;
+	readonly files?: Record<string, string>;
+	readonly paths?: Record<string, string>;
+	/**
+	 * When true, an empty payload (no `files` and no `paths`) returns
+	 * `{ ok: true, bulkFiles: [] }` instead of an error. The HTTP route uses
+	 * this to preserve the historical contract where an empty `files` map
+	 * succeeds with `fileCount: 0`; MCP rejects empty payloads to prevent
+	 * silent no-op tool calls.
+	 */
+	readonly allowEmpty?: boolean;
+}
+
+export type BuildIngestPayloadResult =
+	| { readonly ok: true; readonly bulkFiles: BulkIngestFile[] }
+	| { readonly ok: false; readonly errors: string[] };
+
+export async function buildBulkIngestPayload(args: BuildIngestPayloadArgs): Promise<BuildIngestPayloadResult> {
+	const { basePath } = args;
+
+	if (!isValidBasePath(basePath)) {
+		return { ok: false, errors: ["basePath must be a safe absolute path"] };
+	}
+
+	const filesEntries = Object.entries(args.files ?? {});
+	const pathsEntries = Object.entries(args.paths ?? {});
+
+	if (filesEntries.length === 0 && pathsEntries.length === 0) {
+		if (args.allowEmpty) return { ok: true, bulkFiles: [] };
+		return { ok: false, errors: ["at least one of `files` or `paths` must be non-empty"] };
+	}
+
+	// Validate everything before doing any I/O so the caller sees one
+	// consolidated error rather than a mid-batch failure.
+	const invalidRel: string[] = [];
+	const invalidBase64: string[] = [];
+	const invalidHost: string[] = [];
+	const duplicateKeys: string[] = [];
+
+	const fileKeys = new Set<string>();
+	for (const [rel, b64] of filesEntries) {
+		if (!isValidRelativePath(rel)) {
+			invalidRel.push(rel);
+			continue;
+		}
+		if (!isValidBase64(b64)) {
+			invalidBase64.push(rel);
+			continue;
+		}
+		fileKeys.add(rel);
+	}
+	for (const [rel, hostPath] of pathsEntries) {
+		if (!isValidRelativePath(rel)) {
+			invalidRel.push(rel);
+			continue;
+		}
+		if (!isValidHostPath(hostPath)) {
+			invalidHost.push(rel);
+			continue;
+		}
+		if (fileKeys.has(rel)) duplicateKeys.push(rel);
+	}
+
+	const errors = formatValidationErrors({ invalidRel, invalidBase64, invalidHost, duplicateKeys });
+	if (errors.length > 0) return { ok: false, errors };
+
+	const bulkFiles: BulkIngestFile[] = [];
+
+	for (const [rel, b64] of filesEntries) {
+		bulkFiles.push({
+			path: `${basePath}/${rel}`,
+			content: new Uint8Array(Buffer.from(b64, "base64")),
+			mode: 0o644,
+		});
+	}
+
+	if (pathsEntries.length > 0) {
+		const readResults = await Promise.allSettled(
+			pathsEntries.map(async ([rel, hostPath]) => ({ rel, bytes: await readFile(hostPath) })),
+		);
+		const unreadable: string[] = [];
+		for (let i = 0; i < readResults.length; i++) {
+			const result = readResults[i];
+			if (result === undefined) continue;
+			if (result.status === "rejected") {
+				const entry = pathsEntries[i];
+				if (entry !== undefined) unreadable.push(entry[0]);
+				continue;
+			}
+			bulkFiles.push({
+				path: `${basePath}/${result.value.rel}`,
+				content: new Uint8Array(result.value.bytes),
+				mode: 0o644,
+			});
+		}
+		if (unreadable.length > 0) {
+			return { ok: false, errors: [`unreadable host paths: ${unreadable.join(", ")}`] };
+		}
+	}
+
+	return { ok: true, bulkFiles };
+}
+
+interface ValidationBuckets {
+	readonly invalidRel: string[];
+	readonly invalidBase64: string[];
+	readonly invalidHost: string[];
+	readonly duplicateKeys: string[];
+}
+
+function formatValidationErrors(b: ValidationBuckets): string[] {
+	const out: string[] = [];
+	if (b.invalidRel.length > 0) out.push(`invalid paths: ${b.invalidRel.join(", ")}`);
+	if (b.invalidBase64.length > 0) out.push(`invalid base64: ${b.invalidBase64.join(", ")}`);
+	if (b.invalidHost.length > 0) out.push(`invalid host paths: ${b.invalidHost.join(", ")}`);
+	if (b.duplicateKeys.length > 0) out.push(`duplicate keys in files and paths: ${b.duplicateKeys.join(", ")}`);
+	return out;
+}

--- a/src/api/ingest-validation.ts
+++ b/src/api/ingest-validation.ts
@@ -1,10 +1,15 @@
 /**
- * Shared input validators for the manifest-based ingest paths
+ * Shared input validators for the ingest entry points
  * (HTTP `POST /v1/sandboxes/:id/ingest-files` and MCP `fs_ingest`).
  *
- * Both surfaces accept the same `{ basePath, files: { relPath: base64 } }`
- * shape and need the same checks. Keeping them here avoids drift between
- * the two entry points.
+ * Ingest accepts two payload modes that can be combined in one call:
+ *   - `files`: { relPath: base64 }   — inline bytes (both surfaces)
+ *   - `paths`: { relPath: hostPath } — server reads the host filesystem (MCP only)
+ *
+ * Both modes share basePath/relative-path rules; only the `paths` mode
+ * needs `isValidHostPath`. Keeping every check here avoids drift between
+ * the surfaces. The actual orchestration (read host files, dedup keys,
+ * shape errors) lives in `ingest-manifest.ts`.
  */
 
 /**
@@ -65,6 +70,14 @@ export function isValidBasePath(p: string): boolean {
  * Validates an absolute host-filesystem path supplied to `fs_ingest`'s `paths`
  * param. The server reads the file directly, so we only require the path to be
  * absolute and free of null bytes — the OS enforces access control.
+ *
+ * NOTE on `..`: unlike `isValidBasePath`, we do NOT reject `..` segments here.
+ * The server resolves these at read time and the OS gates whether the
+ * process can read the resulting target; rejecting them in the validator
+ * would block legitimate uses (e.g. paths produced by tools that don't
+ * canonicalize). The asymmetry is intentional — basePath is a path inside
+ * the sandbox where `..` would escape isolation; hostPath is outside the
+ * sandbox entirely.
  */
 export function isValidHostPath(p: string): boolean {
 	if (p.length === 0) return false;

--- a/src/api/ingest-validation.ts
+++ b/src/api/ingest-validation.ts
@@ -60,3 +60,15 @@ export function isValidBasePath(p: string): boolean {
 	if (p.includes("..")) return false;
 	return true;
 }
+
+/**
+ * Validates an absolute host-filesystem path supplied to `fs_ingest`'s `paths`
+ * param. The server reads the file directly, so we only require the path to be
+ * absolute and free of null bytes — the OS enforces access control.
+ */
+export function isValidHostPath(p: string): boolean {
+	if (p.length === 0) return false;
+	if (p.includes("\0")) return false;
+	// Accept Unix absolute paths (/…) and Windows absolute paths (C:\…, \\…)
+	return p.startsWith("/") || /^[a-zA-Z]:[/\\]/.test(p) || p.startsWith("\\\\");
+}

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -8,11 +8,12 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
 import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
-import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
+import { isValidBase64, isValidBasePath, isValidHostPath, isValidRelativePath } from "../ingest-validation.js";
 import { executeBatch } from "../lib/batch-exec.js";
 import { withOwnedSessionOrRehydrate, withOwnedSessionRead } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
@@ -360,22 +361,34 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 	server.tool(
 		"fs_ingest",
 		[
-			"Upload one or more files into a sandbox in a single bulk database insert.",
-			"Use this before `bash_exec` to seed project files. This is the only ingest path",
-			"(the previous tar.gz route was removed). Internally the server commits the entire",
-			"batch with one multi-row INSERT — uploading 100+ files typically completes in",
-			"under a second.",
+			"Seed files into a sandbox in a single bulk database insert.",
 			"",
-			"INPUT PREPARATION (important):",
-			"• Each value in `files` MUST be the file's bytes encoded as base64 — not raw text.",
-			'  For text files: `Buffer.from(textContent, "utf-8").toString("base64")`.',
-			"  For binary files: read the bytes and base64-encode them.",
-			"• Each key in `files` MUST be a relative path — no leading `/`, no `..` segments,",
-			"  no null bytes. The server joins it onto `basePath` to form the absolute path.",
-			"• `basePath` is the absolute root inside the sandbox (default `/home/user`).",
-			"  Missing parent directories under `basePath` are created automatically.",
+			"DEFAULT: use `paths` for any file that already exists on disk.",
+			"EXCEPTION: use `files` only for small, dynamically generated content",
+			"(e.g. a config snippet you just constructed) that has no host path.",
 			"",
-			"Returns `{ ok: true, count: N }` on success. On failure returns `{ ok: false, error }`.",
+			"`paths` — HOST FILESYSTEM PATHS (default, fast, zero token cost):",
+			"   { relativePath: absoluteHostPath }",
+			"   The server reads the bytes directly from the host filesystem.",
+			"   You emit only path strings — no file content ever appears in your output.",
+			"   Use this for every file that exists on disk. There is no size limit.",
+			'   Example: { "src/app.ts": "/Users/me/project/src/app.ts" }',
+			"",
+			"`files` — INLINE BASE64 (small generated content only):",
+			"   { relativePath: base64EncodedBytes }",
+			"   Every byte of file content becomes output tokens — extremely slow for",
+			"   anything larger than a few KB. Only use this when the content does not",
+			"   exist on disk and you are generating it on the fly.",
+			'   For text: Buffer.from(text, "utf-8").toString("base64").',
+			"",
+			"Both params can be combined in one call. At least one must be non-empty.",
+			"",
+			"Keys MUST be relative paths (no leading `/`, no `..`, no null bytes).",
+			"The server joins each key onto `basePath` to form the sandbox path.",
+			"Missing parent directories are created automatically.",
+			"",
+			"`basePath`: absolute root inside the sandbox (default `/home/user`).",
+			"Returns `{ ok: true, count: N }` on success, `{ ok: false, error }` on failure.",
 		].join("\n"),
 		{
 			id: z.string().describe("Sandbox id returned by sandbox_create."),
@@ -383,19 +396,22 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				.string()
 				.optional()
 				.describe("Absolute root path inside the sandbox to anchor relative file keys. Default: /home/user"),
+			paths: z
+				.record(z.string(), z.string())
+				.optional()
+				.describe(
+					"DEFAULT. Map of relativePath → absolute host path. Server reads bytes directly — use for all files that exist on disk.",
+				),
 			files: z
 				.record(z.string(), z.string())
+				.optional()
 				.describe(
-					"Map of relativePath → base64-encoded file bytes. Keys are relative paths under basePath; values must be base64 (use Buffer.from(content).toString('base64')).",
+					"EXCEPTION: small generated content only. Map of relativePath → base64 bytes. Avoid for anything >a few KB — every byte costs output tokens.",
 				),
 		},
 		async (args) => {
 			const basePath = args.basePath ?? "/home/user";
 
-			// Reuse the same basePath guard the HTTP /ingest-files route uses
-			// so the two ingest surfaces share one contract. Inputs like
-			// "tmp", "./proj", "/home/user/../tmp" must not silently normalize
-			// to a different destination than the caller supplied.
 			if (!isValidBasePath(basePath)) {
 				return {
 					content: [
@@ -407,13 +423,25 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				};
 			}
 
-			// Validate paths and base64 in one pass before any DB work.
-			// `Buffer.from(_, "base64")` silently decodes garbage to corrupt bytes,
-			// so we reject malformed values up front rather than persist them.
+			const filesEntries = Object.entries(args.files ?? {});
+			const pathsEntries = Object.entries(args.paths ?? {});
+			if (filesEntries.length === 0 && pathsEntries.length === 0) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({ ok: false, error: "at least one of `files` or `paths` must be non-empty" }),
+						},
+					],
+				};
+			}
+
 			const bulkFiles: BulkIngestFile[] = [];
 			const invalidPaths: string[] = [];
 			const invalidBase64: string[] = [];
-			for (const [rel, b64] of Object.entries(args.files)) {
+
+			// ── inline base64 ────────────────────────────────────────────────
+			for (const [rel, b64] of filesEntries) {
 				if (!isValidRelativePath(rel)) {
 					invalidPaths.push(rel);
 					continue;
@@ -428,12 +456,66 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 					mode: 0o644,
 				});
 			}
+
 			if (invalidPaths.length > 0 || invalidBase64.length > 0) {
 				const parts: string[] = [];
 				if (invalidPaths.length > 0) parts.push(`invalid paths: ${invalidPaths.join(", ")}`);
 				if (invalidBase64.length > 0) parts.push(`invalid base64: ${invalidBase64.join(", ")}`);
 				return {
 					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: parts.join("; ") }) }],
+				};
+			}
+
+			// ── host-filesystem paths ────────────────────────────────────────
+			// Validate all keys/values before doing any I/O so we surface a
+			// single consolidated error rather than failing mid-batch.
+			const invalidRelPaths: string[] = [];
+			const invalidHostPaths: string[] = [];
+			for (const [rel, hostPath] of pathsEntries) {
+				if (!isValidRelativePath(rel)) invalidRelPaths.push(rel);
+				else if (!isValidHostPath(hostPath)) invalidHostPaths.push(rel);
+			}
+			if (invalidRelPaths.length > 0 || invalidHostPaths.length > 0) {
+				const parts: string[] = [];
+				if (invalidRelPaths.length > 0) parts.push(`invalid paths: ${invalidRelPaths.join(", ")}`);
+				if (invalidHostPaths.length > 0) parts.push(`invalid host paths: ${invalidHostPaths.join(", ")}`);
+				return {
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: parts.join("; ") }) }],
+				};
+			}
+
+			// Read all host files in parallel — same pattern as py-sdk ingest_files().
+			const readResults = await Promise.allSettled(
+				pathsEntries.map(async ([rel, hostPath]) => {
+					const bytes = await readFile(hostPath);
+					return { rel, bytes };
+				}),
+			);
+
+			const unreadable: string[] = [];
+			for (const result of readResults) {
+				if (result.status === "rejected") {
+					// The rejected value is an fs error; extract the rel path from
+					// the corresponding pathsEntries position via index.
+					const idx = readResults.indexOf(result);
+					const entry = pathsEntries[idx];
+					if (entry !== undefined) unreadable.push(entry[0]);
+				} else {
+					bulkFiles.push({
+						path: `${basePath}/${result.value.rel}`,
+						content: new Uint8Array(result.value.bytes),
+						mode: 0o644,
+					});
+				}
+			}
+			if (unreadable.length > 0) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({ ok: false, error: `unreadable host paths: ${unreadable.join(", ")}` }),
+						},
+					],
 				};
 			}
 
@@ -461,10 +543,6 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 						content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "sandbox not found" }) }],
 					};
 				}
-				// `ENOTSUP` here means the FS backend has no `bulkIngest` — only reachable
-				// from a misconfigured replica. Don't echo the internal "bulkIngest not
-				// supported by this fs backend" message back to the MCP client; log and
-				// return a generic internal error, mirroring the HTTP route.
 				if (code === "ENOTSUP") {
 					console.error(
 						JSON.stringify({

--- a/src/api/mcp/tools.ts
+++ b/src/api/mcp/tools.ts
@@ -8,12 +8,10 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
-import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
-import { isValidBase64, isValidBasePath, isValidHostPath, isValidRelativePath } from "../ingest-validation.js";
+import { buildBulkIngestPayload } from "../ingest-manifest.js";
 import { executeBatch } from "../lib/batch-exec.js";
 import { withOwnedSessionOrRehydrate, withOwnedSessionRead } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
@@ -410,114 +408,17 @@ export function registerTools(server: McpServer, sessionManager: SessionManager,
 				),
 		},
 		async (args) => {
-			const basePath = args.basePath ?? "/home/user";
-
-			if (!isValidBasePath(basePath)) {
+			const built = await buildBulkIngestPayload({
+				basePath: args.basePath ?? "/home/user",
+				files: args.files,
+				paths: args.paths,
+			});
+			if (!built.ok) {
 				return {
-					content: [
-						{
-							type: "text" as const,
-							text: JSON.stringify({ ok: false, error: "basePath must be a safe absolute path" }),
-						},
-					],
+					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: built.errors.join("; ") }) }],
 				};
 			}
-
-			const filesEntries = Object.entries(args.files ?? {});
-			const pathsEntries = Object.entries(args.paths ?? {});
-			if (filesEntries.length === 0 && pathsEntries.length === 0) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: JSON.stringify({ ok: false, error: "at least one of `files` or `paths` must be non-empty" }),
-						},
-					],
-				};
-			}
-
-			const bulkFiles: BulkIngestFile[] = [];
-			const invalidPaths: string[] = [];
-			const invalidBase64: string[] = [];
-
-			// ── inline base64 ────────────────────────────────────────────────
-			for (const [rel, b64] of filesEntries) {
-				if (!isValidRelativePath(rel)) {
-					invalidPaths.push(rel);
-					continue;
-				}
-				if (!isValidBase64(b64)) {
-					invalidBase64.push(rel);
-					continue;
-				}
-				bulkFiles.push({
-					path: `${basePath}/${rel}`,
-					content: new Uint8Array(Buffer.from(b64, "base64")),
-					mode: 0o644,
-				});
-			}
-
-			if (invalidPaths.length > 0 || invalidBase64.length > 0) {
-				const parts: string[] = [];
-				if (invalidPaths.length > 0) parts.push(`invalid paths: ${invalidPaths.join(", ")}`);
-				if (invalidBase64.length > 0) parts.push(`invalid base64: ${invalidBase64.join(", ")}`);
-				return {
-					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: parts.join("; ") }) }],
-				};
-			}
-
-			// ── host-filesystem paths ────────────────────────────────────────
-			// Validate all keys/values before doing any I/O so we surface a
-			// single consolidated error rather than failing mid-batch.
-			const invalidRelPaths: string[] = [];
-			const invalidHostPaths: string[] = [];
-			for (const [rel, hostPath] of pathsEntries) {
-				if (!isValidRelativePath(rel)) invalidRelPaths.push(rel);
-				else if (!isValidHostPath(hostPath)) invalidHostPaths.push(rel);
-			}
-			if (invalidRelPaths.length > 0 || invalidHostPaths.length > 0) {
-				const parts: string[] = [];
-				if (invalidRelPaths.length > 0) parts.push(`invalid paths: ${invalidRelPaths.join(", ")}`);
-				if (invalidHostPaths.length > 0) parts.push(`invalid host paths: ${invalidHostPaths.join(", ")}`);
-				return {
-					content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: parts.join("; ") }) }],
-				};
-			}
-
-			// Read all host files in parallel — same pattern as py-sdk ingest_files().
-			const readResults = await Promise.allSettled(
-				pathsEntries.map(async ([rel, hostPath]) => {
-					const bytes = await readFile(hostPath);
-					return { rel, bytes };
-				}),
-			);
-
-			const unreadable: string[] = [];
-			for (const result of readResults) {
-				if (result.status === "rejected") {
-					// The rejected value is an fs error; extract the rel path from
-					// the corresponding pathsEntries position via index.
-					const idx = readResults.indexOf(result);
-					const entry = pathsEntries[idx];
-					if (entry !== undefined) unreadable.push(entry[0]);
-				} else {
-					bulkFiles.push({
-						path: `${basePath}/${result.value.rel}`,
-						content: new Uint8Array(result.value.bytes),
-						mode: 0o644,
-					});
-				}
-			}
-			if (unreadable.length > 0) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: JSON.stringify({ ok: false, error: `unreadable host paths: ${unreadable.join(", ")}` }),
-						},
-					],
-				};
-			}
+			const { bulkFiles } = built;
 
 			try {
 				await withOwnedSessionOrRehydrate(sessionManager, tenant, args.id, owner, async (session) => {

--- a/src/api/routes/ingest.ts
+++ b/src/api/routes/ingest.ts
@@ -7,9 +7,8 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import type { ICoherentFs } from "../../fs/sql-fs/sql-fs.js";
-import type { BulkIngestFile } from "../../fs/sql-fs/types.js";
 import type { AuthVariables } from "../auth.js";
-import { isValidBase64, isValidBasePath, isValidRelativePath } from "../ingest-validation.js";
+import { buildBulkIngestPayload } from "../ingest-manifest.js";
 import { forbiddenResponse, isForbiddenError, withOwnedSessionOrRehydrate } from "../ownership.js";
 import type { SessionManager } from "../session-manager.js";
 
@@ -43,38 +42,16 @@ export function ingestRoutes(sessionManager: SessionManager): Hono<{ Variables: 
 
 		const { basePath, files } = parsed.data;
 
-		if (!isValidBasePath(basePath)) {
+		// HTTP intentionally does NOT expose the `paths` (host-filesystem) ingest
+		// mode — that's a local-trust capability and lives only on the MCP surface.
+		const built = await buildBulkIngestPayload({ basePath, files, allowEmpty: true });
+		if (!built.ok) {
 			return c.json(
-				{ error: "validation_error", code: "INVALID_INPUT", details: ["basePath must be a safe absolute path"] },
+				{ error: "validation_error", code: "INVALID_INPUT", details: built.errors },
 				400 as ContentfulStatusCode,
 			);
 		}
-
-		const bulkFiles: BulkIngestFile[] = [];
-		const invalidPaths: string[] = [];
-		const invalidBase64: string[] = [];
-		for (const [rel, b64] of Object.entries(files)) {
-			if (!isValidRelativePath(rel)) {
-				invalidPaths.push(rel);
-				continue;
-			}
-			if (!isValidBase64(b64)) {
-				invalidBase64.push(rel);
-				continue;
-			}
-			bulkFiles.push({
-				path: `${basePath}/${rel}`,
-				content: Buffer.from(b64, "base64"),
-				mode: 0o644,
-			});
-		}
-		if (invalidPaths.length > 0 || invalidBase64.length > 0) {
-			const details: string[] = [];
-			if (invalidPaths.length > 0) details.push(`invalid paths: ${invalidPaths.join(", ")}`);
-			if (invalidBase64.length > 0) details.push(`invalid base64: ${invalidBase64.join(", ")}`);
-			return c.json({ error: "validation_error", code: "INVALID_INPUT", details }, 400 as ContentfulStatusCode);
-		}
-
+		const { bulkFiles } = built;
 		const fileCount = bulkFiles.length;
 
 		try {

--- a/src/api/tests/unit/ingest-validation.test.ts
+++ b/src/api/tests/unit/ingest-validation.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { isValidBase64, isValidBasePath, isValidRelativePath } from "../../ingest-validation.js";
+import { isValidBase64, isValidBasePath, isValidHostPath, isValidRelativePath } from "../../ingest-validation.js";
 
 describe("isValidRelativePath", () => {
 	it.each([
@@ -55,6 +55,29 @@ describe("isValidBase64", () => {
 		["YQ=", "wrong padding length for 1-byte payload"],
 	])("rejects malformed base64 %p — %s", (s) => {
 		expect(isValidBase64(s)).toBe(false);
+	});
+});
+
+describe("isValidHostPath", () => {
+	it.each([
+		["/home/user/project/src/app.ts", "Unix absolute path"],
+		["/tmp/upload.bin", "Unix tmp path"],
+		["/", "root"],
+		["C:\\Users\\me\\project\\file.ts", "Windows drive-letter path"],
+		["C:/Users/me/project/file.ts", "Windows drive-letter with forward slashes"],
+		["\\\\server\\share\\file.txt", "Windows UNC path"],
+	])("accepts valid host path %p — %s", (p) => {
+		expect(isValidHostPath(p)).toBe(true);
+	});
+
+	it.each([
+		["", "empty string"],
+		["relative/path.ts", "relative path — not absolute"],
+		["./local.ts", "dot-relative path"],
+		["../escape.ts", "parent traversal"],
+		["/home/user\0evil", "null byte injection"],
+	])("rejects invalid host path %p — %s", (p) => {
+		expect(isValidHostPath(p)).toBe(false);
 	});
 });
 

--- a/src/api/tests/unit/mcp.test.ts
+++ b/src/api/tests/unit/mcp.test.ts
@@ -51,6 +51,41 @@ function withBulkIngest(fs: IFileSystem): IFileSystem & Pick<ICoherentFs, "bulkI
 
 const b64 = (s: string): string => Buffer.from(s, "utf-8").toString("base64");
 
+/**
+ * Boots an in-memory MCP server + client, registers tools, and creates a
+ * sandbox. Returns `{ client, sandboxId }` plus a `close()` shortcut.
+ *
+ * Used by the fs_ingest tests below — every one of them needs the same
+ * ~10 lines of bootstrap; centralizing here keeps the per-test bodies
+ * focused on the behavior under test.
+ */
+async function bootIngestHarness(
+	opts: { withBulk?: boolean } = {},
+): Promise<{ client: Client; sandboxId: string; close: () => Promise<void> }> {
+	const withBulk = opts.withBulk ?? true;
+	const sessionManager = new SessionManager({
+		createFs: async () => (withBulk ? withBulkIngest(new InMemoryFs()) : new InMemoryFs()),
+	});
+	const server = createMcpServer();
+	registerTools(server, sessionManager, "test-owner", "default");
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: "test-client", version: "1.0.0" });
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+
+	const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+	const { id: sandboxId } = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+		id: string;
+	};
+
+	return { client, sandboxId, close: () => client.close() };
+}
+
+function parseToolJson<T>(res: unknown): T {
+	const content = (res as { content: Array<{ text?: string }> }).content;
+	return JSON.parse(content[0]?.text ?? "") as T;
+}
+
 describe("MCP server", () => {
 	it("initializes without error", () => {
 		const server = createMcpServer();
@@ -578,23 +613,12 @@ describe("MCP tool — fs_ingest", () => {
 			await writeFile(join(tmpDir, "a.txt"), "hello from a", "utf-8");
 			await writeFile(join(tmpDir, "b.txt"), "hello from b", "utf-8");
 
-			const sessionManager = new SessionManager({
-				createFs: async () => withBulkIngest(new InMemoryFs()),
-			});
-			const server = createMcpServer();
-			registerTools(server, sessionManager, "test-owner", "default");
-			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-			const client = new Client({ name: "test-client", version: "1.0.0" });
-			await server.connect(serverTransport);
-			await client.connect(clientTransport);
-
-			const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
-			const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+			const { client, sandboxId, close } = await bootIngestHarness();
 
 			const ingestResult = await client.callTool({
 				name: "fs_ingest",
 				arguments: {
-					id: created.id,
+					id: sandboxId,
 					basePath: "/home/user/project",
 					paths: {
 						"a.txt": join(tmpDir, "a.txt"),
@@ -602,12 +626,7 @@ describe("MCP tool — fs_ingest", () => {
 					},
 				},
 			});
-
-			const parsed = JSON.parse((ingestResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-				ok: boolean;
-				count: number;
-			};
-			expect(parsed).toEqual({ ok: true, count: 2 });
+			expect(parseToolJson<{ ok: boolean; count: number }>(ingestResult)).toEqual({ ok: true, count: 2 });
 
 			for (const [rel, expected] of [
 				["a.txt", "hello from a"],
@@ -615,17 +634,14 @@ describe("MCP tool — fs_ingest", () => {
 			] as Array<[string, string]>) {
 				const execResult = await client.callTool({
 					name: "bash_exec",
-					arguments: { id: created.id, script: `cat /home/user/project/${rel}` },
+					arguments: { id: sandboxId, script: `cat /home/user/project/${rel}` },
 				});
-				const exec = JSON.parse((execResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-					stdout: string;
-					exitCode: number;
-				};
+				const exec = parseToolJson<{ stdout: string; exitCode: number }>(execResult);
 				expect(exec.exitCode).toBe(0);
 				expect(exec.stdout).toBe(expected);
 			}
 
-			await client.close();
+			await close();
 		} finally {
 			await rm(tmpDir, { recursive: true, force: true });
 		}
@@ -636,131 +652,92 @@ describe("MCP tool — fs_ingest", () => {
 		try {
 			await writeFile(join(tmpDir, "from-disk.txt"), "disk content", "utf-8");
 
-			const sessionManager = new SessionManager({
-				createFs: async () => withBulkIngest(new InMemoryFs()),
-			});
-			const server = createMcpServer();
-			registerTools(server, sessionManager, "test-owner", "default");
-			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-			const client = new Client({ name: "test-client", version: "1.0.0" });
-			await server.connect(serverTransport);
-			await client.connect(clientTransport);
-
-			const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
-			const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+			const { client, sandboxId, close } = await bootIngestHarness();
 
 			const ingestResult = await client.callTool({
 				name: "fs_ingest",
 				arguments: {
-					id: created.id,
+					id: sandboxId,
 					basePath: "/home/user/project",
 					files: { "generated.txt": b64("generated content") },
 					paths: { "from-disk.txt": join(tmpDir, "from-disk.txt") },
 				},
 			});
+			expect(parseToolJson<{ ok: boolean; count: number }>(ingestResult)).toEqual({ ok: true, count: 2 });
 
-			const parsed = JSON.parse((ingestResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-				ok: boolean;
-				count: number;
-			};
-			expect(parsed).toEqual({ ok: true, count: 2 });
-
-			await client.close();
+			await close();
 		} finally {
 			await rm(tmpDir, { recursive: true, force: true });
 		}
 	});
 
 	it("rejects relative host path values before any I/O", async () => {
-		const sessionManager = new SessionManager({
-			createFs: async () => withBulkIngest(new InMemoryFs()),
-		});
-		const server = createMcpServer();
-		registerTools(server, sessionManager, "test-owner", "default");
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-		const client = new Client({ name: "test-client", version: "1.0.0" });
-		await server.connect(serverTransport);
-		await client.connect(clientTransport);
-
-		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
-		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
-
+		const { client, sandboxId, close } = await bootIngestHarness();
 		const res = await client.callTool({
 			name: "fs_ingest",
 			arguments: {
-				id: created.id,
+				id: sandboxId,
 				basePath: "/home/user/proj",
 				paths: { "a.txt": "relative/path/not/absolute" },
 			},
 		});
-		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-			ok: boolean;
-			error: string;
-		};
-		expect(parsed).toEqual({ ok: false, error: "invalid host paths: a.txt" });
-
-		await client.close();
+		expect(parseToolJson<{ ok: boolean; error: string }>(res)).toEqual({
+			ok: false,
+			error: "invalid host paths: a.txt",
+		});
+		await close();
 	});
 
 	it("returns unreadable error when a host path does not exist", async () => {
-		const sessionManager = new SessionManager({
-			createFs: async () => withBulkIngest(new InMemoryFs()),
-		});
-		const server = createMcpServer();
-		registerTools(server, sessionManager, "test-owner", "default");
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-		const client = new Client({ name: "test-client", version: "1.0.0" });
-		await server.connect(serverTransport);
-		await client.connect(clientTransport);
-
-		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
-		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
-
+		const { client, sandboxId, close } = await bootIngestHarness();
 		const res = await client.callTool({
 			name: "fs_ingest",
 			arguments: {
-				id: created.id,
+				id: sandboxId,
 				basePath: "/home/user/proj",
 				paths: { "missing.txt": "/tmp/does-not-exist-sqlfs-test-12345.txt" },
 			},
 		});
-		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-			ok: boolean;
-			error: string;
-		};
+		const parsed = parseToolJson<{ ok: boolean; error: string }>(res);
 		expect(parsed.ok).toBe(false);
 		expect(parsed.error).toContain("unreadable host paths");
 		expect(parsed.error).toContain("missing.txt");
-
-		await client.close();
+		await close();
 	});
 
 	it("rejects when both files and paths are absent", async () => {
-		const sessionManager = new SessionManager({
-			createFs: async () => withBulkIngest(new InMemoryFs()),
-		});
-		const server = createMcpServer();
-		registerTools(server, sessionManager, "test-owner", "default");
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-		const client = new Client({ name: "test-client", version: "1.0.0" });
-		await server.connect(serverTransport);
-		await client.connect(clientTransport);
-
-		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
-		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
-
+		const { client, sandboxId, close } = await bootIngestHarness();
 		const res = await client.callTool({
 			name: "fs_ingest",
-			arguments: { id: created.id, basePath: "/home/user/proj" },
+			arguments: { id: sandboxId, basePath: "/home/user/proj" },
 		});
-		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
-			ok: boolean;
-			error: string;
-		};
+		const parsed = parseToolJson<{ ok: boolean; error: string }>(res);
 		expect(parsed.ok).toBe(false);
 		expect(parsed.error).toContain("at least one");
+		await close();
+	});
 
-		await client.close();
+	it("rejects duplicate keys between files and paths", async () => {
+		const tmpDir = await mkdtemp(join(tmpdir(), "sqlfs-test-"));
+		try {
+			await writeFile(join(tmpDir, "dup.txt"), "from disk", "utf-8");
+			const { client, sandboxId, close } = await bootIngestHarness();
+			const res = await client.callTool({
+				name: "fs_ingest",
+				arguments: {
+					id: sandboxId,
+					basePath: "/home/user/proj",
+					files: { "dup.txt": b64("from inline") },
+					paths: { "dup.txt": join(tmpDir, "dup.txt") },
+				},
+			});
+			const parsed = parseToolJson<{ ok: boolean; error: string }>(res);
+			expect(parsed.ok).toBe(false);
+			expect(parsed.error).toContain("duplicate keys in files and paths: dup.txt");
+			await close();
+		} finally {
+			await rm(tmpDir, { recursive: true, force: true });
+		}
 	});
 
 	it("returns a sanitized internal error (no backend wiring) when the FS lacks bulkIngest", async () => {

--- a/src/api/tests/unit/mcp.test.ts
+++ b/src/api/tests/unit/mcp.test.ts
@@ -8,6 +8,9 @@
  * US-087: MCP tool — fs_export
  */
 
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -565,6 +568,197 @@ describe("MCP tool — fs_ingest", () => {
 		const content = res.content as Array<{ type: string; text?: string }>;
 		const parsed = JSON.parse(content[0]?.text ?? "") as { ok: boolean; error: string };
 		expect(parsed).toEqual({ ok: false, error: "basePath must be a safe absolute path" });
+
+		await client.close();
+	});
+
+	it("ingests via paths — server reads host files without model generating base64 tokens", async () => {
+		const tmpDir = await mkdtemp(join(tmpdir(), "sqlfs-test-"));
+		try {
+			await writeFile(join(tmpDir, "a.txt"), "hello from a", "utf-8");
+			await writeFile(join(tmpDir, "b.txt"), "hello from b", "utf-8");
+
+			const sessionManager = new SessionManager({
+				createFs: async () => withBulkIngest(new InMemoryFs()),
+			});
+			const server = createMcpServer();
+			registerTools(server, sessionManager, "test-owner", "default");
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+			const client = new Client({ name: "test-client", version: "1.0.0" });
+			await server.connect(serverTransport);
+			await client.connect(clientTransport);
+
+			const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+			const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+
+			const ingestResult = await client.callTool({
+				name: "fs_ingest",
+				arguments: {
+					id: created.id,
+					basePath: "/home/user/project",
+					paths: {
+						"a.txt": join(tmpDir, "a.txt"),
+						"b.txt": join(tmpDir, "b.txt"),
+					},
+				},
+			});
+
+			const parsed = JSON.parse((ingestResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+				ok: boolean;
+				count: number;
+			};
+			expect(parsed).toEqual({ ok: true, count: 2 });
+
+			for (const [rel, expected] of [
+				["a.txt", "hello from a"],
+				["b.txt", "hello from b"],
+			] as Array<[string, string]>) {
+				const execResult = await client.callTool({
+					name: "bash_exec",
+					arguments: { id: created.id, script: `cat /home/user/project/${rel}` },
+				});
+				const exec = JSON.parse((execResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+					stdout: string;
+					exitCode: number;
+				};
+				expect(exec.exitCode).toBe(0);
+				expect(exec.stdout).toBe(expected);
+			}
+
+			await client.close();
+		} finally {
+			await rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("merges files and paths in one call", async () => {
+		const tmpDir = await mkdtemp(join(tmpdir(), "sqlfs-test-"));
+		try {
+			await writeFile(join(tmpDir, "from-disk.txt"), "disk content", "utf-8");
+
+			const sessionManager = new SessionManager({
+				createFs: async () => withBulkIngest(new InMemoryFs()),
+			});
+			const server = createMcpServer();
+			registerTools(server, sessionManager, "test-owner", "default");
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+			const client = new Client({ name: "test-client", version: "1.0.0" });
+			await server.connect(serverTransport);
+			await client.connect(clientTransport);
+
+			const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+			const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+
+			const ingestResult = await client.callTool({
+				name: "fs_ingest",
+				arguments: {
+					id: created.id,
+					basePath: "/home/user/project",
+					files: { "generated.txt": b64("generated content") },
+					paths: { "from-disk.txt": join(tmpDir, "from-disk.txt") },
+				},
+			});
+
+			const parsed = JSON.parse((ingestResult.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+				ok: boolean;
+				count: number;
+			};
+			expect(parsed).toEqual({ ok: true, count: 2 });
+
+			await client.close();
+		} finally {
+			await rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects relative host path values before any I/O", async () => {
+		const sessionManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: {
+				id: created.id,
+				basePath: "/home/user/proj",
+				paths: { "a.txt": "relative/path/not/absolute" },
+			},
+		});
+		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+			ok: boolean;
+			error: string;
+		};
+		expect(parsed).toEqual({ ok: false, error: "invalid host paths: a.txt" });
+
+		await client.close();
+	});
+
+	it("returns unreadable error when a host path does not exist", async () => {
+		const sessionManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: {
+				id: created.id,
+				basePath: "/home/user/proj",
+				paths: { "missing.txt": "/tmp/does-not-exist-sqlfs-test-12345.txt" },
+			},
+		});
+		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+			ok: boolean;
+			error: string;
+		};
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toContain("unreadable host paths");
+		expect(parsed.error).toContain("missing.txt");
+
+		await client.close();
+	});
+
+	it("rejects when both files and paths are absent", async () => {
+		const sessionManager = new SessionManager({
+			createFs: async () => withBulkIngest(new InMemoryFs()),
+		});
+		const server = createMcpServer();
+		registerTools(server, sessionManager, "test-owner", "default");
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: "test-client", version: "1.0.0" });
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+
+		const createResult = await client.callTool({ name: "sandbox_create", arguments: {} });
+		const created = JSON.parse((createResult.content as Array<{ text?: string }>)[0]?.text ?? "") as { id: string };
+
+		const res = await client.callTool({
+			name: "fs_ingest",
+			arguments: { id: created.id, basePath: "/home/user/proj" },
+		});
+		const parsed = JSON.parse((res.content as Array<{ text?: string }>)[0]?.text ?? "") as {
+			ok: boolean;
+			error: string;
+		};
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toContain("at least one");
 
 		await client.close();
 	});


### PR DESCRIPTION
## Summary

- Adds a `paths` param to the `fs_ingest` MCP tool: `{ relativePath: absoluteHostPath }`. The server reads host bytes via parallel `readFile()` calls and passes them to the existing `bulkIngest` transaction — no file content is generated as output tokens by the model.
- Makes `files` (inline base64) optional and demotes it to an exception path for small, dynamically generated content only. `paths` is now the default with explicit "avoid files for anything >a few KB" guidance in both the tool description and param schema.
- Adds `isValidHostPath()` validator to `ingest-validation.ts` (accepts Unix/Windows absolute paths, rejects relative paths and null bytes).

## Testing

```
pnpm test -- src/api/tests/unit/mcp.test.ts src/api/tests/unit/ingest-validation.test.ts
# 24 mcp tests + 51 ingest-validation tests — all pass
```

End-to-end benchmark against local Postgres (906-file repo):

| | Remote Neon (AU) | Local Postgres |
|---|---|---|
| 906 files via `paths` | 8,007ms (8.8ms/file) | 359ms (0.4ms/file) |

The `paths` fast path matches py-sdk `ingest_files()` performance: model emits only path strings, server does all I/O.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingest now accepts host filesystem paths in addition to base64 uploads; both can be used together in one request.
  * Improved host-path validation to reject invalid or unsafe paths and report unreadable host files.

* **Tests**
  * Added coverage for host-paths, combined ingest cases, duplicate-key handling, and related error messages.

* **Documentation**
  * Release notes updated to reflect the new ingest modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/sql-fs/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->