### PR TITLE
fix: make defense-in-depth compatible with Postgres on just-bash 3.x

### DIFF
--- a/.changeset/defense-postgres-stacktracelimit.md
+++ b/.changeset/defense-postgres-stacktracelimit.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": patch
+---
+
+Make defense-in-depth compatible with Postgres on just-bash 3.x. just-bash 3.x freezes `Error.stackTraceLimit` during `bash.exec`, which the `postgres` driver assigns to (breaking every query). All SqlFs DB chokepoints now route through `runTrustedDbAsync`, which re-opens `Error.stackTraceLimit` writability before trusted DB I/O. No-op on just-bash 2.x (the property is never frozen there).

--- a/src/fs/sql-fs/defense.ts
+++ b/src/fs/sql-fs/defense.ts
@@ -1,0 +1,58 @@
+/**
+ * Defense-in-depth helpers for routing Postgres I/O safely when just-bash's
+ * `defenseInDepth` layer is active.
+ *
+ * just-bash monkey-patches dangerous globals during `bash.exec`. SqlFs runs in
+ * the same event loop as the interpreter, so its DB driver calls happen inside
+ * that patched scope. `DefenseInDepthBox.runTrustedAsync` exits the patched
+ * scope for the duration of the callback (a no-op when no box is installed).
+ *
+ * just-bash 3.x additionally hardens `Error` by redefining `Error.stackTraceLimit`
+ * as non-writable for the duration of the patched scope. The `postgres` driver
+ * (porsager) temporarily assigns to `Error.stackTraceLimit` when it snapshots a
+ * query's origin stack (`cachedError` in `postgres/src/query.js`), so in strict
+ * mode that assignment throws `TypeError: Cannot assign to read only property
+ * 'stackTraceLimit'` — breaking every query issued inside `bash.exec`.
+ * `runTrustedAsync` does NOT fix this: the freeze is an `Error` property-descriptor
+ * change, orthogonal to the trusted-scope guard. We re-open writability instead.
+ */
+
+import { DefenseInDepthBox } from "just-bash";
+
+/**
+ * Re-marks `Error.stackTraceLimit` writable when a defense-in-depth layer has
+ * frozen it. just-bash leaves the property `configurable`, so we can redefine
+ * it back to writable without changing its value.
+ *
+ * - No-op on just-bash < 3 (the property is never frozen there).
+ * - No-op if the property is non-configurable (skip rather than throw).
+ * - Idempotent: once writable, subsequent calls do nothing.
+ *
+ * Intentionally does NOT re-freeze afterwards. Re-freezing per call would race
+ * across concurrent sessions sharing the process; instead we rely on the box's
+ * own `restorePatches()` to restore the original (writable) descriptor when the
+ * defense scope deactivates at the end of `bash.exec`.
+ */
+function ensureWritableStackTraceLimit(): void {
+	const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit");
+	if (desc?.writable === false && desc.configurable) {
+		Object.defineProperty(Error, "stackTraceLimit", {
+			value: desc.value,
+			writable: true,
+			configurable: true,
+		});
+	}
+}
+
+/**
+ * Run trusted database I/O outside the defense-in-depth sandbox scope.
+ *
+ * Combines `DefenseInDepthBox.runTrustedAsync` (so the driver's timer/eval/etc.
+ * usage is not flagged as a violation) with the `Error.stackTraceLimit` un-freeze
+ * above. Every SqlFs DB chokepoint routes through this, so enabling
+ * `JUST_BASH_DEFENSE_IN_DEPTH` cannot break Postgres on any just-bash version.
+ */
+export function runTrustedDbAsync<T>(fn: () => Promise<T>): Promise<T> {
+	ensureWritableStackTraceLimit();
+	return DefenseInDepthBox.runTrustedAsync(fn);
+}

--- a/src/fs/sql-fs/dialects/postgres.ts
+++ b/src/fs/sql-fs/dialects/postgres.ts
@@ -5,8 +5,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { DefenseInDepthBox } from "just-bash";
 import postgres from "postgres";
