### PR TITLE
feat(mcp): static-header (API-key) auth for /mcp (LibreChat)

### DIFF
--- a/.changeset/mcp-static-header-auth.md
+++ b/.changeset/mcp-static-header-auth.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": minor
+---
+
+Add static-header (API-key) auth for the MCP endpoint so external clients that can only send fixed headers — e.g. LibreChat — can connect without minting a per-request JWT. Set `MCP_API_KEY` to accept a pre-shared `Authorization: Bearer <key>`; the sandbox owner (`sub`) is derived from a forwarded identity header (`MCP_IDENTITY_HEADER`, default `x-librechat-user-id`), giving each end-user an isolated sandbox. New env vars: `MCP_API_KEY`, `MCP_IDENTITY_HEADER`, `MCP_DEFAULT_SUB`, `MCP_STATIC_TENANT`. Static auth is additive and off unless `MCP_API_KEY` is set — JWT clients on `/mcp` and all `/v1/*` routes are unchanged.

--- a/.changeset/mcp-static-header-auth.md
+++ b/.changeset/mcp-static-header-auth.md
@@ -3,3 +3,5 @@
 ---
 
 Add static-header (API-key) auth for the MCP endpoint so external clients that can only send fixed headers — e.g. LibreChat — can connect without minting a per-request JWT. Set `MCP_API_KEY` to accept a pre-shared `Authorization: Bearer <key>`; the sandbox owner (`sub`) is derived from a forwarded identity header (`MCP_IDENTITY_HEADER`, default `x-librechat-user-id`), giving each end-user an isolated sandbox. New env vars: `MCP_API_KEY`, `MCP_IDENTITY_HEADER`, `MCP_DEFAULT_SUB`, `MCP_STATIC_TENANT`. Static auth is additive and off unless `MCP_API_KEY` is set — JWT clients on `/mcp` and all `/v1/*` routes are unchanged.
+
+Startup hardening: `MCP_IDENTITY_HEADER` cannot be a reserved transport header (`authorization`, `cookie`, `content-type`, `accept`, `mcp-session-id`, `mcp-protocol-version`, `last-event-id`) — otherwise every request would derive `owner` from a shared value and collapse all users into one sandbox. The `mcp_static_auth_enabled` startup log records only whether a fallback owner is configured (`hasDefaultSub`), never the `MCP_DEFAULT_SUB` value.

--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,13 @@ MAX_CONCURRENT_JS=5             # cap QuickJS workers (~64 MB each)
 
 # JUST_BASH_DEFENSE_IN_DEPTH=false     # monkey-patch host globals during exec
 # JUST_BASH_DEFENSE_AUDIT_MODE=true    # log violations instead of throwing
+
+# ── Optional: MCP static-header auth (e.g. LibreChat) ─────────────────────────
+# Set MCP_API_KEY to let MCP clients that send fixed headers (and cannot mint a
+# per-request JWT) authenticate to /mcp. Owner is derived from the identity
+# header below, so each forwarded end-user gets an isolated sandbox.
+
+# MCP_API_KEY=replace-with-a-long-random-secret   # ≥16 chars; enables static /mcp auth
+# MCP_IDENTITY_HEADER=x-librechat-user-id         # header → sandbox owner (sub)
+# MCP_DEFAULT_SUB=                                 # shared owner when identity header absent
+# MCP_STATIC_TENANT=default                        # tenant for static-header requests

--- a/README.md
+++ b/README.md
@@ -169,6 +169,47 @@ Key design choices:
 | `BOOTSTRAP_RATE_LIMIT_WINDOW_MS` | No | `60000` | Rolling window (ms) for the bootstrap token endpoint. |
 | `BOOTSTRAP_RATE_LIMIT_MAX` | No | `5` | Max requests per window for the bootstrap token endpoint. |
 | `TRUST_PROXY_HEADERS` | No | `false` | Set `true` to read client IP from `X-Forwarded-For` (use only behind a trusted reverse proxy). |
