### PR TITLE
fix(dev): complete local Postgres dev setup (#119)

### DIFF
--- a/.changeset/local-postgres-dev-setup.md
+++ b/.changeset/local-postgres-dev-setup.md
@@ -1,0 +1,20 @@
+---
+"sql-fs-api": patch
+---
+
+Fix local Postgres dev setup for the integration test suite (#119).
+
+- Add `docker-compose.local.yml` (Postgres 16 + Redis 7). Its `initdb` script
+  (`scripts/initdb/00-create-app-role.sql`) provisions a **non-superuser** `sqlfs_app`
+  role that owns the `sqlfs` database — required because migration `0005` enables
+  `FORCE ROW LEVEL SECURITY`, which a superuser silently bypasses (the RLS isolation
+  tests fail under the default `postgres` superuser). The file was previously
+  referenced by the README but `.gitignore`d, so it could never be committed.
+- Document the non-superuser-owner requirement and the full local-DB workflow in
+  `CONTRIBUTING.md` (new "Local database" section).
+- Correct the `DATABASE_DIRECT_URL` row in the README env table: it is optional and
+  used only by drizzle-kit (`pnpm db:generate`); the server's boot-time migration
+  runner uses `DATABASE_URL`.
+- Update `.env.example` defaults to match the compose stack.
+- Remove the broken, unused `pnpm db:migrate` script (drizzle-kit `migrate` with no
+  journal). Migrations are applied automatically on server boot.

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
 # ── Required ──────────────────────────────────────────────────────────────────
 
 FS_BACKEND=postgres
-DATABASE_URL=postgres://user:password@localhost:5432/sqlfs
-DATABASE_DIRECT_URL=postgres://user:password@localhost:5432/sqlfs
-AUTH_SECRET=replace-with-a-long-random-secret
+
+# Defaults match docker-compose.local.yml: a NON-SUPERUSER `sqlfs_app` role that
+# OWNS the `sqlfs` database. This is required, not cosmetic — migration 0005 uses
+# FORCE ROW LEVEL SECURITY, which a superuser silently bypasses. See
+# CONTRIBUTING.md → "Local database".
+DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs
+
+AUTH_SECRET=local-dev-only-secret-change-me-please
+
+# Optional — direct (non-pooler) connection used ONLY by drizzle-kit
+# (pnpm db:generate). The server's boot-time migration runner uses DATABASE_URL.
+# Defaults to DATABASE_URL when unset.
+# DATABASE_DIRECT_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs
 
 # ── Optional: server ──────────────────────────────────────────────────────────
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ dist/
 *.tsbuildinfo
 .claude/worktrees/
 docs/
-docker-compose.local.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ HTTP/MCP Client → Hono API → Session Manager → Bash (just-bash) → IFileS
 
 ```bash
 # Development
-pnpm dev                    # Start dev server with hot reload (tsx watch)
+pnpm dev                    # Start dev server with hot reload (tsx watch) on a fixed port (PORT, default 8080)
+pnpm dev:portless           # Preferred: run the dev server on a dynamic port behind a stable https://sql-fs.localhost URL (portless)
 pnpm build                  # Compile TypeScript to dist/
 pnpm start                  # Run production server from dist/
 
@@ -31,8 +32,8 @@ pnpm test:integration       # Integration tests (requires DB — skips if unavai
 pnpm test -- src/sql-fs/sql-fs.cache.test.ts   # Run specific test file
 
 # Database
-pnpm db:generate            # Generate Drizzle migrations from schema changes
-pnpm db:migrate             # Apply migrations to database
+pnpm db:generate            # Scaffold a new migration SQL from schema changes (drizzle-kit)
+                            # Migrations are APPLIED automatically on server boot (src/api/migrations.ts), not by a CLI
 pnpm db:gc                  # Run blob garbage collection
 
 # Docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,85 @@ Thank you for your interest. This guide covers everything you need to go from ze
 git clone https://github.com/your-org/sql-fs-api.git
 cd sql-fs-api
 pnpm install
-cp .env.example .env        # fill in DATABASE_URL and AUTH_SECRET at minimum
+cp .env.example .env        # defaults target the local compose stack (below)
 pnpm dev                    # dev server at http://localhost:8080
 ```
+
+## Local database
+
+The unit tests need no database, but the **integration suite** (`pnpm test:integration`)
+requires Postgres (and, for the distributed-lock / cache suites, Redis). The fastest
+way to get both is the bundled compose stack:
+
+```bash
+docker compose -f docker-compose.local.yml up -d
+```
+
+This starts Postgres + Redis and runs `scripts/initdb/00-create-app-role.sql`, which
+provisions a **non-superuser** role `sqlfs_app` that **owns** the `sqlfs` database.
+Point your connection strings at it (these are the defaults baked into `.env.example`):
+
+```bash
+export DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs
+export REDIS_URL=redis://localhost:6379
+```
+
+### Why a non-superuser owner role (do not use the default `postgres` user)
+
+Migration `0005_enable_rls.sql` turns on `FORCE ROW LEVEL SECURITY` for sandbox
+isolation. The connecting role therefore has hard requirements that aren't obvious:
+
+- **Not a superuser.** A superuser (the `postgres` image's default role) has
+  `BYPASSRLS` and **silently bypasses** the policy. The RLS suite then fails with
+  confusing errors — under "sandbox A's context", queries return rows from *every*
+  sandbox.
+- **Owns the schema and tables.** The boot-time migration runner creates objects in
+  `public`, and `rls.integration.test.ts` re-applies `0005`'s
+  `ALTER TABLE … FORCE ROW LEVEL SECURITY`, which requires table ownership (a
+  non-owner fails with `must be owner of table inodes` / `permission denied for schema public`).
+- **`CREATEDB`.** The multi-tenant and migrations suites create ephemeral databases
+  at runtime from `DATABASE_URL`.
+
+The compose `initdb` script sets all three up for you. If you bring your own Postgres,
+mirror it (Postgres 16):
+
+```sql
+CREATE ROLE sqlfs_app LOGIN PASSWORD 'sqlfs_app' NOSUPERUSER NOBYPASSRLS CREATEDB;
+CREATE DATABASE sqlfs OWNER sqlfs_app;
+\connect sqlfs
+ALTER SCHEMA public OWNER TO sqlfs_app;   -- PG15+: lets the migration runner CREATE in public
+```
+
+### Applying migrations
+
+There is no manual migrate step — the server applies every migration in
+`src/sql-fs/migrations/postgres/` on boot (`src/api/migrations.ts`). Start it once
+against the compose database to create the schema before running the integration suite:
+
+```bash
+DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs pnpm dev   # creates tables on boot; stop once it logs "server_start"
+```
+
+(`pnpm db:generate` only *scaffolds* a new migration SQL from `schema.ts`; it does not apply anything.)
+
+### Running the suite
+
+```bash
+DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs \
+REDIS_URL=redis://localhost:6379 \
+pnpm test:integration
+```
+
+All suites share one database, so a fully parallel run can occasionally hit transient
+`deadlock detected` errors (DDL-vs-DML lock contention between files). If you see one,
+re-run serialized — it's not a real failure:
+
+```bash
+pnpm test:integration -- --no-file-parallelism --poolOptions.forks.singleFork
+```
+
+Reset the database to a clean slate (re-runs the `initdb` script) with
+`docker compose -f docker-compose.local.yml down -v`.
 
 ## Development workflow
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,31 @@ Most sandbox platforms still spin up full VMs—slow cold starts and per-minute 
 
 ```bash
 cp .env.example .env          # set DATABASE_URL and AUTH_SECRET
-pnpm db:migrate               # apply migrations
-pnpm dev                      # server at http://localhost:8080
+pnpm dev                      # applies migrations on first boot, serves at http://localhost:8080
 ```
+
+Migrations run automatically when the server boots (`src/api/migrations.ts`); there
+is no separate migrate step. (`pnpm db:generate` scaffolds a new migration SQL from
+`schema.ts` changes via drizzle-kit; the boot-time runner then applies it.)
 
 ### Docker Compose
 
+Spin up a local Postgres + Redis for development and the integration test suite:
+
 ```bash
-docker-compose -f docker-compose.local.yml up
+docker compose -f docker-compose.local.yml up -d
+```
+
+This provisions a **non-superuser** `sqlfs_app` role that owns the `sqlfs`
+database — required, because migration `0005` enables `FORCE ROW LEVEL SECURITY`
+and a superuser silently bypasses it. See
+[CONTRIBUTING.md → Local database](CONTRIBUTING.md#local-database). Then point the
+server (or tests) at the stack:
+
+```bash
+export DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs
+export REDIS_URL=redis://localhost:6379
+pnpm dev                      # or: pnpm test:integration
 ```
 
 ## Typical Agent Workflow
@@ -143,7 +160,7 @@ Key design choices:
 |---|---|---|---|
 | `FS_BACKEND` | Yes | — | `postgres` \| `memory` |
 | `DATABASE_URL` | Yes (postgres) | — | Postgres connection string (use pooler endpoint for Neon) |
-| `DATABASE_DIRECT_URL` | Yes (postgres) | — | Direct connection for DDL / migrations |
+| `DATABASE_DIRECT_URL` | No | `DATABASE_URL` | Direct (non-pooler) connection used **only** by drizzle-kit (`pnpm db:generate`). The server's boot-time migration runner uses `DATABASE_URL`. Falls back to `DATABASE_URL` when unset. |
 | `AUTH_SECRET` | Yes | — | Secret for Bearer token validation |
 | `PORT` | No | `8080` | HTTP server port |
 | `SESSION_IDLE_MS` | No | `600000` | Evict idle Bash instances after this many ms |
@@ -193,8 +210,7 @@ pnpm lint:fix               # format + lint (Biome)
 pnpm test:unit              # unit tests — no DB required
 pnpm test:integration       # integration tests — requires DATABASE_URL
 pnpm test                   # all tests
-pnpm db:generate            # generate Drizzle migrations from schema changes
-pnpm db:migrate             # apply migrations
+pnpm db:generate            # scaffold a new migration SQL from schema changes (applied on server boot)
 pnpm db:gc                  # garbage-collect orphan blobs
 pnpm changeset              # record a version bump for the next release
 ```

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,50 @@
+# Local backing services for sql-fs development and the integration test suite.
+#
+#   docker compose -f docker-compose.local.yml up -d
+#
+#   DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs \
+#   REDIS_URL=redis://localhost:6379 \
+#   pnpm test:integration
+#
+# Postgres is provisioned by scripts/initdb/00-create-app-role.sql with a
+# NON-SUPERUSER role `sqlfs_app` that OWNS the `sqlfs` database. This is required,
+# not cosmetic:
+# migration 0005 enables FORCE ROW LEVEL SECURITY, and a superuser (the postgres
+# image's default role) silently bypasses RLS via BYPASSRLS — which makes the
+# RLS isolation tests fail. Always connect as `sqlfs_app`, never as the
+# bootstrap `postgres` superuser. See CONTRIBUTING.md → "Local database".
+#
+# Reset to a clean database (re-runs the initdb script):
+#   docker compose -f docker-compose.local.yml down -v
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      # Bootstrap superuser — used only to run the initdb script below. The app
+      # and tests connect as the non-superuser `sqlfs_app` role it creates.
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./scripts/initdb:/docker-entrypoint-initdb.d:ro
+      - sqlfs-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+volumes:
+  sqlfs-pgdata:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"test:integration": "vitest run src/sql-fs/tests/integration src/api/tests/integration",
 		"test:comparison": "vitest run --config vitest.comparison.config.ts",
 		"db:generate": "drizzle-kit generate",
-		"db:migrate": "drizzle-kit migrate",
 		"db:gc": "tsx src/api/cli/gc.ts",
 		"token:create": "tsx src/api/cli/token.ts",
 		"changeset": "changeset",

--- a/scripts/initdb/00-create-app-role.sql
+++ b/scripts/initdb/00-create-app-role.sql
@@ -1,0 +1,29 @@
+-- Provision the sql-fs application role for local dev / integration tests.
+--
+-- This directory is mounted into /docker-entrypoint-initdb.d by
+-- docker-compose.local.yml, so every *.sql here runs ONCE, as the bootstrap
+-- superuser, on first Postgres container start.
+--
+-- WHY A NON-SUPERUSER OWNER ROLE — do NOT "simplify" this to the default
+-- `postgres` superuser:
+--   * Migration 0005 enables FORCE ROW LEVEL SECURITY on inodes/dirents/sandboxes.
+--     A superuser has BYPASSRLS and SILENTLY bypasses the policy, so the RLS
+--     isolation suite (rls.integration.test.ts) fails with confusing errors —
+--     under "sandbox A's context" the queries return rows from every sandbox.
+--   * The role must OWN the database and the public schema: the migration runner
+--     CREATEs objects in `public`, and the RLS suite re-applies 0005's
+--     `ALTER TABLE ... FORCE ROW LEVEL SECURITY`, which requires table ownership
+--     (a non-owner fails with `must be owner of table inodes`).
+--   * CREATEDB is required because some integration suites (multi-tenant routing,
+--     migrations) create ephemeral databases at runtime from DATABASE_URL.
+--
+-- Point DATABASE_URL at this role, NOT at the bootstrap `postgres` superuser:
+--   DATABASE_URL=postgres://sqlfs_app:sqlfs_app@localhost:5432/sqlfs
+
+CREATE ROLE sqlfs_app LOGIN PASSWORD 'sqlfs_app' NOSUPERUSER NOBYPASSRLS CREATEDB;
+CREATE DATABASE sqlfs OWNER sqlfs_app;
+
+-- PG15+ no longer grants CREATE on `public` to non-owners by default, so the
+-- migration runner cannot create tables until the app role owns the schema.
+\connect sqlfs
+ALTER SCHEMA public OWNER TO sqlfs_app;


### PR DESCRIPTION
## Summary

Closes #119. Makes a fresh local Postgres setup work out of the box so a new contributor can get `pnpm test:integration` green without reverse-engineering the RLS requirements.

## What was wrong

1. **`docker-compose.local.yml` referenced but uncommittable.** The README pointed at it, but it was listed in `.gitignore` — so it could never have been committed (`git log --all` shows it never existed).
2. **Superuser silently bypasses RLS.** Migration `0005` enables `FORCE ROW LEVEL SECURITY`. The `postgres` image's default role is a superuser with `BYPASSRLS`, so it silently defeats the policy — `rls.integration.test.ts` then fails with "sandbox A's context sees every sandbox". A non-owner role instead fails suite setup with `must be owner of table inodes`. Only a **non-superuser role that owns the schema** passes.
3. **`DATABASE_DIRECT_URL` mislabeled.** Documented as `Yes (postgres)` / "required for migrations", but the boot-time migration runner uses `DATABASE_URL`; `DATABASE_DIRECT_URL` is consumed only by drizzle-kit.
4. **Bonus:** `pnpm db:migrate` was broken (drizzle-kit `migrate` with no journal) and unused — the server applies migrations on boot.

## Changes

- **`docker-compose.local.yml`** (new) — Postgres 16 + Redis 7. Its initdb script `scripts/initdb/00-create-app-role.sql` provisions a non-superuser `sqlfs_app` role (`NOSUPERUSER NOBYPASSRLS CREATEDB`) that owns the `sqlfs` database and `public` schema. Un-ignored in `.gitignore`.
- **`CONTRIBUTING.md`** — new "Local database" section: the non-superuser-owner requirement and why, the full local-DB workflow, and a note on the shared-DB parallelism deadlock (re-run serialized).
- **`README.md`** — rewrote the Docker Compose section; corrected the `DATABASE_DIRECT_URL` env row; documented that migrations apply on server boot.
- **`.env.example`** — defaults now target the compose stack; `DATABASE_DIRECT_URL` marked optional.
- **`package.json` / `CLAUDE.md`** — removed the broken/unused `db:migrate` script and references; documented `pnpm dev:portless` for dynamic-port local dev.

## Testing

Reproduced all findings against a real Postgres 16, then validated the fix:

- RLS suite as the default superuser: **3 failed**; as a non-owner: `must be owner of table inodes`; as the new `sqlfs_app` owner role: **5 passed**.
- Full integration suite against the compose stack (serialized): **16 files / 105 tests passed** — matches the issue author. (Fully-parallel runs can hit transient `deadlock detected` from shared-DB DDL/DML contention; confirmed flaky — affected tests pass in isolation.)
- **Developer E2E smoke test:** `cp .env.example .env` → `pnpm dev` applied all 6 migrations on boot → `/healthz` ok → minted JWT → create sandbox → exec write → exec read-back (persistence) → delete→404.
- **`pnpm dev:portless`:** verified the injected dynamic `PORT` is honored (server bound `:4567`) and migrations still ran on boot against the compose Postgres.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Docker Compose configuration for local PostgreSQL and Redis development environment.
  * Migrations now run automatically on server boot.

* **Documentation**
  * Enhanced local development setup documentation with detailed database configuration steps.
  * Clarified environment variable usage and development workflow.

* **Chores**
  * Removed manual migration command from development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->