+import { runTrustedDbAsync } from "../defense.js";
 import { createEisdir, createEnoent, createEnotdir, translateSqlError } from "../errors.js";
 import type { RedisBlobCache } from "../redis-blob-cache.js";
 import {
@@ -58,7 +58,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		const idleTimeout = envInt("PG_POOL_IDLE_TIMEOUT_S", 30);
 		const connectTimeout = envInt("PG_POOL_CONNECT_TIMEOUT_S", 30);
 		const maxLifetime = envInt("PG_POOL_MAX_LIFETIME_S", 60 * 30);
-		this.pool = await DefenseInDepthBox.runTrustedAsync(() =>
+		this.pool = await runTrustedDbAsync(() =>
 			Promise.resolve(
 				postgres(this.connectionString, {
 					prepare: false,
@@ -72,7 +72,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	}
 
 	async disconnect(): Promise<void> {
-		await DefenseInDepthBox.runTrustedAsync(() => this.pool?.end() ?? Promise.resolve());
+		await runTrustedDbAsync(() => this.pool?.end() ?? Promise.resolve());
 		this.pool = null;
 	}
 

--- a/src/fs/sql-fs/sql-fs.ts
+++ b/src/fs/sql-fs/sql-fs.ts
@@ -10,10 +10,10 @@
 import { createHash } from "node:crypto";
 import type { Redis } from "ioredis";
 import type { CpOptions, FileContent, FsStat, IFileSystem, MkdirOptions, RmOptions } from "just-bash";
-import { DefenseInDepthBox } from "just-bash";
 import { LRUCache } from "lru-cache";
 
 import { readOnlyContext } from "../../api/read-only-context.js";
+import { runTrustedDbAsync } from "./defense.js";
 import {
 	createEexist,
 	createEinval,
@@ -217,9 +217,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 				await this.#openScriptTx();
 			}
 			const tx = this.#scriptTx as Tx;
-			return DefenseInDepthBox.runTrustedAsync(() => fn(tx));
+			return runTrustedDbAsync(() => fn(tx));
 		}
-		return DefenseInDepthBox.runTrustedAsync(() =>
+		return runTrustedDbAsync(() =>
 			this.#dialect.transaction(async (tx) => {
 				await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
 				return await fn(tx);
@@ -235,9 +235,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 	async #withReadTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
 		const scriptTx = this.#scriptTx;
 		if (this.#scriptScope && scriptTx !== undefined) {
-			return DefenseInDepthBox.runTrustedAsync(() => fn(scriptTx));
+			return runTrustedDbAsync(() => fn(scriptTx));
 		}
-		return DefenseInDepthBox.runTrustedAsync(() =>
+		return runTrustedDbAsync(() =>
 			this.#dialect.transaction(async (tx) => {
 				await this.#dialect.setSandboxContext(tx, this.#sandboxId);
 				return await fn(tx);
@@ -260,7 +260,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		this.#scriptTxEnd = resolveEnd;
 		this.#scriptTxAbort = rejectEnd;
 
-		const scriptTxPromise = DefenseInDepthBox.runTrustedAsync(() =>
+		const scriptTxPromise = runTrustedDbAsync(() =>
 			this.#dialect.transaction(async (tx) => {
 				await this.#dialect.setSandboxContextWithLock(tx, this.#sandboxId);
 				this.#scriptTx = tx;
@@ -287,9 +287,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		// When no script-tx is open yet, use a fresh transaction (original behavior, no extra RTT).
 		const scriptTx = this.#scriptTx;
 		if (scriptTx !== undefined) {
-			return DefenseInDepthBox.runTrustedAsync(() => fn(scriptTx));
+			return runTrustedDbAsync(() => fn(scriptTx));
 		}
-		return DefenseInDepthBox.runTrustedAsync(() => this.#dialect.transaction(fn));
+		return runTrustedDbAsync(() => this.#dialect.transaction(fn));
 	}
 
 	// ── Path helpers ──────────────────────────────────────────────────────────────
@@ -466,9 +466,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		const cap = this.#contentCache.maxSize;
 		const task = (async (): Promise<void> => {
 			try {
-				const blobs = await DefenseInDepthBox.runTrustedAsync(() =>
-					this.#dialect.getBlobsForSandbox(this.#sandboxId, cap),
-				);
+				const blobs = await runTrustedDbAsync(() => this.#dialect.getBlobsForSandbox(this.#sandboxId, cap));
 				for (const { inodeId, data } of blobs) {
 					if (data.byteLength > 0) this.#contentCache.set(inodeId, data);
 				}
@@ -1001,7 +999,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		}
 
 		// `blobs` is global (no RLS), so a transaction wrapper is unnecessary.
-		const data = await DefenseInDepthBox.runTrustedAsync(() => this.#dialect.getBlobNoTx(entry.contentSha256!));
+		const data = await runTrustedDbAsync(() => this.#dialect.getBlobNoTx(entry.contentSha256!));
 		const bytes = data ?? new Uint8Array(0);
 		if (bytes.byteLength > 0) this.#contentCache.set(entry.inodeId, bytes);
 		return bytes;

--- a/src/fs/sql-fs/tests/defense.test.ts
+++ b/src/fs/sql-fs/tests/defense.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for runTrustedDbAsync (defense-in-depth DB wrapper).
+ *
+ * just-bash 3.x freezes `Error.stackTraceLimit` (writable: false) during
+ * `bash.exec`; the postgres driver assigns to it and throws. These tests
+ * simulate that freeze directly (no real just-bash exec needed) and assert the
+ * wrapper re-opens writability so a driver-style assignment succeeds.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runTrustedDbAsync } from "../defense.js";
+
+describe("runTrustedDbAsync", () => {
+	let original: PropertyDescriptor | undefined;
+
+	beforeEach(() => {
+		original = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit");
+	});
+
+	afterEach(() => {
+		// Restore the original descriptor. Guarded because a test may have left the
+		// property non-configurable (defineProperty would then throw).
+		try {
+			if (original) Object.defineProperty(Error, "stackTraceLimit", original);
+		} catch {
+			Error.stackTraceLimit = original?.value as number;
+		}
+	});
+
+	it("runs the callback and returns its value", async () => {
+		const result = await runTrustedDbAsync(async () => 42);
+		expect(result).toBe(42);
+	});
+
+	it("un-freezes a read-only Error.stackTraceLimit so the callback can assign it (just-bash 3.x)", async () => {
+		// Simulate just-bash 3.x hardening: stackTraceLimit becomes non-writable.
+		Object.defineProperty(Error, "stackTraceLimit", { value: 10, writable: false, configurable: true });
+
+		let assigned = false;
+		await runTrustedDbAsync(async () => {
+			// Mirrors porsager's cachedError(): would throw in strict mode if still frozen.
+			Error.stackTraceLimit = 4;
+			assigned = true;
+			Error.stackTraceLimit = 10;
+		});
+
+		expect(assigned).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")?.writable).toBe(true);
+	});
+
+	it("is a no-op when stackTraceLimit is already writable (just-bash 2.x)", async () => {
+		Object.defineProperty(Error, "stackTraceLimit", { value: 10, writable: true, configurable: true });
+
+		let ran = false;
+		await runTrustedDbAsync(async () => {
+			ran = true;
+		});
+
+		expect(ran).toBe(true);
+		const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit");
+		expect(desc?.writable).toBe(true);
+		expect(desc?.value).toBe(10);
+	});
+});


### PR DESCRIPTION
## Problem

just-bash **3.x** hardens globals during `bash.exec` by redefining `Error.stackTraceLimit` as non-writable. The `postgres` driver (porsager) temporarily assigns to `Error.stackTraceLimit` when snapshotting a query's origin stack (`cachedError`, `postgres/src/query.js`), so in strict mode that assignment throws:

```
TypeError: Cannot assign to read only property 'stackTraceLimit' of function Error()
```

This breaks **every** Postgres query issued inside `bash.exec` when defense-in-depth is enabled on just-bash 3.x. `DefenseInDepthBox.runTrustedAsync` does **not** fix it — the freeze is an `Error` property-descriptor change, orthogonal to the trusted-scope (ALS) guard.

> Note: just-bash **2.14.x** (current pinned version) does not patch the main process at all, so this is latent today — it surfaces only on a 3.x upgrade with defense-in-depth on. Fixing it now keeps the upgrade path clear.

## Fix

Add `runTrustedDbAsync` (`src/fs/sql-fs/defense.ts`) which, before delegating to `DefenseInDepthBox.runTrustedAsync`, re-opens `Error.stackTraceLimit` writability when a defense layer has frozen it (the property is left `configurable`, so it can be redefined). All SqlFs DB chokepoints now route through it:

- `sql-fs.ts`: `#withTx`, `#withReadTx`, `#withBareTx`, `#openScriptTx`, prewarm, lock-free read
- `dialects/postgres.ts`: `connect` / `disconnect`

Properties:
- **No-op on just-bash 2.x** (the property is never frozen there) — version-safe.
- **Race-free**: does not re-freeze; relies on the box's own `restorePatches()` at exec teardown.
- Skips silently if the property is non-configurable (never throws).

## Verification

- New unit test `src/fs/sql-fs/tests/defense.test.ts` (3 cases) simulating the 3.x freeze.
- Full unit suite: 838 passed.
- Manually trialed `just-bash@3.0.1` against a real Neon Postgres: the `defense-in-depth` integration test fails 5/5 **without** this change and passes **5/5 with** it. Reverted the bump; repo stays on 2.14.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Postgres database operation failures when using just-bash 3.x sandbox environments. Enhanced database routing ensures SQL FS functions correctly while maintaining full backward compatibility with just-bash 2.x.

* **Tests**
  * Added test coverage validating database operation behavior across sandbox environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hazzng/sql-fs/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->