+| `MCP_API_KEY` | No | — | Enables static-header auth on `/mcp` (see [MCP auth](#mcp-auth-for-static-header-clients-eg-librechat)). Pre-shared secret (≥16 chars) accepted as `Authorization: Bearer <key>`. When unset, `/mcp` stays JWT-only. |
+| `MCP_IDENTITY_HEADER` | No | `x-librechat-user-id` | Header whose value becomes the sandbox owner (`sub`) for static-header requests. |
+| `MCP_DEFAULT_SUB` | No | — | Owner used for static-header requests when the identity header is absent. When unset, a missing identity header is rejected (`401 AUTH_IDENTITY_REQUIRED`). |
+| `MCP_STATIC_TENANT` | No | `default` | Tenant assigned to static-header requests. Must be a configured tenant. |
+
+## MCP auth (for static-header clients, e.g. LibreChat)
+
+The `/mcp` endpoint normally requires a `Authorization: Bearer <JWT>` signed with `AUTH_SECRET` (the SDKs mint this automatically from `auth_secret`). External MCP clients that can only send **fixed headers** — notably [LibreChat](https://github.com/danny-avila/LibreChat) — cannot mint a per-request JWT.
+
+Setting **`MCP_API_KEY`** turns on a second, additive auth path on `/mcp`:
+
+- A `Authorization: Bearer <MCP_API_KEY>` is accepted **without** JWT verification (constant-time compared).
+- The sandbox **owner** (`sub`) is derived from a forwarded identity header (`MCP_IDENTITY_HEADER`, default `x-librechat-user-id`), so each end-user gets an **isolated** sandbox/owner.
+- Any token that is *not* the API key still falls through to JWT verification, so JWT clients keep working on `/mcp` unchanged.
+
+```yaml
+# librechat.yaml — point LibreChat's MCP client at sql-fs
+mcpServers:
+  sql-fs:
+    type: streamable-http
+    url: https://your-sql-fs.example.com/mcp
+    headers:
+      Authorization: "Bearer ${MCP_API_KEY}"      # the shared service credential
+      x-librechat-user-id: "{{LIBRECHAT_USER_ID}}" # forwarded per end-user → owner
+```
+
+```bash
+# Server config
+MCP_API_KEY=<long-random-shared-secret>   # ≥16 chars; guards code execution — keep it secret
+MCP_IDENTITY_HEADER=x-librechat-user-id    # default; the header carrying the end-user id
+# MCP_DEFAULT_SUB=shared                    # optional: shared owner when no identity header
+# MCP_STATIC_TENANT=default                 # optional: tenant for static-header requests
+```
+
+> **Security model.** The forwarded identity header is trusted as the end-user identity, so it must be set by your proxy/LibreChat and **not** be settable by untrusted callers. Treat `MCP_API_KEY` like a password: anyone who has it *and* can reach `/mcp` directly can choose any `sub`. Put `/mcp` behind your ingress, keep the key secret, and ensure the identity header is stamped by a trusted hop. Cross-sandbox isolation is still enforced by RLS scoped to `(owner, tenant)`.
+
+| Response | Cause |
+|---|---|
+| `401 AUTH_IDENTITY_REQUIRED` | API key matched but no identity header and no `MCP_DEFAULT_SUB`. |
+| `401 AUTH_IDENTITY_INVALID` | Identity header present but empty, >256 chars, or contains control characters. |
+| `401 AUTH_INVALID` | Token is neither the API key nor a valid JWT. |
 
 ## Deployment
 

--- a/plugins/sql-fs/skills/api/SETUP.md
+++ b/plugins/sql-fs/skills/api/SETUP.md
@@ -114,6 +114,44 @@ echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | jq
 
 ---
 
+## MCP static-header auth (LibreChat and other fixed-header clients)
+
+The `/mcp` endpoint defaults to the same JWT Bearer auth as `/v1/*`. MCP clients that
+can only send **fixed headers** (e.g. [LibreChat](https://github.com/danny-avila/LibreChat))
+cannot mint a per-request JWT. Setting **`MCP_API_KEY`** on the server enables an additive
+static-header path on `/mcp`:
+
+- `Authorization: Bearer <MCP_API_KEY>` is accepted without JWT verification (constant-time compare).
+- The sandbox **owner** (`sub`) is taken from a forwarded identity header — `MCP_IDENTITY_HEADER`,
+  default `x-librechat-user-id` — so each end-user gets an isolated sandbox.
+- A non-matching token still falls through to JWT verification, so JWT clients keep working on `/mcp`.
+
+```yaml
+# librechat.yaml
+mcpServers:
+  sql-fs:
+    type: streamable-http
+    url: https://your-sql-fs.example.com/mcp
+    headers:
+      Authorization: "Bearer ${MCP_API_KEY}"
+      x-librechat-user-id: "{{LIBRECHAT_USER_ID}}"
+```
+
+Server env vars:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MCP_API_KEY` | — (off) | Pre-shared secret (≥16 chars) enabling static `/mcp` auth. Keep it secret — it guards code execution. |
+| `MCP_IDENTITY_HEADER` | `x-librechat-user-id` | Header whose value becomes the sandbox owner. |
+| `MCP_DEFAULT_SUB` | — | Shared owner when the identity header is absent. When unset, a missing header is rejected. |
+| `MCP_STATIC_TENANT` | `default` | Tenant for static-header requests; must be configured. |
+
+> **Trust note.** The identity header is trusted as the end-user identity, so it must be stamped
+> by your proxy/LibreChat and not be settable by untrusted callers. Anyone holding `MCP_API_KEY`
+> who can reach `/mcp` directly can pick any `sub` — keep the key secret and `/mcp` behind your ingress.
+
+---
+
 ## Environment setup (put in ~/.zshrc or .env)
 
 ```bash
@@ -138,6 +176,8 @@ alias vfs-bootstrap='curl -fsS -X POST "$VIRTUALFS_BASE_URL/v1/auth/bootstrap" -
 | `{"error":"unknown_tenant","code":"AUTH_UNKNOWN_TENANT"}` | `tenant` claim in JWT not configured on server | Omit `tenant` claim or update server config |
 | `{"error":"forbidden","code":"FORBIDDEN"}` | Sandbox owned by a different `sub`, OR wrong/missing `X-Auth-Secret` on bootstrap | Use the token that created the sandbox; double-check `AUTH_SECRET` |
 | `{"error":"auth_not_configured","code":"AUTH_NOT_CONFIGURED"}` | Server has no `AUTH_SECRET` env var | Ask the deployer to set `AUTH_SECRET` |
+| `{"error":"identity_required","code":"AUTH_IDENTITY_REQUIRED"}` | Static `/mcp` API key matched but no identity header and no `MCP_DEFAULT_SUB` | Send the `MCP_IDENTITY_HEADER` (default `x-librechat-user-id`) or set `MCP_DEFAULT_SUB` |
+| `{"error":"invalid_identity","code":"AUTH_IDENTITY_INVALID"}` | Identity header present but empty, >256 chars, or contains control characters | Forward a valid user id/email in the identity header |
 | `{"error":"admin_not_configured","code":"ADMIN_NOT_CONFIGURED"}` | Server has no `ADMIN_SECRET` env var | Ask the deployer to set `ADMIN_SECRET` |
 | `{"error":"rate_limited","code":"RATE_LIMITED"}` | Too many requests to `/v1/auth/bootstrap` or `/v1/auth/admin` (default 5 / 60s). Response includes `Retry-After` header. | Wait `Retry-After` seconds, or raise `*_RATE_LIMIT_*` env vars. |
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,11 +10,20 @@
  * Usage (legacy lazy):
  *   app.use("/v1/*", authMiddleware);
  *   // lazily resolves TenantConfig from env on first request
+ *
+ * Static MCP auth (issue #117 — external clients that send fixed headers, e.g.
+ * LibreChat, that cannot mint a per-request JWT):
+ *   const staticAuth = loadStaticMcpAuthConfig(tenantConfig);
+ *   app.use("/mcp", createAuthMiddleware(tenantConfig, { staticAuth }));
+ *   // A Bearer token equal to MCP_API_KEY is accepted without JWT verification;
+ *   // the sandbox owner/sub is derived from a forwarded identity header.
  */
 
+import type { Context, Next } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { jwtVerify } from "jose";
+import { constantTimeEqual } from "./lib/constant-time.js";
 import { DEFAULT_TENANT_ID, type TenantConfig, loadTenantConfig } from "./tenants.js";
 
 export type AuthVariables = {
@@ -25,6 +34,139 @@ export type AuthVariables = {
 const UNAUTHORIZED = 401 as ContentfulStatusCode;
 
 /**
+ * Static-header auth configuration for the MCP endpoint.
+ *
+ * When present, a Bearer token byte-equal to `apiKey` is accepted without JWT
+ * verification, and the principal (`owner`/`sub`) is derived from the request's
+ * `identityHeader`. This lets MCP clients that can only send fixed headers
+ * (e.g. LibreChat) connect while still giving each forwarded end-user an
+ * isolated sandbox owner.
+ */
+export interface StaticMcpAuthConfig {
+	/** Pre-shared secret expected verbatim in `Authorization: Bearer <apiKey>`. */
+	readonly apiKey: string;
+	/** Lowercased name of the header carrying the end-user identity → becomes `owner`. */
+	readonly identityHeader: string;
+	/** Owner used when the identity header is absent. When unset, a missing header is rejected. */
+	readonly defaultSub?: string;
+	/** Tenant id assigned to every static-auth request. Validated against the tenant config. */
+	readonly tenant: string;
+}
+
+export interface AuthMiddlewareOptions {
+	/** When set, enables static-header (API-key) auth in addition to JWT auth. */
+	readonly staticAuth?: StaticMcpAuthConfig;
+}
+
+/** Upper bound on a forwarded identity value, mirroring a sane username/email length. */
+const MAX_IDENTITY_LENGTH = 256;
+/** RFC 7230 token chars — the valid charset for an HTTP header field name. */
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+/** Minimum length for MCP_API_KEY — it guards remote code execution, so weak keys are refused. */
+const MIN_API_KEY_LENGTH = 16;
+
+/**
+ * Normalize and validate a forwarded identity value.
+ *
+ * Rejects empty/overlong values and any ASCII control character (< 0x20 or
+ * 0x7F) — those have no place in a username/email and could corrupt logs or
+ * downstream keys.
+ *
+ * @param raw - Raw header value (or env value).
+ * @returns The trimmed identity, or `undefined` when absent/empty/too long/control-char-laden.
+ */
+export function sanitizeIdentity(raw: string | undefined): string | undefined {
+	if (raw === undefined) return undefined;
+	const trimmed = raw.trim();
+	if (trimmed.length === 0 || trimmed.length > MAX_IDENTITY_LENGTH) return undefined;
+	for (let i = 0; i < trimmed.length; i++) {
+		const code = trimmed.charCodeAt(i);
+		if (code < 0x20 || code === 0x7f) return undefined;
+	}
+	return trimmed;
+}
+
+/**
+ * Build the static MCP auth config from the environment.
+ *
+ * Static auth is OFF unless `MCP_API_KEY` is set, so existing deployments keep
+ * JWT-only behaviour on `/mcp` with no change. Misconfiguration throws at load
+ * time (fail-fast at startup) rather than per-request.
+ *
+ * @param tenantConfig - Active tenant config, used to validate `MCP_STATIC_TENANT`.
+ * @param env - Environment to read from. Defaults to `process.env`.
+ * @returns The config, or `undefined` when `MCP_API_KEY` is unset.
+ * @throws If `MCP_API_KEY` is too short, the identity header name is invalid,
+ *   `MCP_DEFAULT_SUB` is malformed, or `MCP_STATIC_TENANT` is not configured.
+ */
+export function loadStaticMcpAuthConfig(
+	tenantConfig: TenantConfig,
+	env: NodeJS.ProcessEnv = process.env,
+): StaticMcpAuthConfig | undefined {
+	const apiKey = env.MCP_API_KEY;
+	if (apiKey === undefined || apiKey.length === 0) return undefined;
+	if (apiKey.length < MIN_API_KEY_LENGTH) {
+		throw new Error(`MCP_API_KEY must be at least ${MIN_API_KEY_LENGTH} characters (use a long random value).`);
+	}
+
+	const identityHeader = (env.MCP_IDENTITY_HEADER ?? "x-librechat-user-id").trim().toLowerCase();
+	if (!HEADER_NAME_PATTERN.test(identityHeader)) {
+		throw new Error(`MCP_IDENTITY_HEADER "${identityHeader}" is not a valid HTTP header name.`);
+	}
+
+	let defaultSub: string | undefined;
+	const rawDefaultSub = env.MCP_DEFAULT_SUB;
+	if (rawDefaultSub !== undefined && rawDefaultSub.length > 0) {
+		defaultSub = sanitizeIdentity(rawDefaultSub);
+		if (defaultSub === undefined) {
+			throw new Error("MCP_DEFAULT_SUB is invalid (must be ≤256 chars and contain no control characters).");
+		}
+	}
+
+	const tenant = env.MCP_STATIC_TENANT ?? DEFAULT_TENANT_ID;
+	if (!tenantConfig.hasTenant(tenant)) {
+		throw new Error(`MCP_STATIC_TENANT "${tenant}" is not a configured tenant.`);
+	}
+
+	return { apiKey, identityHeader, defaultSub, tenant };
+}
+
+/**
+ * Resolve the principal for a static-auth request and stash it on the context.
+ * Returns a 401 response when the identity cannot be resolved or the configured
+ * static tenant is (no longer) known.
+ */
+async function handleStaticAuth(
+	c: Context<{ Variables: AuthVariables }>,
+	next: Next,
+	tenantConfig: TenantConfig,
+	staticAuth: StaticMcpAuthConfig,
+): Promise<Response | undefined> {
+	const rawIdentity = c.req.header(staticAuth.identityHeader);
+
+	let owner: string;
+	if (rawIdentity !== undefined) {
+		const sanitized = sanitizeIdentity(rawIdentity);
+		if (sanitized === undefined) {
+			return c.json({ error: "invalid_identity", code: "AUTH_IDENTITY_INVALID" }, UNAUTHORIZED);
+		}
+		owner = sanitized;
+	} else if (staticAuth.defaultSub !== undefined) {
+		owner = staticAuth.defaultSub;
+	} else {
+		return c.json({ error: "identity_required", code: "AUTH_IDENTITY_REQUIRED" }, UNAUTHORIZED);
+	}
+
+	if (!tenantConfig.hasTenant(staticAuth.tenant)) {
+		return c.json({ error: "unknown_tenant", code: "AUTH_UNKNOWN_TENANT" }, UNAUTHORIZED);
+	}
+
+	c.set("owner", owner);
+	c.set("tenant", staticAuth.tenant);
+	await next();
+}
+
+/**
  * Build a tenant-aware auth middleware.
  *
  * - Verifies the HS256 JWT using `process.env.AUTH_SECRET` (read per-request).
@@ -32,8 +174,12 @@ const UNAUTHORIZED = 401 as ContentfulStatusCode;
  *   so legacy tokens work unchanged in single-tenant deployments.
  * - Rejects the request with 401 `AUTH_UNKNOWN_TENANT` when the claimed tenant
  *   is not configured.
+ * - When `options.staticAuth` is set, a Bearer token equal to the configured
+ *   API key takes a separate path (identity-header → owner). Any other Bearer
+ *   token falls through to JWT verification, so JWT clients keep working.
  *
  * @param tenantConfig - The active tenant configuration.
+ * @param options - Optional features (e.g. static MCP auth).
  */
 /**
  * Paths under /v1/* that are intentionally exempt from Bearer auth because they
@@ -44,7 +190,8 @@ const UNAUTHORIZED = 401 as ContentfulStatusCode;
  */
 const UNAUTHENTICATED_PATHS = new Set<string>(["POST /v1/auth/bootstrap"]);
 
-export function createAuthMiddleware(tenantConfig: TenantConfig) {
+export function createAuthMiddleware(tenantConfig: TenantConfig, options: AuthMiddlewareOptions = {}) {
+	const staticAuth = options.staticAuth;
 	return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
 		const requestKey = `${c.req.method.toUpperCase()} ${c.req.path}`;
 		if (UNAUTHENTICATED_PATHS.has(requestKey)) {
@@ -58,6 +205,13 @@ export function createAuthMiddleware(tenantConfig: TenantConfig) {
 		}
 
 		const token = authHeader.slice(7);
+
+		// Static MCP API-key path. Checked before JWT verification so a fixed-header
+		// client can authenticate; any non-matching token falls through to JWT.
+		if (staticAuth !== undefined && constantTimeEqual(token, staticAuth.apiKey)) {
+			return handleStaticAuth(c, next, tenantConfig, staticAuth);
+		}
+
 		const secret = process.env.AUTH_SECRET;
 
 		if (!secret) {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -19,7 +19,7 @@
  *   // the sandbox owner/sub is derived from a forwarded identity header.
  */
 
-import type { Context, Next } from "hono";
+import type { Context, MiddlewareHandler, Next } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { jwtVerify } from "jose";
@@ -64,6 +64,28 @@ const MAX_IDENTITY_LENGTH = 256;
 const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 /** Minimum length for MCP_API_KEY — it guards remote code execution, so weak keys are refused. */
 const MIN_API_KEY_LENGTH = 16;
+/**
+ * Headers that cannot carry a per-user identity. If `MCP_IDENTITY_HEADER` were
+ * one of these, every static-auth request would derive `owner` from a shared
+ * transport value (e.g. `Authorization: Bearer <MCP_API_KEY>`, or a session's
+ * `last-event-id`), silently collapsing all end-users into one sandbox owner
+ * and defeating isolation. Mirrors the MCP transport headers advertised in
+ * `mcp-cors.ts`. Reject them at startup.
+ */
+const RESERVED_IDENTITY_HEADERS = new Set<string>([
+	"authorization",
+	"cookie",
+	"content-type",
+	"accept",
+	"mcp-session-id",
+	"mcp-protocol-version",
+	"last-event-id",
+]);
+
+/** Build a startup config error with a stable `code` for consistent diagnostics. */
+function configError(message: string): Error {
+	return Object.assign(new Error(message), { code: "AUTH_CONFIG_INVALID" });
+}
 
 /**
  * Normalize and validate a forwarded identity value.
@@ -96,8 +118,10 @@ export function sanitizeIdentity(raw: string | undefined): string | undefined {
  * @param tenantConfig - Active tenant config, used to validate `MCP_STATIC_TENANT`.
  * @param env - Environment to read from. Defaults to `process.env`.
  * @returns The config, or `undefined` when `MCP_API_KEY` is unset.
- * @throws If `MCP_API_KEY` is too short, the identity header name is invalid,
- *   `MCP_DEFAULT_SUB` is malformed, or `MCP_STATIC_TENANT` is not configured.
+ * @throws If `MCP_API_KEY` is too short, the identity header name is invalid or
+ *   reserved (e.g. `authorization`), `MCP_DEFAULT_SUB` is malformed, or
+ *   `MCP_STATIC_TENANT` is not configured. All such errors carry
+ *   `code: "AUTH_CONFIG_INVALID"`.
  */
 export function loadStaticMcpAuthConfig(
 	tenantConfig: TenantConfig,
@@ -106,12 +130,17 @@ export function loadStaticMcpAuthConfig(
 	const apiKey = env.MCP_API_KEY;
 	if (apiKey === undefined || apiKey.length === 0) return undefined;
 	if (apiKey.length < MIN_API_KEY_LENGTH) {
-		throw new Error(`MCP_API_KEY must be at least ${MIN_API_KEY_LENGTH} characters (use a long random value).`);
+		throw configError(`MCP_API_KEY must be at least ${MIN_API_KEY_LENGTH} characters (use a long random value).`);
 	}
 
 	const identityHeader = (env.MCP_IDENTITY_HEADER ?? "x-librechat-user-id").trim().toLowerCase();
 	if (!HEADER_NAME_PATTERN.test(identityHeader)) {
-		throw new Error(`MCP_IDENTITY_HEADER "${identityHeader}" is not a valid HTTP header name.`);
+		throw configError(`MCP_IDENTITY_HEADER "${identityHeader}" is not a valid HTTP header name.`);
+	}
+	if (RESERVED_IDENTITY_HEADERS.has(identityHeader)) {
+		throw configError(
+			`MCP_IDENTITY_HEADER "${identityHeader}" is reserved and cannot carry a per-user identity; choose a dedicated header such as x-librechat-user-id.`,
+		);
 	}
 
 	let defaultSub: string | undefined;
@@ -119,13 +148,13 @@ export function loadStaticMcpAuthConfig(
 	if (rawDefaultSub !== undefined && rawDefaultSub.length > 0) {
 		defaultSub = sanitizeIdentity(rawDefaultSub);
 		if (defaultSub === undefined) {
-			throw new Error("MCP_DEFAULT_SUB is invalid (must be ≤256 chars and contain no control characters).");
+			throw configError("MCP_DEFAULT_SUB is invalid (must be ≤256 chars and contain no control characters).");
 		}
 	}
 
 	const tenant = env.MCP_STATIC_TENANT ?? DEFAULT_TENANT_ID;
 	if (!tenantConfig.hasTenant(tenant)) {
-		throw new Error(`MCP_STATIC_TENANT "${tenant}" is not a configured tenant.`);
+		throw configError(`MCP_STATIC_TENANT "${tenant}" is not a configured tenant.`);
 	}
 
 	return { apiKey, identityHeader, defaultSub, tenant };
@@ -190,7 +219,10 @@ async function handleStaticAuth(
  */
 const UNAUTHENTICATED_PATHS = new Set<string>(["POST /v1/auth/bootstrap"]);
 
-export function createAuthMiddleware(tenantConfig: TenantConfig, options: AuthMiddlewareOptions = {}) {
+export function createAuthMiddleware(
+	tenantConfig: TenantConfig,
+	options: AuthMiddlewareOptions = {},
+): MiddlewareHandler<{ Variables: AuthVariables }> {
 	const staticAuth = options.staticAuth;
 	return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
 		const requestKey = `${c.req.method.toUpperCase()} ${c.req.path}`;

--- a/src/api/lib/constant-time.ts
+++ b/src/api/lib/constant-time.ts
@@ -1,0 +1,22 @@
+/**
+ * Constant-time secret comparison.
+ *
+ * Both inputs are hashed to fixed-length 32-byte SHA-256 digests before
+ * `timingSafeEqual`, so the comparison cannot throw on a length mismatch and
+ * there is no length oracle from an early return.
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * Compares two secrets in constant time relative to their content.
+ *
+ * @param a - First value (e.g. a caller-supplied header).
+ * @param b - Second value (e.g. the configured secret).
+ * @returns `true` iff the two strings are byte-for-byte equal.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+	const aDigest = createHash("sha256").update(a, "utf8").digest();
+	const bDigest = createHash("sha256").update(b, "utf8").digest();
+	return timingSafeEqual(aDigest, bDigest);
+}

--- a/src/api/mcp-cors.ts
+++ b/src/api/mcp-cors.ts
@@ -33,17 +33,30 @@ export function withMcpCors(req: Request, res: Response): Response {
 	return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 
-/** Preflight for browser MCP clients (e.g. Inspector UI). No JWT required. */
-export function mcpOptionsResponse(req: Request): Response {
+const MCP_BASE_ALLOW_HEADERS =
+	"authorization, content-type, accept, mcp-session-id, mcp-protocol-version, last-event-id";
+
+/**
+ * Preflight for browser MCP clients (e.g. Inspector UI). No JWT required.
+ *
+ * @param req - The OPTIONS request (used for Origin).
+ * @param extraAllowHeader - Optional extra request header to advertise in
+ *   `Access-Control-Allow-Headers` — e.g. the configured static-auth identity
+ *   header — so a browser client is allowed to send it on the actual request.
+ */
+export function mcpOptionsResponse(req: Request, extraAllowHeader?: string): Response {
 	const allow = allowOriginHeader(req.headers.get("origin") ?? undefined);
+	const allowHeaders =
+		extraAllowHeader !== undefined && extraAllowHeader.length > 0
+			? `${MCP_BASE_ALLOW_HEADERS}, ${extraAllowHeader}`
+			: MCP_BASE_ALLOW_HEADERS;
 	return new Response(null, {
 		status: 204,
 		headers: {
 			"Access-Control-Allow-Origin": allow,
 			...(allow !== "*" ? { Vary: "Origin" } : {}),
 			"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-			"Access-Control-Allow-Headers":
-				"authorization, content-type, accept, mcp-session-id, mcp-protocol-version, last-event-id",
+			"Access-Control-Allow-Headers": allowHeaders,
 			"Access-Control-Max-Age": "86400",
 		},
 	});

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -5,13 +5,14 @@
  * POST /v1/auth/admin      (Bearer + X-Admin-Secret) — mint tokens for arbitrary subs.
  */
 
-import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import { parseNonNegativeInt } from "../../redis/config.js";
 import type { AuthVariables } from "../auth.js";
 import { logAudit } from "../lib/audit.js";
+import { constantTimeEqual } from "../lib/constant-time.js";
 import { signToken } from "../lib/jwt.js";
 import { clientIp, rateLimit } from "../rate-limit.js";
 import { loadTenantConfig } from "../tenants.js";
@@ -33,14 +34,6 @@ const EXPIRES_IN_SECONDS: Record<string, number> = {
 	"30d": 2592000,
 	"1y": 31536000,
 };
-
-function constantTimeEqual(a: string, b: string): boolean {
-	// Hash both inputs to fixed-length 32-byte digests so timingSafeEqual cannot
-	// throw on length mismatch and there is no length oracle from an early return.
-	const aDigest = createHash("sha256").update(a, "utf8").digest();
-	const bDigest = createHash("sha256").update(b, "utf8").digest();
-	return timingSafeEqual(aDigest, bDigest);
-}
 
 function expiresAt(expiresIn: string): string | null {
 	if (expiresIn === "never") return null;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -15,7 +15,7 @@ import { translateSqlError } from "../sql-fs/errors.js";
 import { RedisBlobCache } from "../sql-fs/redis-blob-cache.js";
 import { RedisPathSnapshot } from "../sql-fs/redis-path-snapshot.js";
 import type { SandboxListEntry, SandboxMeta } from "../sql-fs/types.js";
-import { type AuthVariables, createAuthMiddleware } from "./auth.js";
+import { type AuthVariables, createAuthMiddleware, loadStaticMcpAuthConfig } from "./auth.js";
 import { clientSafeErrorMessage, mapFsErrorToStatus } from "./errors.js";
 import { mcpOptionsResponse, withMcpCors } from "./mcp-cors.js";
 import { handleMcpRequest, shutdownMcp, startMcpSessionSweeper } from "./mcp/server.js";
@@ -206,16 +206,33 @@ app.route("/v1/sandboxes", ingestRoutes(sessionManager));
 
 // ── MCP endpoint (requires auth) + CORS for browser MCP clients (Inspector UI) ─
 
+// Static-header (API-key) auth for MCP clients that cannot mint a per-request
+// JWT (e.g. LibreChat). Enabled only when MCP_API_KEY is set; otherwise /mcp
+// keeps JWT-only behaviour. A non-matching Bearer token still falls through to
+// JWT verification, so existing JWT clients keep working on /mcp regardless.
+const staticMcpAuth = loadStaticMcpAuthConfig(tenantConfig);
+if (staticMcpAuth !== undefined) {
+	console.log(
+		JSON.stringify({
+			event: "mcp_static_auth_enabled",
+			identityHeader: staticMcpAuth.identityHeader,
+			tenant: staticMcpAuth.tenant,
+			defaultSub: staticMcpAuth.defaultSub ?? null,
+		}),
+	);
+}
+const mcpAuthMiddleware = createAuthMiddleware(tenantConfig, { staticAuth: staticMcpAuth });
+
 app.use("/mcp", async (c, next) => {
 	if (c.req.method === "OPTIONS") {
-		return mcpOptionsResponse(c.req.raw);
+		return mcpOptionsResponse(c.req.raw, staticMcpAuth?.identityHeader);
 	}
 	await next();
 	if (c.res !== undefined) {
 		c.res = withMcpCors(c.req.raw, c.res);
 	}
 });
-app.use("/mcp", authMiddleware);
+app.use("/mcp", mcpAuthMiddleware);
 app.all("/mcp", (c) => handleMcpRequest(c.req.raw, sessionManager, c.get("owner"), c.get("tenant")));
 
 // ── Health endpoints ───────────────────────────────────────────────────────────

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -217,7 +217,9 @@ if (staticMcpAuth !== undefined) {
 			event: "mcp_static_auth_enabled",
 			identityHeader: staticMcpAuth.identityHeader,
 			tenant: staticMcpAuth.tenant,
-			defaultSub: staticMcpAuth.defaultSub ?? null,
+			// Log only whether a fallback owner is configured — MCP_DEFAULT_SUB can be
+			// an email/identifier and must not be written verbatim to process logs.
+			hasDefaultSub: staticMcpAuth.defaultSub !== undefined,
 		}),
 	);
 }

--- a/src/api/tests/unit/auth-mcp-static.test.ts
+++ b/src/api/tests/unit/auth-mcp-static.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for static-header (API-key) MCP auth.
+ * Issue #117: external MCP clients (e.g. LibreChat) that send fixed headers and
+ * cannot mint a per-request JWT must still authenticate, with each forwarded
+ * end-user mapped to an isolated sandbox owner.
+ */
+
+import { Hono } from "hono";
+import { SignJWT } from "jose";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type AuthVariables, type StaticMcpAuthConfig, createAuthMiddleware } from "../../auth.js";
+import type { TenantConfig } from "../../tenants.js";
+
+const SECRET = "test-secret-at-least-32-bytes-long!!";
+const API_KEY = "static-mcp-api-key-1234567890";
+const secretBytes = new TextEncoder().encode(SECRET);
+
+function makeTenantConfig(ids: readonly string[]): TenantConfig {
+	const set = new Set(ids);
+	return {
+		tenantIds: [...ids],
+		hasTenant: (id) => set.has(id),
+		getConnectionString: (id) => {
+			if (!set.has(id)) throw new Error(`Unknown tenant: ${id}`);
+			return `postgres://stub/${id}`;
+		},
+	};
+}
+
+function makeApp(staticAuth: StaticMcpAuthConfig | undefined, tenants: readonly string[] = ["default"]) {
+	const app = new Hono<{ Variables: AuthVariables }>();
+	app.use("/mcp", createAuthMiddleware(makeTenantConfig(tenants), { staticAuth }));
+	app.all("/mcp", (c) => c.json({ owner: c.get("owner"), tenant: c.get("tenant") }));
+	return app;
+}
+
+const baseConfig: StaticMcpAuthConfig = {
+	apiKey: API_KEY,
+	identityHeader: "x-librechat-user-id",
+	tenant: "default",
+};
+
+async function makeJwt(claims: Record<string, unknown>): Promise<string> {
+	return new SignJWT(claims).setProtectedHeader({ alg: "HS256" }).sign(secretBytes);
+}
+
+async function body(res: Response): Promise<{ owner?: string; tenant?: string; code?: string; error?: string }> {
+	return (await res.json()) as { owner?: string; tenant?: string; code?: string; error?: string };
+}
+
+describe("static MCP auth", () => {
+	let savedSecret: string | undefined;
+
+	beforeEach(() => {
+		savedSecret = process.env.AUTH_SECRET;
+		process.env.AUTH_SECRET = SECRET;
+	});
+
+	afterEach(() => {
+		process.env.AUTH_SECRET = savedSecret ?? "";
+	});
+
+	it("accepts the static API key and derives owner from the identity header", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "alice@example.com" },
+		});
+		expect(res.status).toBe(200);
+		expect(await body(res)).toEqual({ owner: "alice@example.com", tenant: "default" });
+	});
+
+	it("trims surrounding whitespace from the identity header value", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "  bob  " },
+		});
+		expect(res.status).toBe(200);
+		expect(await body(res)).toEqual({ owner: "bob", tenant: "default" });
+	});
+
+	it("isolates two end-users behind the same static credential", async () => {
+		const app = makeApp(baseConfig);
+		const a = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "user-a" },
+		});
+		const b = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "user-b" },
+		});
+		expect((await body(a)).owner).toBe("user-a");
+		expect((await body(b)).owner).toBe("user-b");
+	});
+
+	it("falls back to defaultSub when the identity header is absent", async () => {
+		const app = makeApp({ ...baseConfig, defaultSub: "shared-owner" });
+		const res = await app.request("/mcp", { headers: { Authorization: `Bearer ${API_KEY}` } });
+		expect(res.status).toBe(200);
+		expect(await body(res)).toEqual({ owner: "shared-owner", tenant: "default" });
+	});
+
+	it("returns 401 AUTH_IDENTITY_REQUIRED when no header and no defaultSub", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", { headers: { Authorization: `Bearer ${API_KEY}` } });
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_IDENTITY_REQUIRED");
+	});
+
+	it("returns 401 AUTH_IDENTITY_INVALID for an empty identity header", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "   " },
+		});
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_IDENTITY_INVALID");
+	});
+
+	it("uses the configured custom identity header", async () => {
+		const app = makeApp({ ...baseConfig, identityHeader: "x-user-email" });
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-user-email": "carol@example.com" },
+		});
+		expect(res.status).toBe(200);
+		expect((await body(res)).owner).toBe("carol@example.com");
+	});
+
+	it("assigns the configured static tenant", async () => {
+		const app = makeApp({ ...baseConfig, tenant: "tenant-a" }, ["default", "tenant-a"]);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "dave" },
+		});
+		expect(res.status).toBe(200);
+		expect(await body(res)).toEqual({ owner: "dave", tenant: "tenant-a" });
+	});
+
+	it("still accepts a valid JWT when static auth is enabled (falls through)", async () => {
+		const app = makeApp(baseConfig);
+		const token = await makeJwt({ sub: "jwt-agent" });
+		const res = await app.request("/mcp", { headers: { Authorization: `Bearer ${token}` } });
+		expect(res.status).toBe(200);
+		expect(await body(res)).toEqual({ owner: "jwt-agent", tenant: "default" });
+	});
+
+	it("does not derive owner from the identity header on the JWT path", async () => {
+		// A JWT caller's sub must win — the identity header is only consulted on
+		// the static-key path, so it cannot override a verified JWT principal.
+		const app = makeApp(baseConfig);
+		const token = await makeJwt({ sub: "jwt-agent" });
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${token}`, "x-librechat-user-id": "attacker" },
+		});
+		expect((await body(res)).owner).toBe("jwt-agent");
+	});
+
+	it("rejects a wrong key that is not a valid JWT with AUTH_INVALID", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: "Bearer not-the-key-and-not-a-jwt", "x-librechat-user-id": "mallory" },
+		});
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_INVALID");
+	});
+
+	it("returns 401 AUTH_REQUIRED when the Authorization header is missing", async () => {
+		const app = makeApp(baseConfig);
+		const res = await app.request("/mcp", { headers: { "x-librechat-user-id": "alice" } });
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_REQUIRED");
+	});
+
+	it("with static auth disabled, the API key value is rejected (JWT-only)", async () => {
+		const app = makeApp(undefined);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "alice" },
+		});
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_INVALID");
+	});
+
+	it("returns 401 AUTH_UNKNOWN_TENANT when the static tenant is not configured", async () => {
+		// tenant config does not include "ghost", simulating a tenant removed after startup.
+		const app = makeApp({ ...baseConfig, tenant: "ghost" }, ["default"]);
+		const res = await app.request("/mcp", {
+			headers: { Authorization: `Bearer ${API_KEY}`, "x-librechat-user-id": "alice" },
+		});
+		expect(res.status).toBe(401);
+		expect((await body(res)).code).toBe("AUTH_UNKNOWN_TENANT");
+	});
+});

--- a/src/api/tests/unit/auth-mcp-static.test.ts
+++ b/src/api/tests/unit/auth-mcp-static.test.ts
@@ -57,7 +57,12 @@ describe("static MCP auth", () => {
 	});
 
 	afterEach(() => {
-		process.env.AUTH_SECRET = savedSecret ?? "";
+		// Restore exactly — never convert an originally-undefined var into "".
+		if (savedSecret === undefined) {
+			Reflect.deleteProperty(process.env, "AUTH_SECRET");
+		} else {
+			process.env.AUTH_SECRET = savedSecret;
+		}
 	});
 
 	it("accepts the static API key and derives owner from the identity header", async () => {

--- a/src/api/tests/unit/mcp-static-config.test.ts
+++ b/src/api/tests/unit/mcp-static-config.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for loadStaticMcpAuthConfig + sanitizeIdentity (issue #117).
+ * Config is validated at load time (fail-fast at startup), not per-request.
+ */
+
+import { describe, expect, it } from "vitest";
+import { loadStaticMcpAuthConfig, sanitizeIdentity } from "../../auth.js";
+import type { TenantConfig } from "../../tenants.js";
+
+function makeTenantConfig(ids: readonly string[]): TenantConfig {
+	const set = new Set(ids);
+	return {
+		tenantIds: [...ids],
+		hasTenant: (id) => set.has(id),
+		getConnectionString: (id) => {
+			if (!set.has(id)) throw new Error(`Unknown tenant: ${id}`);
+			return `postgres://stub/${id}`;
+		},
+	};
+}
+
+const tenants = makeTenantConfig(["default", "tenant-a"]);
+const STRONG_KEY = "static-mcp-api-key-1234567890";
+
+describe("loadStaticMcpAuthConfig", () => {
+	it("returns undefined when MCP_API_KEY is unset (static auth disabled)", () => {
+		expect(loadStaticMcpAuthConfig(tenants, {})).toBeUndefined();
+	});
+
+	it("returns undefined when MCP_API_KEY is empty", () => {
+		expect(loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: "" })).toBeUndefined();
+	});
+
+	it("applies defaults: identity header x-librechat-user-id, default tenant", () => {
+		const config = loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY });
+		expect(config).toEqual({
+			apiKey: STRONG_KEY,
+			identityHeader: "x-librechat-user-id",
+			defaultSub: undefined,
+			tenant: "default",
+		});
+	});
+
+	it("lowercases and trims a custom identity header", () => {
+		const config = loadStaticMcpAuthConfig(tenants, {
+			MCP_API_KEY: STRONG_KEY,
+			MCP_IDENTITY_HEADER: "  X-User-Email  ",
+		});
+		expect(config?.identityHeader).toBe("x-user-email");
+	});
+
+	it("carries a valid defaultSub and configured tenant", () => {
+		const config = loadStaticMcpAuthConfig(tenants, {
+			MCP_API_KEY: STRONG_KEY,
+			MCP_DEFAULT_SUB: "shared-owner",
+			MCP_STATIC_TENANT: "tenant-a",
+		});
+		expect(config).toEqual({
+			apiKey: STRONG_KEY,
+			identityHeader: "x-librechat-user-id",
+			defaultSub: "shared-owner",
+			tenant: "tenant-a",
+		});
+	});
+
+	it("throws when MCP_API_KEY is shorter than 16 characters", () => {
+		expect(() => loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: "short" })).toThrow(/at least 16 characters/);
+	});
+
+	it("throws when MCP_IDENTITY_HEADER is not a valid header name", () => {
+		expect(() =>
+			loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY, MCP_IDENTITY_HEADER: "bad header" }),
+		).toThrow(/not a valid HTTP header name/);
+	});
+
+	it("throws when MCP_DEFAULT_SUB is invalid", () => {
+		expect(() =>
+			loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY, MCP_DEFAULT_SUB: "a".repeat(257) }),
+		).toThrow(/MCP_DEFAULT_SUB is invalid/);
+	});
+
+	it("throws when MCP_STATIC_TENANT is not configured", () => {
+		expect(() => loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY, MCP_STATIC_TENANT: "ghost" })).toThrow(
+			/not a configured tenant/,
+		);
+	});
+});
+
+describe("sanitizeIdentity", () => {
+	it("returns undefined for undefined input", () => {
+		expect(sanitizeIdentity(undefined)).toBeUndefined();
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(sanitizeIdentity("  alice@example.com  ")).toBe("alice@example.com");
+	});
+
+	it("returns undefined for empty / whitespace-only input", () => {
+		expect(sanitizeIdentity("")).toBeUndefined();
+		expect(sanitizeIdentity("   ")).toBeUndefined();
+	});
+
+	it("returns undefined for values longer than 256 chars", () => {
+		expect(sanitizeIdentity("a".repeat(257))).toBeUndefined();
+		expect(sanitizeIdentity("a".repeat(256))).toBe("a".repeat(256));
+	});
+
+	it("returns undefined when an internal control character is present", () => {
+		expect(sanitizeIdentity("alice\u0000bob")).toBeUndefined(); // NUL
+		expect(sanitizeIdentity("alice\nbob")).toBeUndefined(); // newline (0x0A)
+		expect(sanitizeIdentity("alice\tbob")).toBeUndefined(); // tab (0x09)
+		expect(sanitizeIdentity("alice\u007fbob")).toBeUndefined(); // DEL (0x7F)
+	});
+
+	it("allows common identity characters (@ . + - _)", () => {
+		expect(sanitizeIdentity("user.name+tag-1_2@example.com")).toBe("user.name+tag-1_2@example.com");
+	});
+});

--- a/src/api/tests/unit/mcp-static-config.test.ts
+++ b/src/api/tests/unit/mcp-static-config.test.ts
@@ -73,6 +73,30 @@ describe("loadStaticMcpAuthConfig", () => {
 		).toThrow(/not a valid HTTP header name/);
 	});
 
+	it.each([
+		"authorization",
+		"Authorization",
+		"cookie",
+		"content-type",
+		"accept",
+		"mcp-session-id",
+		"mcp-protocol-version",
+		"last-event-id",
+	])("rejects reserved identity header %p (would collapse all users to one owner)", (header) => {
+		expect(() => loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY, MCP_IDENTITY_HEADER: header })).toThrow(
+			/reserved and cannot carry a per-user identity/,
+		);
+	});
+
+	it("attaches code AUTH_CONFIG_INVALID to config validation errors", () => {
+		try {
+			loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: "short" });
+			throw new Error("expected loadStaticMcpAuthConfig to throw");
+		} catch (e) {
+			expect((e as { code?: string }).code).toBe("AUTH_CONFIG_INVALID");
+		}
+	});
+
 	it("throws when MCP_DEFAULT_SUB is invalid", () => {
 		expect(() =>
 			loadStaticMcpAuthConfig(tenants, { MCP_API_KEY: STRONG_KEY, MCP_DEFAULT_SUB: "a".repeat(257) }),


### PR DESCRIPTION
Closes #117.

## Summary
- Add an additive **static-header (API-key) auth path on `/mcp`** for MCP clients that can only send fixed headers (e.g. LibreChat) and cannot mint a per-request JWT. Setting `MCP_API_KEY` makes `/mcp` accept the pre-shared key as a Bearer token (constant-time compared); a non-matching token still falls through to JWT verification, so JWT clients on `/mcp` and all `/v1/*` routes are unchanged.
- Derive the sandbox **owner (`sub`)** from a forwarded identity header (`MCP_IDENTITY_HEADER`, default `x-librechat-user-id`), so each end-user behind one shared service credential gets an **isolated** sandbox. Optional `MCP_DEFAULT_SUB` (shared owner when the header is absent) and `MCP_STATIC_TENANT`.
- Validate config at startup (fail-fast): `MCP_API_KEY` ≥16 chars, valid header name, sanitized default sub, configured tenant. Identity values are trimmed and rejected if empty/>256 chars/contain control characters. The CORS preflight advertises the configured identity header for browser MCP clients.
- Extract the duplicated SHA-256-digest `timingSafeEqual` into `src/api/lib/constant-time.ts`, now shared by the auth middleware and the token-minting routes.
- Docs: README env table + new "MCP auth" section with a `librechat.yaml` example and security model; API skill `SETUP.md` (incl. new error-code rows); `.env.example`. Changeset added (`minor`, additive).

## Security model
- The forwarded identity header is trusted as the end-user identity, so it must be stamped by a trusted hop (proxy/LibreChat) and not be settable by untrusted callers. `MCP_API_KEY` must be kept secret and `/mcp` placed behind the ingress; cross-sandbox isolation remains enforced by RLS scoped to `(owner, tenant)`. The MCP session `(owner, tenant)` replay guard prevents a leaked session-id from being reused by a different owner.

## Testing
- `pnpm typecheck` — pass
- `pnpm lint:fix` — pass (no fixes)
- `pnpm test:unit` — 904 passed (29 new across `auth-mcp-static.test.ts` and `mcp-static-config.test.ts`)
- Integration tests not run (no SQL/DB-layer changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added static header (API-key) authentication for MCP endpoints as an alternative authentication method.
  * Introduced configurable identity header support to derive sandbox ownership from forwarded identity information.

* **Documentation**
  * Updated environment variable documentation with new MCP authentication configuration options.
  * Added authentication guides and examples for static-header authentication setup.

* **Tests**
  * Added comprehensive unit tests for static-header authentication and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->