### PR TITLE
feat(gc): multi-tenant orphan-blob garbage collection via pnpm db:gc

### DIFF
--- a/.changeset/nlink-zero-tombstone-fix.md
+++ b/.changeset/nlink-zero-tombstone-fix.md
@@ -1,0 +1,9 @@
+---
+"sql-fs-api": patch
+---
+
+fix(fs): delete inodes when their link count reaches zero (no `nlink=0` tombstones).
+
+The Postgres `rmComposite`, `writeFileComposite`, and `mvComposite` paths decremented an inode's `nlink` and deleted it (when it hit 0) within a single CTE statement. Postgres applies **only the UPDATE** when a row is both updated and deleted in one statement, so the inode was left at `nlink=0` instead of being removed — a tombstone that still referenced `content_sha256`. This pinned the blob (defeating the new orphan-blob GC, whose anti-join saw the tombstone) and leaked inode rows on every file delete, overwrite, and move-overwrite.
+
+Each path now splits the work into two mutually-exclusive branches against the statement snapshot — delete when `nlink <= 1`, decrement when `nlink > 1` — so each inode row is touched exactly once. `gcOrphanBlobs` additionally ignores `nlink = 0` inodes so blobs pinned by tombstones left behind by older builds become collectible. Hardlinked inodes are unaffected (still decremented, not deleted, while other links remain).

--- a/.changeset/orphan-blob-gc.md
+++ b/.changeset/orphan-blob-gc.md
@@ -1,0 +1,12 @@
+---
+"sql-fs-api": minor
+---
+
+feat(gc): multi-tenant orphan-blob garbage collection via `pnpm db:gc`.
+
+Restores the `pnpm db:gc` CLI as a real, multi-tenant orphan-blob sweep for an external scheduler (cron / k8s CronJob). Orphan blobs (rows in `blobs` referenced by zero `inodes`) previously accumulated forever.
+
+- New migration `0006` adds `blobs.last_referenced_at` (instant, catalog-only — legacy rows stay NULL and are treated as ancient/collectible). Every blob reference (insert + dedup re-adoption) now bumps it via `ON CONFLICT (sha256) DO UPDATE`; that row lock serializes a re-adopting writer against GC's `DELETE`, closing the dedup re-adoption race (silent content loss).
+- `gcOrphanBlobs` rewritten to a null-safe `NOT EXISTS` anti-join with a grace window (`minAgeMs`), returning the deleted sha256s. It runs with no sandbox context (RLS escape) so the anti-join sees every inode; a blob referenced by another sandbox survives.
+- Deleted blobs are purged from the tenant-scoped Redis blob cache (`RedisBlobCache.mdel`, fail-open).
+- New env `BLOB_GC_MIN_AGE_MS` (default 3h) sets the grace window; `pnpm db:gc -- --min-age-ms 0` collects all orphans now, `--tenant <id>` restricts to one tenant.

--- a/.changeset/orphan-blob-gc.md
+++ b/.changeset/orphan-blob-gc.md
@@ -6,7 +6,8 @@ feat(gc): multi-tenant orphan-blob garbage collection via `pnpm db:gc`.
 
 Restores the `pnpm db:gc` CLI as a real, multi-tenant orphan-blob sweep for an external scheduler (cron / k8s CronJob). Orphan blobs (rows in `blobs` referenced by zero `inodes`) previously accumulated forever.
 
-- New migration `0006` adds `blobs.last_referenced_at` (instant, catalog-only — legacy rows stay NULL and are treated as ancient/collectible). Every blob reference (insert + dedup re-adoption) now bumps it via `ON CONFLICT (sha256) DO UPDATE`; that row lock serializes a re-adopting writer against GC's `DELETE`, closing the dedup re-adoption race (silent content loss).
+- New migration `0006` adds `blobs.last_referenced_at` (instant, catalog-only — legacy rows stay NULL and are treated as ancient/collectible). Every blob reference (insert + dedup re-adoption) now bumps it via `ON CONFLICT (sha256) DO UPDATE`, which also touches the blob so the grace window tracks real usage.
 - `gcOrphanBlobs` rewritten to a null-safe `NOT EXISTS` anti-join with a grace window (`minAgeMs`), returning the deleted sha256s. It runs with no sandbox context (RLS escape) so the anti-join sees every inode; a blob referenced by another sandbox survives.
+- The sweep runs at **REPEATABLE READ with bounded retries** to close the dedup re-adoption race: under READ COMMITTED a concurrent writer that re-adopts an existing orphan blob could leave its committed inode without content (the GC's `NOT EXISTS` re-check keeps a stale snapshot of `inodes`). REPEATABLE READ turns that conflict into a serialization failure that is retried, so even `--min-age-ms 0` is safe under concurrent writes.
 - Deleted blobs are purged from the tenant-scoped Redis blob cache (`RedisBlobCache.mdel`, fail-open).
 - New env `BLOB_GC_MIN_AGE_MS` (default 3h) sets the grace window; `pnpm db:gc -- --min-age-ms 0` collects all orphans now, `--tenant <id>` restricts to one tenant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pnpm test -- src/sql-fs/sql-fs.cache.test.ts   # Run specific test file
 # Database
 pnpm db:generate            # Scaffold a new migration SQL from schema changes (drizzle-kit)
                             # Migrations are APPLIED automatically on server boot (src/api/migrations.ts), not by a CLI
-pnpm db:gc                  # Run blob garbage collection
+pnpm db:gc                  # Run multi-tenant orphan-blob GC (external scheduler; see BLOB_GC_MIN_AGE_MS)
 
 # Docker
 docker build -t sql-fs-api .
@@ -83,7 +83,8 @@ HTTP Request → Auth Middleware → Route Handler → Session Manager → Bash.
 - `routes/files.ts` — File ops: read, write, delete, mkdir, bulk write, tree listing
 - `routes/exec.ts` — Bash execution: sync (JSON) and streaming (SSE)
 - `routes/ingest.ts` — Ingest (tar.gz / JSON manifest) and export (tar.gz download)
-- `routes/admin.ts` — Admin endpoints (blob GC)
+- `blob-gc.ts` — Multi-tenant orphan-blob GC orchestrator (`runBlobGc`); invoked by `cli/gc.ts`
+- `cli/gc.ts` — Blob GC CLI (`pnpm db:gc`), for an external cron / k8s CronJob
 - `mcp/server.ts` — MCP server setup with streamable HTTP transport
 - `mcp/tools.ts` — 10 MCP tool definitions and handlers
 
@@ -219,6 +220,7 @@ const TABLE = Object.assign(Object.create(null) as Record<string, string>, {
 | `REDIS_PATH_SNAPSHOT_TTL_MS` | No (default: 3600000) | TTL for path snapshot entries (ms, default 1h). |
 | `JUST_BASH_DEFENSE_IN_DEPTH` | No (default: `false`) | Enables just-bash's defense-in-depth security layer (monkey-patches `setTimeout`, `eval`, `Function`, dynamic `import`, etc. for the duration of `bash.exec`). All Postgres I/O is wrapped in `DefenseInDepthBox.runTrustedAsync` to remain compatible. |
 | `JUST_BASH_DEFENSE_AUDIT_MODE` | No (default: `true`) | When `JUST_BASH_DEFENSE_IN_DEPTH=true`, controls whether violations throw (`false`) or are logged only (`true`). Recommended `true` for initial rollout, then flip to `false` once logs are clean. |
+| `BLOB_GC_MIN_AGE_MS` | No (default: 10800000) | Grace window (ms, default 3h) before an orphan blob becomes collectible by `pnpm db:gc`. Orphans whose `last_referenced_at` is newer than this are kept; the `ON CONFLICT DO UPDATE` row lock on blob writes is the actual dedup re-adoption race guard — this window is churn/margin control. Rows with NULL `last_referenced_at` (legacy, pre-migration-0006) are treated as ancient and always collectible. Override per-run with `--min-age-ms`. |
 
 ## File Layout
 
@@ -245,17 +247,17 @@ src/
     validation.ts                ← Zod middleware
     session-manager.ts           ← Warm Bash instance pool
     errors.ts                    ← HTTP error helpers
+    blob-gc.ts                   ← Orphan-blob GC orchestrator (runBlobGc)
     routes/
       sandboxes.ts               ← CRUD
       files.ts                   ← File operations
       exec.ts                    ← Bash execution (sync + SSE)
       ingest.ts                  ← Ingest/export
-      admin.ts                   ← GC endpoint
     mcp/
       server.ts                  ← MCP server
       tools.ts                   ← Tool definitions + handlers
     cli/
-      gc.ts                      ← Blob GC CLI
+      gc.ts                      ← Blob GC CLI (pnpm db:gc)
     tests/                       ← API unit + e2e tests (integration/ inside)
 ```
 

--- a/src/api/blob-gc.ts
+++ b/src/api/blob-gc.ts
@@ -1,0 +1,59 @@
+import type { Redis } from "ioredis";
+import { PostgresDialect } from "../sql-fs/dialects/postgres.js";
+import { RedisBlobCache } from "../sql-fs/redis-blob-cache.js";
+import type { TenantConfig } from "./tenants.js";
+
+export interface BlobGcOptions {
+	readonly minAgeMs: number;
+	readonly redis?: Redis;
+	readonly blobCacheEnabled?: boolean;
+	/** Restrict to these tenant ids; defaults to all configured tenants. */
+	readonly tenantIds?: readonly string[];
+}
+
+export interface BlobGcTenantResult {
+	readonly tenantId: string;
+	readonly deleted: number;
+	readonly error?: string;
+}
+
+/**
+ * Strip credentials from any connection-string-like substring before logging.
+ * A per-tenant failure logs `err.message`, which for some driver / DNS / TLS
+ * errors can echo the DSN; redacting the `user:pass@` userinfo keeps secrets
+ * out of operator logs (CLAUDE.md: no connection strings in errors).
+ */
+function redactCredentials(message: string): string {
+	return message.replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]*@/gi, "$1***@");
+}
+
+/**
+ * Garbage-collect orphan blobs across tenants. Each tenant gets a dedicated
+ * dialect connection that NEVER sets a sandbox context, so the RLS escape
+ * (migration 0005) lets the anti-join see every inode. Resilient: a per-tenant
+ * failure is logged and recorded, and the remaining tenants still run.
+ */
+export async function runBlobGc(tenantConfig: TenantConfig, opts: BlobGcOptions): Promise<BlobGcTenantResult[]> {
+	const tenantIds = opts.tenantIds ?? tenantConfig.tenantIds;
+	const results: BlobGcTenantResult[] = [];
+	for (const tenantId of tenantIds) {
+		const url = tenantConfig.getConnectionString(tenantId);
+		const dialect = new PostgresDialect(url);
+		try {
+			await dialect.connect();
+			const deleted = await dialect.transaction((tx) => dialect.gcOrphanBlobs(tx, opts.minAgeMs));
+			if (deleted.length > 0 && opts.redis && opts.blobCacheEnabled !== false) {
+				await new RedisBlobCache(opts.redis, tenantId).mdel(deleted);
+			}
+			console.log(JSON.stringify({ event: "blob_gc_tenant_ok", tenantId, deleted: deleted.length }));
+			results.push({ tenantId, deleted: deleted.length });
+		} catch (err) {
+			const message = redactCredentials(err instanceof Error ? err.message : String(err));
+			console.error(JSON.stringify({ event: "blob_gc_tenant_failed", tenantId, error: message }));
+			results.push({ tenantId, deleted: 0, error: message });
+		} finally {
+			await dialect.disconnect().catch(() => {});
+		}
+	}
+	return results;
+}

--- a/src/api/blob-gc.ts
+++ b/src/api/blob-gc.ts
@@ -27,6 +27,39 @@ function redactCredentials(message: string): string {
 	return message.replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]*@/gi, "$1***@");
 }
 
+/** Postgres SQLSTATEs that mean "retry the whole transaction". */
+const RETRYABLE_SQLSTATES = new Set(["40001", "40P01"]); // serialization_failure, deadlock_detected
+const MAX_GC_ATTEMPTS = 5;
+
+function isRetryable(err: unknown): boolean {
+	const code = (err as { code?: unknown }).code;
+	return typeof code === "string" && RETRYABLE_SQLSTATES.has(code);
+}
+
+/**
+ * Run the orphan-blob sweep at REPEATABLE READ, retrying on serialization
+ * failure. The isolation level is load-bearing for correctness: a concurrent
+ * dedup re-adoption (writer touches+locks an existing orphan blob, then inserts
+ * its inode) would, under READ COMMITTED, let GC delete the freshly-referenced
+ * blob (EvalPlanQual re-checks the blob row but not the inode anti-join). At
+ * REPEATABLE READ that conflict raises 40001 and we retry, by which point the
+ * inode is committed and the blob is correctly kept.
+ */
+async function gcOrphanBlobsRetrying(dialect: PostgresDialect, minAgeMs: number): Promise<Uint8Array[]> {
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= MAX_GC_ATTEMPTS; attempt++) {
+		try {
+			return await dialect.transaction((tx) => dialect.gcOrphanBlobs(tx, minAgeMs), {
+				isolationLevel: "repeatable read",
+			});
+		} catch (err) {
+			lastErr = err;
+			if (!isRetryable(err) || attempt === MAX_GC_ATTEMPTS) throw err;
+		}
+	}
+	throw lastErr; // unreachable: the loop either returns or throws
+}
+
 /**
  * Garbage-collect orphan blobs across tenants. Each tenant gets a dedicated
  * dialect connection that NEVER sets a sandbox context, so the RLS escape
@@ -41,7 +74,7 @@ export async function runBlobGc(tenantConfig: TenantConfig, opts: BlobGcOptions)
 		const dialect = new PostgresDialect(url);
 		try {
 			await dialect.connect();
-			const deleted = await dialect.transaction((tx) => dialect.gcOrphanBlobs(tx, opts.minAgeMs));
+			const deleted = await gcOrphanBlobsRetrying(dialect, opts.minAgeMs);
 			if (deleted.length > 0 && opts.redis && opts.blobCacheEnabled !== false) {
 				await new RedisBlobCache(opts.redis, tenantId).mdel(deleted);
 			}

--- a/src/api/cli/gc.ts
+++ b/src/api/cli/gc.ts
@@ -1,0 +1,100 @@
+/**
+ * CLI: Garbage-collect orphan blobs across tenants.
+ * US-014 (Phase 4)
+ *
+ * Usage:
+ *   pnpm db:gc                       # grace from BLOB_GC_MIN_AGE_MS (default 3h)
+ *   pnpm db:gc -- --min-age-ms 0     # collect all orphans now (ignore grace)
+ *   pnpm db:gc -- --tenant tenant-a  # restrict to one tenant
+ *
+ * Each tenant is collected with a dedicated, context-less Postgres connection
+ * so the RLS escape lets the anti-join see every inode. A per-tenant failure is
+ * logged and recorded; the remaining tenants still run. Exits non-zero if any
+ * tenant failed.
+ */
+
+import { closeRedisClient, getRedisClient } from "../../redis/client.js";
+import { parseNonNegativeInt } from "../../redis/config.js";
+import { runBlobGc } from "../blob-gc.js";
+import { loadTenantConfig } from "../tenants.js";
+
+interface CliArgs {
+	minAgeMs: string | undefined;
+	tenant: string | undefined;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	let minAgeMs: string | undefined;
+	let tenant: string | undefined;
+
+	const readValue = (flag: string, index: number): string => {
+		const next = argv[index + 1];
+		if (next === undefined || next.startsWith("--")) {
+			throw Object.assign(new Error(`Missing value for ${flag}`), { code: "EINVAL" });
+		}
+		return next;
+	};
+
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--min-age-ms") {
+			minAgeMs = readValue("--min-age-ms", i);
+			i++;
+		} else if (argv[i] === "--tenant") {
+			tenant = readValue("--tenant", i);
+			i++;
+		}
+	}
+
+	return { minAgeMs, tenant };
+}
+
+async function main(): Promise<void> {
+	const { minAgeMs: minAgeMsArg, tenant } = parseArgs(process.argv.slice(2));
+
+	let minAgeMs: number;
+	if (minAgeMsArg !== undefined) {
+		const parsed = Number(minAgeMsArg);
+		if (!Number.isInteger(parsed) || parsed < 0) {
+			process.stderr.write(`Error: --min-age-ms must be a non-negative integer (got "${minAgeMsArg}").\n`);
+			process.exit(1);
+		}
+		minAgeMs = parsed;
+	} else {
+		minAgeMs = parseNonNegativeInt("BLOB_GC_MIN_AGE_MS", 3 * 60 * 60 * 1000);
+	}
+
+	const tenantConfig = loadTenantConfig();
+
+	let tenantIds: readonly string[] | undefined;
+	if (tenant !== undefined) {
+		if (!tenantConfig.hasTenant(tenant)) {
+			process.stderr.write(`Error: unknown tenant "${tenant}".\n`);
+			process.exit(1);
+		}
+		tenantIds = [tenant];
+	}
+
+	const redis = getRedisClient();
+	const blobCacheEnabled = process.env.REDIS_BLOB_CACHE_ENABLED !== "false";
+
+	const results = await runBlobGc(tenantConfig, {
+		minAgeMs,
+		redis: redis ?? undefined,
+		blobCacheEnabled,
+		...(tenant ? { tenantIds } : {}),
+	});
+
+	const total = results.reduce((n, r) => n + r.deleted, 0);
+	const failed = results.filter((r) => r.error);
+
+	console.log(JSON.stringify({ event: "blob_gc_complete", total, tenants: results.length, failed: failed.length }));
+
+	await closeRedisClient();
+
+	if (failed.length > 0) process.exit(1);
+}
+
+main().catch((err) => {
+	process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+	process.exit(1);
+});

--- a/src/api/tests/unit/blob-gc.test.ts
+++ b/src/api/tests/unit/blob-gc.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the multi-tenant blob GC orchestrator `runBlobGc`.
+ * US-014 (Phase 4)
+ *
+ * The SUT constructs `new PostgresDialect(url)` and `new RedisBlobCache(redis, tenantId)`
+ * internally, so both modules are mocked. `vi.mock` factories are hoisted above
+ * imports and cannot close over normal top-level variables, so the shared mutable
+ * mock-state object is created via `vi.hoisted` and referenced inside the factories.
+ */
+
+import type { Redis } from "ioredis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runBlobGc } from "../../blob-gc.js";
+import type { TenantConfig } from "../../tenants.js";
+
+const OK_URL = "postgres://localhost/ok";
+const BOOM_URL = "postgres://localhost/boom";
+
+const SHA_T1: Uint8Array[] = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])];
+
+const state = vi.hoisted(() => ({
+	connected: [] as string[],
+	disconnected: [] as string[],
+	minAgeMsSeen: [] as number[],
+	mdelCalls: [] as Array<{ tenantId: string; shas: ReadonlyArray<Uint8Array> }>,
+	// Per-url configured GC return values.
+	gcReturns: new Map<string, Uint8Array[]>(),
+}));
+
+vi.mock("../../../sql-fs/dialects/postgres.js", () => ({
+	PostgresDialect: class {
+		readonly #url: string;
+		constructor(url: string) {
+			this.#url = url;
+		}
+		async connect(): Promise<void> {
+			state.connected.push(this.#url);
+			if (this.#url.includes("boom")) {
+				throw new Error("connect failed: boom");
+			}
+		}
+		async disconnect(): Promise<void> {
+			state.disconnected.push(this.#url);
+		}
+		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+			return fn({});
+		}
+		async gcOrphanBlobs(_tx: unknown, minAgeMs: number): Promise<Uint8Array[]> {
+			state.minAgeMsSeen.push(minAgeMs);
+			return state.gcReturns.get(this.#url) ?? [];
+		}
+	},
+}));
+
+vi.mock("../../../sql-fs/redis-blob-cache.js", () => ({
+	RedisBlobCache: class {
+		readonly #tenantId: string;
+		constructor(_client: unknown, tenantId: string) {
+			this.#tenantId = tenantId;
+		}
+		async mdel(shas: ReadonlyArray<Uint8Array>): Promise<void> {
+			state.mdelCalls.push({ tenantId: this.#tenantId, shas });
+		}
+	},
+}));
+
+function makeTenantConfig(): TenantConfig {
+	const map = new Map<string, string>([
+		["t1", OK_URL],
+		["t2", BOOM_URL],
+	]);
+	return {
+		tenantIds: ["t1", "t2"],
+		hasTenant: (id) => map.has(id),
+		getConnectionString: (id) => {
+			const v = map.get(id);
+			if (v === undefined) throw new Error(`Unknown tenant: ${id}`);
+			return v;
+		},
+	};
+}
+
+const fakeRedis = {} as Redis;
+
+beforeEach(() => {
+	state.connected.length = 0;
+	state.disconnected.length = 0;
+	state.minAgeMsSeen.length = 0;
+	state.mdelCalls.length = 0;
+	state.gcReturns.clear();
+	state.gcReturns.set(OK_URL, SHA_T1);
+	vi.spyOn(console, "log").mockImplementation(() => undefined);
+	vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+describe("runBlobGc", () => {
+	it("connects and disconnects every tenant, including the failing one (finally)", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 1000, redis: fakeRedis });
+
+		expect(state.connected).toEqual([OK_URL, BOOM_URL]);
+		expect(state.disconnected).toEqual([OK_URL, BOOM_URL]);
+	});
+
+	it("passes minAgeMs through to gcOrphanBlobs", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 4242, redis: fakeRedis });
+
+		// Only t1 reaches gcOrphanBlobs (t2 fails at connect).
+		expect(state.minAgeMsSeen).toEqual([4242]);
+	});
+
+	it("calls mdel with the deleted sha256s for the succeeding tenant when redis is enabled", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		expect(state.mdelCalls).toEqual([{ tenantId: "t1", shas: SHA_T1 }]);
+	});
+
+	it("is resilient: one tenant failing does not abort the others", async () => {
+		const results = await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		expect(results).toHaveLength(2);
+		const t1 = results.find((r) => r.tenantId === "t1");
+		const t2 = results.find((r) => r.tenantId === "t2");
+
+		expect(t1).toEqual({ tenantId: "t1", deleted: SHA_T1.length });
+		expect(t2?.tenantId).toBe("t2");
+		expect(t2?.deleted).toBe(0);
+		expect(t2?.error).toBeTruthy();
+		expect(t2?.error).toContain("boom");
+	});
+
+	it("does not call mdel when redis is absent", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: undefined });
+
+		expect(state.mdelCalls).toEqual([]);
+	});
+
+	it("does not call mdel when blobCacheEnabled is false", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis, blobCacheEnabled: false });
+
+		expect(state.mdelCalls).toEqual([]);
+	});
+});

--- a/src/api/tests/unit/blob-gc.test.ts
+++ b/src/api/tests/unit/blob-gc.test.ts
@@ -25,6 +25,12 @@ const state = vi.hoisted(() => ({
 	mdelCalls: [] as Array<{ tenantId: string; shas: ReadonlyArray<Uint8Array> }>,
 	// Per-url configured GC return values.
 	gcReturns: new Map<string, Uint8Array[]>(),
+	// Isolation level requested for each transaction() call.
+	isolationLevels: [] as Array<string | undefined>,
+	// One url per gcOrphanBlobs invocation (counts retries).
+	gcAttempts: [] as string[],
+	// Per-url: throw an error with this `code` for the next `remaining` calls.
+	gcErrors: new Map<string, { code?: string; remaining: number }>(),
 }));
 
 vi.mock("../../../sql-fs/dialects/postgres.js", () => ({
@@ -42,11 +48,18 @@ vi.mock("../../../sql-fs/dialects/postgres.js", () => ({
 		async disconnect(): Promise<void> {
 			state.disconnected.push(this.#url);
 		}
-		async transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T> {
+		async transaction<T>(fn: (tx: unknown) => Promise<T>, opts?: { isolationLevel?: string }): Promise<T> {
+			state.isolationLevels.push(opts?.isolationLevel);
 			return fn({});
 		}
 		async gcOrphanBlobs(_tx: unknown, minAgeMs: number): Promise<Uint8Array[]> {
 			state.minAgeMsSeen.push(minAgeMs);
+			state.gcAttempts.push(this.#url);
+			const fail = state.gcErrors.get(this.#url);
+			if (fail !== undefined && fail.remaining > 0) {
+				fail.remaining -= 1;
+				throw Object.assign(new Error(`serialization failure (${fail.code ?? "none"})`), { code: fail.code });
+			}
 			return state.gcReturns.get(this.#url) ?? [];
 		}
 	},
@@ -89,6 +102,9 @@ beforeEach(() => {
 	state.mdelCalls.length = 0;
 	state.gcReturns.clear();
 	state.gcReturns.set(OK_URL, SHA_T1);
+	state.isolationLevels.length = 0;
+	state.gcAttempts.length = 0;
+	state.gcErrors.clear();
 	vi.spyOn(console, "log").mockImplementation(() => undefined);
 	vi.spyOn(console, "error").mockImplementation(() => undefined);
 });
@@ -138,5 +154,45 @@ describe("runBlobGc", () => {
 		await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis, blobCacheEnabled: false });
 
 		expect(state.mdelCalls).toEqual([]);
+	});
+
+	it("runs the GC transaction at REPEATABLE READ (closes the dedup re-adoption race)", async () => {
+		await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		// Only t1 reaches a transaction (t2 fails at connect).
+		expect(state.isolationLevels).toEqual(["repeatable read"]);
+	});
+
+	it("retries the GC transaction on a serialization failure (40001) and then succeeds", async () => {
+		state.gcErrors.set(OK_URL, { code: "40001", remaining: 2 }); // fail twice, succeed on the 3rd
+
+		const results = await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		const t1 = results.find((r) => r.tenantId === "t1");
+		expect(t1).toEqual({ tenantId: "t1", deleted: SHA_T1.length }); // no error — eventually succeeded
+		expect(state.gcAttempts.filter((u) => u === OK_URL)).toHaveLength(3);
+		expect(state.mdelCalls).toEqual([{ tenantId: "t1", shas: SHA_T1 }]); // invalidation still runs once
+	});
+
+	it("gives up after the retry cap on persistent serialization failures and records the tenant error", async () => {
+		state.gcErrors.set(OK_URL, { code: "40001", remaining: 99 }); // always fail
+
+		const results = await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		const t1 = results.find((r) => r.tenantId === "t1");
+		expect(t1?.deleted).toBe(0);
+		expect(t1?.error).toBeTruthy();
+		expect(state.gcAttempts.filter((u) => u === OK_URL)).toHaveLength(5); // MAX_GC_ATTEMPTS
+		expect(state.disconnected).toContain(OK_URL); // still disconnected in finally
+	});
+
+	it("does not retry a non-serialization error", async () => {
+		state.gcErrors.set(OK_URL, { code: "23505", remaining: 1 }); // unique_violation — not retryable
+
+		const results = await runBlobGc(makeTenantConfig(), { minAgeMs: 0, redis: fakeRedis });
+
+		const t1 = results.find((r) => r.tenantId === "t1");
+		expect(t1?.error).toBeTruthy();
+		expect(state.gcAttempts.filter((u) => u === OK_URL)).toHaveLength(1); // no retry
 	});
 });

--- a/src/sql-fs/dialects/postgres.ts
+++ b/src/sql-fs/dialects/postgres.ts
@@ -20,6 +20,7 @@ import {
 	type SandboxListEntry,
 	type SandboxMeta,
 	type SqlDialect,
+	type TransactionOptions,
 	type UpdateInodeOpts,
 } from "../types.js";
 
@@ -78,7 +79,11 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 
 	// ── Transactions ──────────────────────────────────────────────────────────────
 
-	async transaction<T>(fn: (tx: PgTx) => Promise<T>): Promise<T> {
+	async transaction<T>(fn: (tx: PgTx) => Promise<T>, opts?: TransactionOptions): Promise<T> {
+		if (opts?.isolationLevel !== undefined) {
+			// `postgres` passes this string after BEGIN, e.g. BEGIN ISOLATION LEVEL REPEATABLE READ.
+			return this.db().begin(`isolation level ${opts.isolationLevel}`, fn) as Promise<T>;
+		}
 		return this.db().begin(fn) as Promise<T>;
 	}
 
@@ -715,8 +720,14 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	// Runs with NO sandbox context — the RLS escape (migration 0005) lets a
 	// context-less tx see every inode so the anti-join is correct. NOT EXISTS
 	// (vs NOT IN) is null-safe and lets the planner use idx_inodes_content_sha256.
-	// The grace window + the DO-UPDATE row lock on the blob upsert path close the
-	// dedup re-adoption race (see plan 2026-06-08 orphan-blob-gc).
+	// Dedup re-adoption race: a concurrent writer that touches+locks an existing
+	// orphan blob (ON CONFLICT DO UPDATE) and then inserts its inode can be missed
+	// here under READ COMMITTED — EvalPlanQual re-checks the updated blob row but
+	// the NOT EXISTS subquery keeps the stale snapshot and never sees the new
+	// inode, so a small/zero grace window would delete a freshly-referenced blob.
+	// The CALLER (runBlobGc) must therefore run this at REPEATABLE READ, which
+	// turns that conflict into a serialization failure (retried) instead of
+	// silent content loss. The grace window is defense-in-depth / churn control.
 	// `i.nlink > 0` excludes nlink=0 inode tombstones: the composite write/delete
 	// paths no longer create them, but rows left by older buggy builds would
 	// otherwise pin their blobs forever — this lets GC clear that backlog.

--- a/src/sql-fs/dialects/postgres.ts
+++ b/src/sql-fs/dialects/postgres.ts
@@ -165,7 +165,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 			blob_insert AS (
 				INSERT INTO blobs (sha256, data, size)
 				SELECT ${sha256}, ${data}, ${size} FROM ctx
-				ON CONFLICT (sha256) DO NOTHING
+				ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
 			),
 			new_inode AS (
 				INSERT INTO inodes (sandbox_id, kind, mode, size, content_sha256)
@@ -582,14 +582,15 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		await tx`
 			INSERT INTO blobs (sha256, data, size)
 			VALUES (${sha256}, ${data}, ${data.length})
-			ON CONFLICT (sha256) DO NOTHING
+			ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
 		`;
 		// Fire-and-forget: don't hold the PG transaction (and the per-sandbox
 		// advisory lock acquired in setSandboxContext) open on Redis latency.
 		// RedisBlobCache.set() swallows its own errors so this promise cannot
 		// reject. Safe under races: blobs are content-addressable and the PG
-		// insert is ON CONFLICT DO NOTHING, so a concurrent SET with identical
-		// bytes is a no-op.
+		// insert is ON CONFLICT DO UPDATE (touch-only — it bumps
+		// last_referenced_at but never rewrites data/size), so a concurrent SET
+		// with identical bytes is a no-op.
 		if (this.#blobCache !== undefined) {
 			void this.#blobCache.set(sha256, data);
 		}
@@ -698,16 +699,25 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		return out;
 	}
 
-	// US-014
-	async gcOrphanBlobs(tx: PgTx): Promise<number> {
+	// US-014: collect orphan blobs older than the grace window.
+	// Runs with NO sandbox context — the RLS escape (migration 0005) lets a
+	// context-less tx see every inode so the anti-join is correct. NOT EXISTS
+	// (vs NOT IN) is null-safe and lets the planner use idx_inodes_content_sha256.
+	// The grace window + the DO-UPDATE row lock on the blob upsert path close the
+	// dedup re-adoption race (see plan 2026-06-08 orphan-blob-gc).
+	async gcOrphanBlobs(tx: PgTx, minAgeMs: number): Promise<Uint8Array[]> {
 		const rows = await tx<{ sha256: Buffer }[]>`
-			DELETE FROM blobs
-			WHERE sha256 NOT IN (
-				SELECT content_sha256 FROM inodes WHERE content_sha256 IS NOT NULL
+			DELETE FROM blobs b
+			WHERE NOT EXISTS (
+				SELECT 1 FROM inodes i WHERE i.content_sha256 = b.sha256
 			)
-			RETURNING sha256
+			AND (
+				b.last_referenced_at IS NULL
+				OR b.last_referenced_at < now() - (${minAgeMs} * interval '1 millisecond')
+			)
+			RETURNING b.sha256
 		`;
-		return rows.length;
+		return rows.map((r) => new Uint8Array(r.sha256));
 	}
 
 	// US-015
@@ -962,7 +972,7 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		}
 		if (uniqueBlobs.size > 0) {
 			const blobRows = [...uniqueBlobs.values()];
-			await tx`INSERT INTO blobs ${tx(blobRows)} ON CONFLICT (sha256) DO NOTHING`;
+			await tx`INSERT INTO blobs ${tx(blobRows)} ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()`;
 		}
 
 		// ── Phase D: bulk insert file inodes ─────────────────────────────────────

--- a/src/sql-fs/dialects/postgres.ts
+++ b/src/sql-fs/dialects/postgres.ts
@@ -129,16 +129,21 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 					AND (SELECT 1 FROM ctx) IS NOT NULL
 				RETURNING inode_id
 			),
+			-- Delete and decrement are split into two mutually-exclusive CTEs
+			-- (by the snapshot nlink) so each inode row is touched exactly once.
+			-- Postgres applies ONLY the UPDATE when a row is both updated and deleted
+			-- in one statement, which would leave an nlink=0 inode tombstone that
+			-- still references content_sha256 and pins its blob against GC.
+			deleted_inode AS (
+				DELETE FROM inodes
+				WHERE id IN (SELECT inode_id FROM removed_dirent)
+					AND nlink <= 1
+			),
 			decremented AS (
 				UPDATE inodes
 				SET nlink = nlink - 1
-				FROM removed_dirent
-				WHERE inodes.id = removed_dirent.inode_id
-				RETURNING inodes.id, inodes.nlink
-			),
-			cleaned AS (
-				DELETE FROM inodes
-				WHERE id IN (SELECT id FROM decremented WHERE nlink <= 0)
+				WHERE id IN (SELECT inode_id FROM removed_dirent)
+					AND nlink > 1
 			)
 			SELECT inode_id AS removed_inode_id FROM removed_dirent
 		`;
@@ -183,16 +188,19 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 				ON CONFLICT (parent_inode_id, name) DO UPDATE SET inode_id = EXCLUDED.inode_id
 				RETURNING inode_id
 			),
+			-- Drop the replaced inode in two mutually-exclusive statements (see
+			-- rmComposite): a combined update+delete of the same row applies only
+			-- the UPDATE, leaving an nlink=0 tombstone that pins the old blob.
+			deleted_old_inode AS (
+				DELETE FROM inodes
+				WHERE id IN (SELECT inode_id FROM old_dirent)
+					AND nlink <= 1
+			),
 			decremented AS (
 				UPDATE inodes
 				SET nlink = nlink - 1
-				FROM old_dirent
-				WHERE inodes.id = old_dirent.inode_id
-				RETURNING inodes.id, inodes.nlink
-			),
-			cleaned AS (
-				DELETE FROM inodes
-				WHERE id IN (SELECT id FROM decremented WHERE nlink <= 0)
+				WHERE id IN (SELECT inode_id FROM old_dirent)
+					AND nlink > 1
 			)
 			SELECT id AS new_inode_id FROM new_inode
 		`;
@@ -231,15 +239,19 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 					AND (SELECT 1 FROM ctx) IS NOT NULL
 				RETURNING inode_id
 			),
-			decremented AS (
-				UPDATE inodes
-				SET nlink = nlink - 1
-				FROM old_dest
-				WHERE inodes.id = old_dest.inode_id
-				RETURNING inodes.id, inodes.nlink
+			-- Split delete/decrement by snapshot nlink so the overwritten
+			-- destination inode is touched exactly once (see rmComposite): a
+			-- combined update+delete applies only the UPDATE, leaving an nlink=0
+			-- tombstone that pins the destination's old blob against GC.
+			deleted_dest_inode AS (
+				DELETE FROM inodes
+				WHERE id IN (SELECT inode_id FROM old_dest)
+					AND nlink <= 1
 			)
-			DELETE FROM inodes
-			WHERE id IN (SELECT id FROM decremented WHERE nlink <= 0)
+			UPDATE inodes
+			SET nlink = nlink - 1
+			WHERE id IN (SELECT inode_id FROM old_dest)
+				AND nlink > 1
 		`;
 		const rows = await tx<{ inode_id: string }[]>`
 			UPDATE dirents
@@ -705,11 +717,14 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 	// (vs NOT IN) is null-safe and lets the planner use idx_inodes_content_sha256.
 	// The grace window + the DO-UPDATE row lock on the blob upsert path close the
 	// dedup re-adoption race (see plan 2026-06-08 orphan-blob-gc).
+	// `i.nlink > 0` excludes nlink=0 inode tombstones: the composite write/delete
+	// paths no longer create them, but rows left by older buggy builds would
+	// otherwise pin their blobs forever — this lets GC clear that backlog.
 	async gcOrphanBlobs(tx: PgTx, minAgeMs: number): Promise<Uint8Array[]> {
 		const rows = await tx<{ sha256: Buffer }[]>`
 			DELETE FROM blobs b
 			WHERE NOT EXISTS (
-				SELECT 1 FROM inodes i WHERE i.content_sha256 = b.sha256
+				SELECT 1 FROM inodes i WHERE i.content_sha256 = b.sha256 AND i.nlink > 0
 			)
 			AND (
 				b.last_referenced_at IS NULL

--- a/src/sql-fs/migrations/postgres/0006_blob_last_referenced_at.sql
+++ b/src/sql-fs/migrations/postgres/0006_blob_last_referenced_at.sql
@@ -1,0 +1,12 @@
+-- Migration 0006: blob last_referenced_at — supports grace-period orphan GC.
+--
+-- Existing rows are left NULL (ADD COLUMN with no default is an instant catalog-only
+-- change — no table rewrite). GC treats NULL as "ancient" so the pre-existing orphan
+-- backlog is collectible on the first run. New inserts default to now(); every
+-- reference (including dedup re-adoption) bumps it via ON CONFLICT DO UPDATE, which
+-- also takes the row lock that serializes a re-adopting writer against GC's DELETE.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS / ALTER ... SET DEFAULT / CREATE INDEX IF NOT EXISTS.
+ALTER TABLE blobs ADD COLUMN IF NOT EXISTS last_referenced_at TIMESTAMPTZ;
+ALTER TABLE blobs ALTER COLUMN last_referenced_at SET DEFAULT now();
+CREATE INDEX IF NOT EXISTS idx_blobs_last_referenced_at ON blobs(last_referenced_at);

--- a/src/sql-fs/redis-blob-cache.ts
+++ b/src/sql-fs/redis-blob-cache.ts
@@ -88,4 +88,23 @@ export class RedisBlobCache {
 			console.error(JSON.stringify({ event: "redis_blob_set_error", error: (err as Error).message }));
 		}
 	}
+
+	/**
+	 * Bulk-delete cache entries for the given sha256s (e.g. after blob GC).
+	 * Chunked like `mget`; uses UNLINK (non-blocking reclaim). Fail-open: a Redis
+	 * error is logged and swallowed — stale entries are harmless (no inode
+	 * references them) and expire by TTL.
+	 */
+	async mdel(sha256s: ReadonlyArray<Uint8Array>): Promise<void> {
+		if (!this.#enabled || sha256s.length === 0) return;
+		const CHUNK = 1024;
+		try {
+			for (let i = 0; i < sha256s.length; i += CHUNK) {
+				const keys = sha256s.slice(i, i + CHUNK).map((s) => this.#key(s));
+				await this.#client.unlink(...keys);
+			}
+		} catch (err) {
+			console.error(JSON.stringify({ event: "redis_blob_mdel_error", error: (err as Error).message }));
+		}
+	}
 }

--- a/src/sql-fs/tests/integration/postgres.test.ts
+++ b/src/sql-fs/tests/integration/postgres.test.ts
@@ -842,7 +842,7 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — gcOrphanBlobs", 
 
 		// Run GC
 		await dialect.transaction(async (tx) => {
-			await dialect.gcOrphanBlobs(tx);
+			await dialect.gcOrphanBlobs(tx, 0);
 		});
 
 		// Blob should still exist (referenced by the inode)
@@ -877,10 +877,10 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — gcOrphanBlobs", 
 
 		// Run GC — should delete the orphan blob
 		const deleted = await dialect.transaction(async (tx) => {
-			return await dialect.gcOrphanBlobs(tx);
+			return await dialect.gcOrphanBlobs(tx, 0);
 		});
 
-		expect(deleted).toBeGreaterThanOrEqual(1);
+		expect(deleted.length).toBeGreaterThanOrEqual(1);
 
 		// Blob should be gone
 		const result = await dialect.transaction(async (tx) => {
@@ -924,7 +924,7 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — gcOrphanBlobs", 
 
 		// Run GC — blob should survive (still referenced by inodeId2)
 		await dialect.transaction(async (tx) => {
-			await dialect.gcOrphanBlobs(tx);
+			await dialect.gcOrphanBlobs(tx, 0);
 		});
 
 		const result = await dialect.transaction(async (tx) => {
@@ -937,6 +937,165 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — gcOrphanBlobs", 
 		await dialect.transaction(async (tx) => {
 			await dialect.deleteInode(tx, inodeId2);
 		});
+	});
+
+	it("re-referencing an existing blob bumps last_referenced_at", async () => {
+		const sha256 = new Uint8Array(32).fill(0xdd);
+		const data = new TextEncoder().encode("rereferenced content");
+
+		// First upsert: inserts the row with last_referenced_at = now().
+		await dialect.transaction(async (tx) => {
+			await dialect.upsertBlob(tx, sha256, data);
+		});
+
+		const firstRows = await dialect.transaction(async (tx) => {
+			return await tx<{ last_referenced_at: Date }[]>`
+				SELECT last_referenced_at FROM blobs WHERE sha256 = ${sha256}
+			`;
+		});
+		const first = firstRows[0]!.last_referenced_at;
+
+		// now() is the transaction start time; the two upserts run in separate
+		// transactions, so this sleep guarantees the second is strictly later.
+		await new Promise((r) => setTimeout(r, 5));
+
+		// Second upsert: ON CONFLICT DO UPDATE bumps last_referenced_at to now().
+		await dialect.transaction(async (tx) => {
+			await dialect.upsertBlob(tx, sha256, data);
+		});
+
+		const secondRows = await dialect.transaction(async (tx) => {
+			return await tx<{ last_referenced_at: Date }[]>`
+				SELECT last_referenced_at FROM blobs WHERE sha256 = ${sha256}
+			`;
+		});
+		const second = secondRows[0]!.last_referenced_at;
+
+		expect(second.getTime()).toBeGreaterThan(first.getTime());
+
+		// Cleanup: blob is unreferenced; remove it directly.
+		await dialect.transaction(async (tx) => {
+			await tx`DELETE FROM blobs WHERE sha256 = ${sha256}`;
+		});
+	});
+
+	// Compares a sha256 against the Uint8Array[] returned by gcOrphanBlobs.
+	const includesSha = (deleted: Uint8Array[], sha: Uint8Array): boolean => {
+		const target = Buffer.from(sha).toString("hex");
+		return deleted.some((d) => Buffer.from(d).toString("hex") === target);
+	};
+
+	it("orphan inside the grace window survives, then is collected once grace is zero", async () => {
+		const sha256 = new Uint8Array(32).fill(0x11);
+		const data = new TextEncoder().encode("grace window content");
+
+		// Upsert blob (last_referenced_at = now()), reference it, then orphan it.
+		await dialect.transaction(async (tx) => {
+			await dialect.upsertBlob(tx, sha256, data);
+		});
+		const inodeId = await dialect.transaction(async (tx) => {
+			return await dialect.createInode(tx, {
+				sandboxId,
+				kind: 1,
+				mode: 0o644,
+				size: data.length,
+				contentSha256: sha256,
+			});
+		});
+		await dialect.transaction(async (tx) => {
+			await dialect.deleteInode(tx, inodeId);
+		});
+
+		// 1h grace window: the orphan is fresh, so it must survive.
+		const survived = await dialect.transaction(async (tx) => {
+			return await dialect.gcOrphanBlobs(tx, 3_600_000);
+		});
+		expect(includesSha(survived, sha256)).toBe(false);
+		const stillThere = await dialect.transaction(async (tx) => {
+			return await dialect.getBlob(tx, sha256);
+		});
+		expect(stillThere).toEqual(data);
+
+		// Zero grace window: the orphan is now eligible and gets collected.
+		const collected = await dialect.transaction(async (tx) => {
+			return await dialect.gcOrphanBlobs(tx, 0);
+		});
+		expect(includesSha(collected, sha256)).toBe(true);
+		const gone = await dialect.transaction(async (tx) => {
+			return await dialect.getBlob(tx, sha256);
+		});
+		expect(gone).toBeNull();
+	});
+
+	it("orphan with NULL last_referenced_at is collected even under a long grace window", async () => {
+		const sha256 = new Uint8Array(32).fill(0x22);
+		const data = new TextEncoder().encode("legacy null content");
+
+		// Insert directly with an explicit NULL last_referenced_at and no inode.
+		await dialect.transaction(async (tx) => {
+			await tx`
+				INSERT INTO blobs (sha256, data, size, last_referenced_at)
+				VALUES (${sha256}, ${data}, ${data.length}, NULL)
+			`;
+		});
+
+		// Long grace window — NULL is treated as ancient, so it is still collected.
+		const collected = await dialect.transaction(async (tx) => {
+			return await dialect.gcOrphanBlobs(tx, 3_600_000);
+		});
+		expect(includesSha(collected, sha256)).toBe(true);
+
+		const gone = await dialect.transaction(async (tx) => {
+			return await dialect.getBlob(tx, sha256);
+		});
+		expect(gone).toBeNull();
+	});
+
+	it("blob referenced only by another sandbox survives no-context GC (RLS escape)", async () => {
+		const sha256 = new Uint8Array(32).fill(0x33);
+		const data = new TextEncoder().encode("cross sandbox content");
+		const otherSandboxId = `${sandboxId}-other`;
+
+		await dialect.transaction(async (tx) => {
+			await dialect.createSandbox(tx, otherSandboxId);
+		});
+
+		try {
+			await dialect.transaction(async (tx) => {
+				await dialect.upsertBlob(tx, sha256, data);
+			});
+			// The referencing inode lives in the OTHER sandbox.
+			await dialect.transaction(async (tx) => {
+				await dialect.setSandboxContext(tx, otherSandboxId);
+				await dialect.createInode(tx, {
+					sandboxId: otherSandboxId,
+					kind: 1,
+					mode: 0o644,
+					size: data.length,
+					contentSha256: sha256,
+				});
+			});
+
+			// GC runs with NO setSandboxContext — the RLS escape lets the
+			// context-less tx see the other sandbox's inode, so the anti-join
+			// keeps this blob alive.
+			const deleted = await dialect.transaction(async (tx) => {
+				return await dialect.gcOrphanBlobs(tx, 0);
+			});
+			expect(includesSha(deleted, sha256)).toBe(false);
+
+			const survived = await dialect.transaction(async (tx) => {
+				return await dialect.getBlob(tx, sha256);
+			});
+			expect(survived).toEqual(data);
+		} finally {
+			// deleteSandbox cascades the inode, but blobs are global (no sandbox_id),
+			// so the now-orphan blob must be removed explicitly to avoid leaking.
+			await dialect.transaction(async (tx) => {
+				await dialect.deleteSandbox(tx, otherSandboxId);
+				await tx`DELETE FROM blobs WHERE sha256 = ${sha256}`;
+			});
+		}
 	});
 });
 

--- a/src/sql-fs/tests/integration/postgres.test.ts
+++ b/src/sql-fs/tests/integration/postgres.test.ts
@@ -1099,6 +1099,172 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — gcOrphanBlobs", 
 	});
 });
 
+describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — nlink=0 tombstone fix (rm/overwrite/GC)", () => {
+	const dialect = new PostgresDialect(process.env.DATABASE_URL!);
+	let sandboxId: string;
+	let rootInodeId: bigint;
+
+	beforeAll(async () => {
+		await dialect.connect();
+		sandboxId = `test-tombstone-${Date.now()}`;
+		const res = await dialect.transaction(async (tx) => dialect.createSandbox(tx, sandboxId));
+		rootInodeId = res.rootInodeId;
+	});
+
+	afterAll(async () => {
+		await dialect.transaction(async (tx) => {
+			await dialect.deleteSandbox(tx, sandboxId);
+		});
+		await dialect.disconnect();
+	});
+
+	const countInode = (id: bigint): Promise<number> =>
+		dialect.transaction(async (tx) => {
+			const rows = await tx<{ n: number }[]>`SELECT count(*)::int AS n FROM inodes WHERE id = ${String(id)}`;
+			return rows[0]!.n;
+		});
+
+	it("rmComposite hard-deletes a single-linked inode (no nlink=0 tombstone left behind)", async () => {
+		const sha = new Uint8Array(32).fill(0x51);
+		const inodeId = await dialect.transaction(async (tx) =>
+			dialect.createInode(tx, { sandboxId, kind: 1, mode: 0o644, size: 3, contentSha256: sha }),
+		);
+		await dialect.transaction(async (tx) => dialect.insertDirent(tx, rootInodeId, "single.txt", inodeId));
+
+		await dialect.transaction(async (tx) => dialect.rmComposite(tx, sandboxId, rootInodeId, "single.txt"));
+
+		// Regression: the inode ROW must be gone, not lingering at nlink=0.
+		expect(await countInode(inodeId)).toBe(0);
+	});
+
+	it("rmComposite decrements a hardlinked inode instead of deleting it", async () => {
+		const sha = new Uint8Array(32).fill(0x52);
+		const inodeId = await dialect.transaction(async (tx) =>
+			dialect.createInode(tx, { sandboxId, kind: 1, mode: 0o644, size: 3, contentSha256: sha }),
+		);
+		await dialect.transaction(async (tx) => {
+			await dialect.insertDirent(tx, rootInodeId, "link1.txt", inodeId);
+			await dialect.insertDirent(tx, rootInodeId, "link2.txt", inodeId);
+			await dialect.incrementNlink(tx, inodeId); // two links → nlink = 2
+		});
+
+		await dialect.transaction(async (tx) => dialect.rmComposite(tx, sandboxId, rootInodeId, "link2.txt"));
+
+		const inode = await dialect.transaction(async (tx) => dialect.getInode(tx, inodeId));
+		expect(inode).not.toBeNull();
+		expect(inode!.nlink).toBe(1); // survives with the remaining link
+
+		// removing the last link now hard-deletes it
+		await dialect.transaction(async (tx) => dialect.rmComposite(tx, sandboxId, rootInodeId, "link1.txt"));
+		expect(await countInode(inodeId)).toBe(0);
+	});
+
+	it("writeFileComposite overwrite hard-deletes the replaced inode and frees its blob for GC", async () => {
+		const shaA = new Uint8Array(32).fill(0x53);
+		const shaB = new Uint8Array(32).fill(0x54);
+		const dataA = new TextEncoder().encode("AAA");
+		const dataB = new TextEncoder().encode("BBBB");
+
+		const inodeA = await dialect.transaction(async (tx) =>
+			dialect.writeFileComposite(tx, sandboxId, rootInodeId, "ow.txt", 0o644, dataA.length, shaA, dataA),
+		);
+		const inodeB = await dialect.transaction(async (tx) =>
+			dialect.writeFileComposite(tx, sandboxId, rootInodeId, "ow.txt", 0o644, dataB.length, shaB, dataB),
+		);
+		expect(inodeB).not.toBe(inodeA);
+		// Regression: the replaced inode must be deleted, not left as an nlink=0 tombstone.
+		expect(await countInode(inodeA)).toBe(0);
+
+		// Old blob is now a true orphan → collected; the new blob survives.
+		await dialect.transaction(async (tx) => dialect.gcOrphanBlobs(tx, 0));
+		const blobA = await dialect.transaction(async (tx) => dialect.getBlob(tx, shaA));
+		const blobB = await dialect.transaction(async (tx) => dialect.getBlob(tx, shaB));
+		expect(blobA).toBeNull();
+		expect(blobB).toEqual(dataB);
+
+		// cleanup
+		await dialect.transaction(async (tx) => dialect.rmComposite(tx, sandboxId, rootInodeId, "ow.txt"));
+		await dialect.transaction(async (tx) => {
+			await tx`DELETE FROM blobs WHERE sha256 = ${shaB}`;
+		});
+	});
+
+	it("gcOrphanBlobs ignores an nlink=0 inode tombstone (legacy backlog) and collects its blob", async () => {
+		const sha = new Uint8Array(32).fill(0x55);
+		const data = new TextEncoder().encode("tomb");
+		await dialect.transaction(async (tx) => dialect.upsertBlob(tx, sha, data));
+		// Simulate a tombstone left by an older buggy build: nlink=0 but still references the blob.
+		const inodeId = await dialect.transaction(async (tx) =>
+			dialect.createInode(tx, { sandboxId, kind: 1, mode: 0o644, size: data.length, contentSha256: sha }),
+		);
+		await dialect.transaction(async (tx) => {
+			await tx`UPDATE inodes SET nlink = 0 WHERE id = ${String(inodeId)}`;
+		});
+
+		await dialect.transaction(async (tx) => dialect.gcOrphanBlobs(tx, 0));
+
+		const blob = await dialect.transaction(async (tx) => dialect.getBlob(tx, sha));
+		expect(blob).toBeNull(); // collected despite the tombstone reference
+
+		// cleanup the tombstone inode
+		await dialect.transaction(async (tx) => {
+			await tx`DELETE FROM inodes WHERE id = ${String(inodeId)}`;
+		});
+	});
+
+	it("mvComposite over a single-linked destination hard-deletes the replaced inode (no tombstone)", async () => {
+		const shaSrc = new Uint8Array(32).fill(0x56);
+		const shaDst = new Uint8Array(32).fill(0x57);
+		const dataSrc = new TextEncoder().encode("SRC");
+		const dataDst = new TextEncoder().encode("DST");
+
+		const srcInode = await dialect.transaction(async (tx) => {
+			await dialect.upsertBlob(tx, shaSrc, dataSrc);
+			const id = await dialect.createInode(tx, {
+				sandboxId,
+				kind: 1,
+				mode: 0o644,
+				size: dataSrc.length,
+				contentSha256: shaSrc,
+			});
+			await dialect.insertDirent(tx, rootInodeId, "mvsrc.txt", id);
+			return id;
+		});
+		const dstInode = await dialect.transaction(async (tx) => {
+			await dialect.upsertBlob(tx, shaDst, dataDst);
+			const id = await dialect.createInode(tx, {
+				sandboxId,
+				kind: 1,
+				mode: 0o644,
+				size: dataDst.length,
+				contentSha256: shaDst,
+			});
+			await dialect.insertDirent(tx, rootInodeId, "mvdst.txt", id);
+			return id;
+		});
+
+		// Move src onto the existing dst, overwriting it.
+		await dialect.transaction(async (tx) =>
+			dialect.mvComposite(tx, sandboxId, rootInodeId, "mvsrc.txt", rootInodeId, "mvdst.txt"),
+		);
+
+		// Regression: the overwritten destination inode must be deleted, not an nlink=0 tombstone.
+		expect(await countInode(dstInode)).toBe(0);
+		expect(await countInode(srcInode)).toBe(1); // src inode now lives at mvdst.txt
+
+		// The dest's old blob is freed for GC; the moved src blob survives.
+		await dialect.transaction(async (tx) => dialect.gcOrphanBlobs(tx, 0));
+		expect(await dialect.transaction(async (tx) => dialect.getBlob(tx, shaDst))).toBeNull();
+		expect(await dialect.transaction(async (tx) => dialect.getBlob(tx, shaSrc))).toEqual(dataSrc);
+
+		// cleanup
+		await dialect.transaction(async (tx) => dialect.rmComposite(tx, sandboxId, rootInodeId, "mvdst.txt"));
+		await dialect.transaction(async (tx) => {
+			await tx`DELETE FROM blobs WHERE sha256 = ${shaSrc}`;
+		});
+	});
+});
+
 describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — loadAllPaths", () => {
 	const dialect = new PostgresDialect(process.env.DATABASE_URL!);
 	let sandboxId: string;

--- a/src/sql-fs/tests/unit/redis-blob-cache.test.ts
+++ b/src/sql-fs/tests/unit/redis-blob-cache.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for RedisBlobCache. Uses an in-memory fake Redis client that
- * implements only the methods the cache relies on (`getBuffer`, `set`).
+ * implements only the methods the cache relies on (`getBuffer`, `mgetBuffer`,
+ * `set`, `unlink`).
  */
 
 import type { Redis } from "ioredis";
@@ -17,6 +18,8 @@ class FakeRedis {
 	failGet = false;
 	failMget = false;
 	failSet = false;
+	failUnlink = false;
+	unlinkCalls: number[] = [];
 
 	async getBuffer(key: string): Promise<Buffer | null> {
 		if (this.failGet) throw new Error("redis get failed");
@@ -32,6 +35,16 @@ class FakeRedis {
 		if (this.failSet) throw new Error("redis set failed");
 		this.store.set(key, { data: value, ttlMs });
 		return "OK";
+	}
+
+	async unlink(...keys: string[]): Promise<number> {
+		if (this.failUnlink) throw new Error("redis unlink failed");
+		this.unlinkCalls.push(keys.length);
+		let deleted = 0;
+		for (const key of keys) {
+			if (this.store.delete(key)) deleted++;
+		}
+		return deleted;
 	}
 }
 
@@ -194,6 +207,83 @@ describe("RedisBlobCache.mget", () => {
 		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const result = await cache.mget([sha(0x01), sha(0x02)]);
 		expect(result).toEqual([null, null]);
+		expect(errSpy).toHaveBeenCalled();
+		errSpy.mockRestore();
+	});
+});
+
+describe("RedisBlobCache.mdel", () => {
+	it("deletes the correct tenant-prefixed keys and leaves others intact", async () => {
+		const { fake, client } = makeClient();
+		const cache = new RedisBlobCache(client, "default");
+		fake.store.set(`vfs:default:blob:${hexSha(0x01)}`, { data: Buffer.from([1]), ttlMs: 1000 });
+		fake.store.set(`vfs:default:blob:${hexSha(0x02)}`, { data: Buffer.from([2]), ttlMs: 1000 });
+		const unrelated = `vfs:default:blob:${hexSha(0x03)}`;
+		fake.store.set(unrelated, { data: Buffer.from([3]), ttlMs: 1000 });
+
+		await cache.mdel([sha(0x01), sha(0x02)]);
+
+		expect(fake.store.has(`vfs:default:blob:${hexSha(0x01)}`)).toBe(false);
+		expect(fake.store.has(`vfs:default:blob:${hexSha(0x02)}`)).toBe(false);
+		expect(fake.store.has(unrelated)).toBe(true);
+	});
+
+	it("scopes deletes to its own tenant prefix", async () => {
+		const { fake, client } = makeClient();
+		const cacheA = new RedisBlobCache(client, "tenant-a");
+		const keyA = `vfs:tenant-a:blob:${hexSha(0x01)}`;
+		const keyB = `vfs:tenant-b:blob:${hexSha(0x01)}`;
+		fake.store.set(keyA, { data: Buffer.from([1]), ttlMs: 1000 });
+		fake.store.set(keyB, { data: Buffer.from([1]), ttlMs: 1000 });
+
+		await cacheA.mdel([sha(0x01)]);
+
+		expect(fake.store.has(keyA)).toBe(false);
+		expect(fake.store.has(keyB)).toBe(true);
+	});
+
+	it("chunks UNLINK at 1024 keys per round-trip", async () => {
+		const { fake, client } = makeClient();
+		const cache = new RedisBlobCache(client, "default");
+		// Build 1500 distinct shas by encoding the index into the first 2 bytes.
+		const shas: Uint8Array[] = [];
+		for (let i = 0; i < 1500; i++) {
+			const s = new Uint8Array(32);
+			s[0] = i & 0xff;
+			s[1] = (i >> 8) & 0xff;
+			shas.push(s);
+		}
+
+		await cache.mdel(shas);
+
+		expect(fake.unlinkCalls).toEqual([1024, 476]);
+	});
+
+	it("no-ops when cache is disabled", async () => {
+		const { fake, client } = makeClient();
+		const cache = new RedisBlobCache(client, "default", { enabled: false });
+		const key = `vfs:default:blob:${hexSha(0x01)}`;
+		fake.store.set(key, { data: Buffer.from([1]), ttlMs: 1000 });
+
+		await cache.mdel([sha(0x01)]);
+
+		expect(fake.store.has(key)).toBe(true);
+		expect(fake.unlinkCalls).toEqual([]);
+	});
+
+	it("no-ops on empty input (no round-trip)", async () => {
+		const { fake, client } = makeClient();
+		const cache = new RedisBlobCache(client, "default");
+		await cache.mdel([]);
+		expect(fake.unlinkCalls).toEqual([]);
+	});
+
+	it("fails open on Redis error", async () => {
+		const { fake, client } = makeClient();
+		fake.failUnlink = true;
+		const cache = new RedisBlobCache(client, "default");
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		await expect(cache.mdel([sha(0x01)])).resolves.toBeUndefined();
 		expect(errSpy).toHaveBeenCalled();
 		errSpy.mockRestore();
 	});

--- a/src/sql-fs/tests/unit/sql-fs.resolvepath.test.ts
+++ b/src/sql-fs/tests/unit/sql-fs.resolvepath.test.ts
@@ -29,7 +29,7 @@ function makeFs(): SqlFs<unknown> {
 		moveDirent: async () => {},
 		upsertBlob: async () => {},
 		getBlob: async () => null,
-		gcOrphanBlobs: async () => 0,
+		gcOrphanBlobs: async () => [],
 		getBlobsForSandbox: async () => [],
 		loadAllPaths: async () => [],
 		loadSubtreeInodes: async () => [],

--- a/src/sql-fs/types.ts
+++ b/src/sql-fs/types.ts
@@ -329,10 +329,18 @@ export interface SqlDialect<Tx = unknown> {
 	getBlobsForSandbox(sandboxId: string, maxBytes: number): Promise<Array<{ inodeId: bigint; data: Uint8Array }>>;
 
 	/**
-	 * Deletes blobs whose sha256 is not referenced by any inode's content_sha256.
-	 * Returns the count of blobs deleted.
+	 * Deletes orphan blobs — those whose sha256 is not referenced by any inode's
+	 * content_sha256 — that are older than the `minAgeMs` grace window.
+	 *
+	 * `minAgeMs` is the grace window in milliseconds: orphans whose
+	 * `last_referenced_at` is younger than this are kept (they may be re-adopted
+	 * by an in-flight dedup upsert). A NULL `last_referenced_at` is treated as
+	 * ancient and is always eligible for collection. Pass `0` to collect every
+	 * orphan immediately.
+	 *
+	 * Returns the sha256s of the deleted blobs (for later cache invalidation).
 	 */
-	gcOrphanBlobs(tx: Tx): Promise<number>;
+	gcOrphanBlobs(tx: Tx, minAgeMs: number): Promise<Uint8Array[]>;
 
 	// ── Bulk / tree operations ────────────────────────────────────────────────────
 

--- a/src/sql-fs/types.ts
+++ b/src/sql-fs/types.ts
@@ -106,6 +106,17 @@ export interface BulkIngestFile {
 	readonly mode: number;
 }
 
+/** Options for a transaction. */
+export interface TransactionOptions {
+	/**
+	 * Isolation level for the transaction. Defaults to the connection default
+	 * (READ COMMITTED). Use `repeatable read` for the orphan-blob GC so a
+	 * concurrent dedup re-adoption surfaces as a serialization failure (retry)
+	 * instead of silently deleting a freshly-referenced blob.
+	 */
+	readonly isolationLevel?: "repeatable read" | "serializable";
+}
+
 /**
  * SqlDialect abstracts all database-specific SQL operations so that SqlFs
  * can work with Postgres, MySQL, and Azure SQL without modification.
@@ -127,8 +138,9 @@ export interface SqlDialect<Tx = unknown> {
 	/**
 	 * Wraps the callback in a BEGIN/COMMIT transaction.
 	 * Rolls back automatically on error and re-throws the original error.
+	 * `opts.isolationLevel` overrides the default (READ COMMITTED).
 	 */
-	transaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T>;
+	transaction<T>(fn: (tx: Tx) => Promise<T>, opts?: TransactionOptions): Promise<T>;
 
 	// ── Sandbox context ──────────────────────────────────────────────────────────
 

--- a/thoughts/shared/plans/2026-06-08_21-59-31_orphan-blob-gc.md
+++ b/thoughts/shared/plans/2026-06-08_21-59-31_orphan-blob-gc.md
@@ -1,0 +1,535 @@
+---
+date: 2026-06-08T21:59:31+09:30
+researcher: quangnguyentechno@gmail.com
+git_commit: 72a8857ed41978d7fd2de2b6e1e99a6e734a3932
+branch: feature/blob-gc
+repository: virtualFS
+task: "Orphan Blob Garbage Collection (CLI + grace-period sweep)"
+tags: [implementation-plan, blobs, gc, garbage-collection, cas, postgres, redis, multi-tenant]
+status: draft
+last_updated: 2026-06-08
+last_updated_by: quangnguyentechno@gmail.com
+---
+
+# Orphan Blob Garbage Collection Implementation Plan
+
+## Overview
+
+Orphan blobs (rows in `blobs` referenced by zero `inodes`) currently accumulate
+forever: `gcOrphanBlobs` has zero production callers, the `pnpm db:gc` CLI
+(`src/api/cli/gc.ts`) is missing, and no scheduler invokes it. This plan restores
+a **multi-tenant, race-safe blob GC** invoked from a CLI for an external cron /
+k8s CronJob, hardened with a grace-period + touch design that closes the dedup
+re-adoption race (silent content loss), and wired to invalidate the Redis blob
+cache on collection.
+
+## Current State Analysis
+
+- **Only GC implementation**: `gcOrphanBlobs` at `src/sql-fs/dialects/postgres.ts:702-711`
+  runs `DELETE FROM blobs WHERE sha256 NOT IN (SELECT content_sha256 FROM inodes …)`
+  and returns only a count. **Zero production callers.**
+- **Missing entry points**: `src/api/cli/gc.ts` does not exist (`package.json:26`
+  `"db:gc": "tsx src/api/cli/gc.ts"` is broken). `src/api/routes/admin.ts` does
+  not exist. No `setInterval`/cron in `src/api/server.ts`.
+- **Multi-tenant**: each tenant has its own Postgres database
+  (`src/api/tenants.ts`). Any GC must iterate `tenantConfig.tenantIds` and connect
+  per-tenant — exactly the pattern in `src/api/migrations.ts:40-88`.
+- **RLS escape is intentional and load-bearing**: `inodes` has `FORCE ROW LEVEL
+  SECURITY` (`src/sql-fs/migrations/postgres/0005_enable_rls.sql:47-58`). The policy
+  allows all rows only when `app.sandbox_id` is unset/empty; the migration comment
+  (lines 18-20) names `gcOrphanBlobs` as the reason. **GC must run in a transaction
+  that never calls `setSandboxContext`** — otherwise the anti-join sees zero inodes
+  and deletes the entire blob store. `rls.integration.test.ts:88` documents this.
+- **Three blob-insert sites** (all `ON CONFLICT (sha256) DO NOTHING` today):
+  `writeFileComposite` CTE (`postgres.ts:166-168`), `upsertBlob`
+  (`postgres.ts:583-585`), `bulkIngest` (`postgres.ts:965`). `bulkIngest` already
+  dedups by sha256 (`postgres.ts:952-962`).
+- **Write atomicity**: both write paths commit blob + inode in one transaction
+  (`sql-fs.ts:750-778`), so the *forward* race does not exist. Only **re-adoption
+  of an existing orphan via dedup** races with GC.
+- **Redis blob cache**: `RedisBlobCache` (`src/sql-fs/redis-blob-cache.ts`) has
+  `get`/`mget`/`set` but **no delete**; keys are tenant-scoped
+  (`vfs:{tenantId}:blob:<hex>`). GC discards its `RETURNING sha256` rows, so cache
+  entries for deleted blobs linger until TTL.
+- **No drizzle schema file** (`CLAUDE.md`'s reference to `schema.ts` is stale);
+  schema is the raw SQL migrations only. Next file is `0006_*.sql`.
+
+### Key Discoveries
+- The dedup re-adoption race is closed by switching blob upserts from
+  `ON CONFLICT DO NOTHING` to `ON CONFLICT DO UPDATE SET last_referenced_at = now()`.
+  `DO UPDATE` takes a **row lock** on the conflicting blob, which serializes a
+  re-adopting writer against GC's `DELETE`: writer wins the lock → GC re-checks
+  (EvalPlanQual under READ COMMITTED) and skips; GC wins → writer's data-carrying
+  `INSERT` recreates the blob. The grace window is defense-in-depth + churn control,
+  not the correctness mechanism.
+- Rewriting `NOT IN` → `NOT EXISTS` is both planner-friendly (uses the partial index
+  `idx_inodes_content_sha256`, `0000_create_tables.sql:49`) and removes the
+  three-valued-logic fragility of `NOT IN` with NULLs.
+- Legacy rows can be added as `NULL` (instant `ALTER TABLE ADD COLUMN` with no
+  default → no table rewrite). GC treats `NULL` as "ancient", so the pre-existing
+  orphan backlog is collectible on the first run regardless of the grace window.
+
+## Desired End State
+
+- `pnpm db:gc` runs a real, multi-tenant orphan-blob sweep. Verify:
+  `pnpm db:gc -- --min-age-ms 0` deletes all orphans across tenants and logs counts.
+- Concurrent dedup re-adoption can no longer dangle an inode (grace + row lock).
+- Deleted blobs' Redis cache entries are invalidated (when Redis configured).
+- `gcOrphanBlobs` run with no sandbox context still respects cross-sandbox sharing
+  (a blob referenced by another sandbox survives) — covered by integration tests.
+- `pnpm typecheck && pnpm lint:fix && pnpm test:unit` pass; integration tests pass
+  against a real Postgres (skip gracefully without `DATABASE_URL`).
+
+## What We're NOT Doing
+
+- **No admin HTTP endpoint** (`routes/admin.ts`) and **no in-process scheduled
+  sweeper** this round. `runBlobGc` is factored so either can be layered on later
+  (the existing `distributed-lock.ts` would gate a multi-replica sweeper).
+- **No refcount column**. We use the anti-join + grace approach; refcounting is a
+  larger change with ongoing drift risk, justified only at high churn.
+- **No MySQL / Azure SQL** GC — those dialects are not implemented on disk.
+- **No change to the CAS dedup model or the blobs↔inodes FK-less design.**
+
+## Implementation Approach
+
+Test-anchored (TDD where it pays): the dialect/cache behaviors (grace, touch,
+NOT EXISTS, cross-sandbox survival, Redis invalidation) are precise and DB-backed,
+so we write/extend integration + unit tests first, then implement. The CLI wiring
+is thin and verified manually + with a focused `runBlobGc` test using mocks.
+
+Phases are ordered by dependency: schema+touch → GC algorithm → Redis delete →
+orchestration+CLI → docs/changeset.
+
+**TDD Assessment:** Recommended for Phases 1–3 (clear behaviors, DB-backed,
+algorithmic). Phase 4 (CLI/orchestration) is partly infra — covered by a mocked
+`runBlobGc` unit test plus manual verification. Phase 5 is docs/changeset.
+
+---
+
+## Phase 1: Schema migration + touch-on-reference
+
+### Phase 1: Overview
+Add `blobs.last_referenced_at` and make every blob reference (insert and dedup
+re-adoption) bump it via `ON CONFLICT DO UPDATE`, introducing the serializing row
+lock and enabling the grace window.
+
+### Phase 1: Changes Required
+
+#### 1. New migration
+**File**: `src/sql-fs/migrations/postgres/0006_blob_last_referenced_at.sql` (new)
+**Changes**: Add the column (NULL for legacy rows → instant, no rewrite), set the
+default for new inserts, add a supporting index. Idempotent (re-applied on every boot).
+
+```sql
+-- Migration 0006: blob last_referenced_at — supports grace-period orphan GC.
+--
+-- Existing rows are left NULL (ADD COLUMN with no default is an instant catalog-only
+-- change — no table rewrite). GC treats NULL as "ancient" so the pre-existing orphan
+-- backlog is collectible on the first run. New inserts default to now(); every
+-- reference (including dedup re-adoption) bumps it via ON CONFLICT DO UPDATE, which
+-- also takes the row lock that serializes a re-adopting writer against GC's DELETE.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS / ALTER ... SET DEFAULT / CREATE INDEX IF NOT EXISTS.
+ALTER TABLE blobs ADD COLUMN IF NOT EXISTS last_referenced_at TIMESTAMPTZ;
+ALTER TABLE blobs ALTER COLUMN last_referenced_at SET DEFAULT now();
+CREATE INDEX IF NOT EXISTS idx_blobs_last_referenced_at ON blobs(last_referenced_at);
+```
+
+> Note: `scripts/copy-postgres-migrations.mjs` (referenced by `pnpm build`) copies
+> migration SQL into `dist/`; the new file is picked up automatically by the
+> lexicographic loader in `migrations.ts:26-32`.
+
+#### 2. Touch on every blob reference
+**File**: `src/sql-fs/dialects/postgres.ts`
+**Changes**: Flip all three `ON CONFLICT (sha256) DO NOTHING` to
+`DO UPDATE SET last_referenced_at = now()`.
+
+- `writeFileComposite` CTE — `postgres.ts:166-168`:
+```sql
+INSERT INTO blobs (sha256, data, size)
+SELECT ${sha256}, ${data}, ${size} FROM ctx
+ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
+```
+- `upsertBlob` — `postgres.ts:583-585`:
+```sql
+INSERT INTO blobs (sha256, data, size)
+VALUES (${sha256}, ${data}, ${data.length})
+ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
+```
+- `bulkIngest` — `postgres.ts:965` (blobRows already deduped by sha256 at 952-962,
+  so `DO UPDATE` is safe — no "cannot affect row a second time"):
+```sql
+await tx`INSERT INTO blobs ${tx(blobRows)} ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()`;
+```
+
+### Phase 1: Success Criteria
+
+#### Phase 1: Automated Verification
+- [ ] Type checks: `pnpm typecheck`
+- [ ] Lint: `pnpm lint:fix`
+- [ ] Unit tests still pass (no behavior change for callers): `pnpm test:unit`
+- [ ] Integration (with `DATABASE_URL`): new test — overwriting a file with content
+      identical to an existing orphan bumps that blob's `last_referenced_at`
+      (re-adoption touch): `pnpm test:integration`
+- [ ] Migration applies cleanly twice (idempotency): boot the dev server twice, or
+      run the integration suite which applies migrations on connect.
+
+#### Phase 1: Manual Verification
+- [ ] On an existing DB, after deploy: `SELECT count(*) FROM blobs WHERE last_referenced_at IS NULL` shows legacy rows are NULL (no rewrite); new writes populate `now()`.
+
+### Phase 1: Discoveries and Notable Information
+[Filled by implementing agent.]
+
+---
+
+## Phase 2: Race-safe `gcOrphanBlobs` (NOT EXISTS + grace)
+
+### Phase 2: Overview
+Rewrite the GC query to use `NOT EXISTS`, apply the grace window, and return the
+deleted sha256 list (for Redis invalidation). Update the `SqlDialect` interface and
+all mocks/tests.
+
+### Phase 2: Changes Required
+
+#### 1. Dialect interface
+**File**: `src/sql-fs/types.ts:335`
+**Changes**:
+```ts
+// before: gcOrphanBlobs(tx: Tx): Promise<number>;
+gcOrphanBlobs(tx: Tx, minAgeMs: number): Promise<Uint8Array[]>;
+```
+
+#### 2. Implementation
+**File**: `src/sql-fs/dialects/postgres.ts:702-711`
+**Changes**:
+```ts
+// US-014: collect orphan blobs older than the grace window.
+// Runs with NO sandbox context — the RLS escape (migration 0005) lets a
+// context-less tx see every inode so the anti-join is correct. NOT EXISTS
+// (vs NOT IN) is null-safe and lets the planner use idx_inodes_content_sha256.
+// The grace window + the DO-UPDATE row lock on the blob upsert path close the
+// dedup re-adoption race (see plan 2026-06-08 orphan-blob-gc).
+async gcOrphanBlobs(tx: PgTx, minAgeMs: number): Promise<Uint8Array[]> {
+    const rows = await tx<{ sha256: Buffer }[]>`
+        DELETE FROM blobs b
+        WHERE NOT EXISTS (
+            SELECT 1 FROM inodes i WHERE i.content_sha256 = b.sha256
+        )
+        AND (
+            b.last_referenced_at IS NULL
+            OR b.last_referenced_at < now() - (${minAgeMs} * interval '1 millisecond')
+        )
+        RETURNING b.sha256
+    `;
+    return rows.map((r) => new Uint8Array(r.sha256));
+}
+```
+
+#### 3. Update mocks and tests
+**Files**:
+- `src/sql-fs/tests/unit/sql-fs.resolvepath.test.ts:32` — change `async () => 0`
+  to `async () => []` (return type now `Uint8Array[]`).
+- The ~35 `gcOrphanBlobs: vi.fn()` mock sites are loose and compile as-is; confirm
+  via `pnpm typecheck`. Fix any that assert a numeric return.
+- `src/sql-fs/tests/integration/postgres.test.ts:811-941` — update the three existing
+  calls (`:845`, `:880`, `:927`) to pass `minAgeMs` (use `0`) and assert on
+  `.length` instead of the count return. Add:
+  - **grace**: orphan with fresh `last_referenced_at` is NOT collected when
+    `minAgeMs` exceeds its age; IS collected with `minAgeMs = 0`.
+  - **legacy NULL**: a blob row with `last_referenced_at IS NULL` is collected.
+  - **cross-sandbox survival with no context**: a blob referenced by sandbox B
+    survives GC run with no `setSandboxContext` (regression for the RLS escape;
+    mirror `rls.integration.test.ts:88`).
+
+### Phase 2: Success Criteria
+
+#### Phase 2: Automated Verification
+- [ ] `pnpm typecheck` (interface + all mock sites)
+- [ ] `pnpm lint:fix`
+- [ ] `pnpm test:unit`
+- [ ] `pnpm test:integration` (grace, NULL-legacy, cross-sandbox survival, referenced-blob survival)
+
+#### Phase 2: Manual Verification
+- [ ] `EXPLAIN` the DELETE shows the anti-join uses `idx_inodes_content_sha256`.
+
+### Phase 2: Discoveries and Notable Information
+[Filled by implementing agent.]
+
+---
+
+## Phase 3: Redis blob-cache invalidation (`mdel`)
+
+### Phase 3: Overview
+Add a chunked, fail-open bulk delete to `RedisBlobCache` so GC can purge deleted
+blobs from the tenant-scoped cache.
+
+### Phase 3: Changes Required
+
+#### 1. `RedisBlobCache.mdel`
+**File**: `src/sql-fs/redis-blob-cache.ts` (after `set`, ~line 90)
+**Changes**:
+```ts
+/**
+ * Bulk-delete cache entries for the given sha256s (e.g. after blob GC).
+ * Chunked like `mget`; uses UNLINK (non-blocking). Fail-open: a Redis error is
+ * logged and swallowed — stale entries are harmless (no inode references them)
+ * and expire by TTL.
+ */
+async mdel(sha256s: ReadonlyArray<Uint8Array>): Promise<void> {
+    if (!this.#enabled || sha256s.length === 0) return;
+    const CHUNK = 1024;
+    try {
+        for (let i = 0; i < sha256s.length; i += CHUNK) {
+            const keys = sha256s.slice(i, i + CHUNK).map((s) => this.#key(s));
+            await this.#client.unlink(...keys);
+        }
+    } catch (err) {
+        console.error(JSON.stringify({ event: "redis_blob_mdel_error", error: (err as Error).message }));
+    }
+}
+```
+
+#### 2. Unit test
+**File**: `src/sql-fs/tests/unit/redis-blob-cache.test.ts`
+**Changes**: add cases — `mdel` issues `unlink` with the correct tenant-prefixed
+keys, chunks at 1024, no-ops when disabled or empty, and fails open on a thrown
+Redis error.
+
+### Phase 3: Success Criteria
+
+#### Phase 3: Automated Verification
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test:unit -- src/sql-fs/tests/unit/redis-blob-cache.test.ts`
+
+### Phase 3: Discoveries and Notable Information
+[Filled by implementing agent.]
+
+---
+
+## Phase 4: Orchestration (`runBlobGc`) + CLI (`db:gc`)
+
+### Phase 4: Overview
+Add a shared, multi-tenant orchestration function and a thin CLI that restores
+`pnpm db:gc`, mirroring `migrations.ts` (per-tenant connection) and `cli/token.ts`
+(arg parsing + `main().catch`).
+
+### Phase 4: Changes Required
+
+#### 1. Shared orchestrator
+**File**: `src/api/blob-gc.ts` (new)
+**Changes**:
+```ts
+import type { Redis } from "ioredis";
+import { PostgresDialect } from "../sql-fs/dialects/postgres.js";
+import { RedisBlobCache } from "../sql-fs/redis-blob-cache.js";
+import type { TenantConfig } from "./tenants.js";
+
+export interface BlobGcOptions {
+    readonly minAgeMs: number;
+    readonly redis?: Redis;
+    readonly blobCacheEnabled?: boolean;
+    /** Restrict to these tenant ids; defaults to all configured tenants. */
+    readonly tenantIds?: readonly string[];
+}
+export interface BlobGcTenantResult {
+    readonly tenantId: string;
+    readonly deleted: number;
+    readonly error?: string;
+}
+
+/**
+ * Garbage-collect orphan blobs across tenants. Each tenant gets a dedicated
+ * dialect connection that NEVER sets a sandbox context, so the RLS escape
+ * (migration 0005) lets the anti-join see every inode. Resilient: a per-tenant
+ * failure is logged and recorded, and the remaining tenants still run.
+ */
+export async function runBlobGc(
+    tenantConfig: TenantConfig,
+    opts: BlobGcOptions,
+): Promise<BlobGcTenantResult[]> {
+    const tenantIds = opts.tenantIds ?? tenantConfig.tenantIds;
+    const results: BlobGcTenantResult[] = [];
+    for (const tenantId of tenantIds) {
+        const url = tenantConfig.getConnectionString(tenantId);
+        const dialect = new PostgresDialect(url);
+        try {
+            await dialect.connect();
+            const deleted = await dialect.transaction((tx) => dialect.gcOrphanBlobs(tx, opts.minAgeMs));
+            if (deleted.length > 0 && opts.redis && opts.blobCacheEnabled !== false) {
+                await new RedisBlobCache(opts.redis, tenantId).mdel(deleted);
+            }
+            console.log(JSON.stringify({ event: "blob_gc_tenant_ok", tenantId, deleted: deleted.length }));
+            results.push({ tenantId, deleted: deleted.length });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(JSON.stringify({ event: "blob_gc_tenant_failed", tenantId, error: message }));
+            results.push({ tenantId, deleted: 0, error: message });
+        } finally {
+            await dialect.disconnect().catch(() => {});
+        }
+    }
+    return results;
+}
+```
+
+#### 2. CLI
+**File**: `src/api/cli/gc.ts` (new) — mirrors `cli/token.ts` structure
+**Changes**:
+```ts
+/**
+ * CLI: garbage-collect orphan blobs across all configured tenants.
+ * Restores `pnpm db:gc`. Intended for an external scheduler (cron / k8s CronJob).
+ *
+ * Usage:
+ *   pnpm db:gc                       # grace from BLOB_GC_MIN_AGE_MS (default 3h)
+ *   pnpm db:gc -- --min-age-ms 0     # collect all orphans now (ignore grace)
+ *   pnpm db:gc -- --tenant tenant-a  # restrict to one tenant
+ */
+import { closeRedisClient, getRedisClient } from "../redis/client.js";
+import { parseNonNegativeInt } from "../redis/config.js";
+import { runBlobGc } from "./blob-gc.js";
+import { loadTenantConfig } from "./tenants.js";
+
+// parse --min-age-ms and --tenant (reuse the readValue pattern from token.ts);
+// default minAgeMs = parseNonNegativeInt("BLOB_GC_MIN_AGE_MS", 3 * 60 * 60 * 1000)
+
+async function main(): Promise<void> {
+    const tenantConfig = loadTenantConfig();
+    // validate --tenant against tenantConfig.hasTenant(...)
+    const redis = getRedisClient();
+    const blobCacheEnabled = process.env.REDIS_BLOB_CACHE_ENABLED !== "false";
+    const results = await runBlobGc(tenantConfig, {
+        minAgeMs, redis: redis ?? undefined, blobCacheEnabled, tenantIds /* if --tenant */,
+    });
+    const total = results.reduce((n, r) => n + r.deleted, 0);
+    const failed = results.filter((r) => r.error);
+    console.log(JSON.stringify({ event: "blob_gc_complete", total, tenants: results.length, failed: failed.length }));
+    await closeRedisClient();
+    if (failed.length > 0) process.exit(1);
+}
+
+main().catch((err) => {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+});
+```
+> Note the import paths: `cli/gc.ts` is one level under `api/`, so it imports
+> `./blob-gc.js`, `./tenants.js`, `../redis/client.js`, `../redis/config.js`
+> (matching `cli/token.ts` which imports `../lib/jwt.js`).
+
+#### 3. Focused orchestrator unit test
+**File**: `src/api/tests/unit/blob-gc.test.ts` (new)
+**Changes**: mock `PostgresDialect` (or inject a fake) + a fake `TenantConfig` with
+two tenants; assert `runBlobGc` connects/disconnects per tenant, passes `minAgeMs`
+through, calls `mdel` with the returned sha256s, continues past a failing tenant,
+and records the error.
+
+### Phase 4: Success Criteria
+
+#### Phase 4: Automated Verification
+- [ ] `pnpm typecheck`
+- [ ] `pnpm lint:fix`
+- [ ] `pnpm test:unit` (includes new `blob-gc.test.ts`)
+- [ ] `pnpm db:gc -- --min-age-ms 0` runs against a dev DB and exits 0
+
+#### Phase 4: Manual Verification
+- [ ] Write then delete a file, run `pnpm db:gc -- --min-age-ms 0`, confirm the
+      orphan blob row is gone and (if Redis on) its cache key is removed.
+- [ ] With a fresh orphan and default grace, `pnpm db:gc` leaves it (grace), then
+      `--min-age-ms 0` collects it.
+
+### Phase 4: Discoveries and Notable Information
+[Filled by implementing agent.]
+
+---
+
+## Phase 5: Docs + changeset
+
+### Phase 5: Overview
+Document the env knob and the restored CLI; add a changeset.
+
+### Phase 5: Changes Required
+
+#### 1. CLAUDE.md
+**File**: `CLAUDE.md`
+**Changes**:
+- Add `BLOB_GC_MIN_AGE_MS` to the Environment Variables table (No; default
+  `10800000` = 3h; grace window before an orphan blob is collectible; the
+  DO-UPDATE row lock is the actual race guard, this is margin/churn control).
+- File Layout: add `cli/gc.ts` and `api/blob-gc.ts`; remove/annotate the stale
+  `routes/admin.ts` reference (not implemented).
+- Note that `pnpm db:gc` is now functional and intended for an external scheduler.
+
+#### 2. Changeset
+**File**: `.changeset/*.md` (via `pnpm changeset`, minor)
+**Changes**: "feat(gc): multi-tenant orphan-blob GC via `pnpm db:gc` with
+grace-period + touch (closes dedup re-adoption race) and Redis cache invalidation."
+
+### Phase 5: Success Criteria
+
+#### Phase 5: Automated Verification
+- [ ] `.changeset/` contains a new entry
+- [ ] `pnpm typecheck && pnpm lint:fix && pnpm test:unit`
+
+#### Phase 5: Manual Verification
+- [ ] CLAUDE.md env table and file layout reviewed for accuracy.
+
+### Phase 5: Discoveries and Notable Information
+[Filled by implementing agent.]
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- `RedisBlobCache.mdel`: correct tenant-prefixed keys, chunking at 1024, disabled/empty
+  no-op, fail-open on Redis error.
+- `runBlobGc`: per-tenant connect/disconnect, `minAgeMs` passthrough, `mdel` called
+  with deleted sha256s, resilience to a failing tenant.
+- Existing SqlFs unit suites: confirm the `gcOrphanBlobs` signature change compiles
+  (fix `sql-fs.resolvepath.test.ts:32`).
+
+### Integration Tests (`src/sql-fs/tests/integration/postgres.test.ts`, skip without `DATABASE_URL`)
+- Referenced blob survives GC (existing, updated signature).
+- Orphan after inode delete is collected with `minAgeMs = 0` (existing, updated).
+- Blob shared by two inodes survives after one inode deleted (existing, updated).
+- **New**: fresh orphan NOT collected within grace; collected at `minAgeMs = 0`.
+- **New**: legacy `last_referenced_at IS NULL` orphan collected.
+- **New**: blob referenced by another sandbox survives a no-context GC run.
+- **New (Phase 1)**: re-writing identical content bumps `last_referenced_at`.
+
+### Manual Testing Steps
+1. `pnpm dev:portless`; create a sandbox; write `a.txt`; delete it.
+2. `pnpm db:gc -- --min-age-ms 0`; verify the orphan blob row and Redis key are gone.
+3. Repeat with default grace; verify the fresh orphan is retained until it ages out.
+
+## Performance Considerations
+
+- The DELETE is a full anti-join over `blobs` filtered by `NOT EXISTS` against
+  `idx_inodes_content_sha256` plus the `last_referenced_at` predicate
+  (`idx_blobs_last_referenced_at`). Acceptable for a periodic cron; if `blobs`
+  grows very large, a future refcount design would make GC scan-free.
+- `ON CONFLICT DO UPDATE` writes a new row version on every dedup hit (mild write
+  amplification on hot, repeatedly-written blobs) — the cost of the touch.
+- GC uses a dedicated short-lived pool per tenant (`PostgresDialect` defaults
+  `PG_POOL_MAX=2`); it does not contend with warm session pools.
+
+## Migration Notes
+
+- `0006` is an instant catalog-only change (ADD COLUMN with no default); existing
+  rows are `NULL` and are treated as collectible-if-orphan, so the accumulated
+  backlog is cleared on the first `pnpm db:gc` run (grace does not block NULL rows).
+- Rollout ordering is safe in any order: old replicas writing `DO NOTHING` and new
+  replicas writing `DO UPDATE` both leave a valid `last_referenced_at` (NULL or a
+  timestamp); GC tolerates both. No `REDIS_RWLOCK`-style flag needed.
+
+## References
+
+- Research: `thoughts/shared/research/2026-06-08_21-12-01_orphan-blob-lifecycle.md`
+- GC impl: `src/sql-fs/dialects/postgres.ts:702-711`
+- Blob inserts: `src/sql-fs/dialects/postgres.ts:166-168`, `:583-585`, `:965`
+- RLS escape: `src/sql-fs/migrations/postgres/0005_enable_rls.sql:18-58`
+- Per-tenant iteration pattern: `src/api/migrations.ts:40-88`
+- CLI pattern: `src/api/cli/token.ts`
+- Redis blob cache: `src/sql-fs/redis-blob-cache.ts`
+- No-context GC test precedent: `src/sql-fs/tests/integration/rls.integration.test.ts:88`

--- a/thoughts/shared/research/2026-06-08_21-12-01_orphan-blob-lifecycle.md
+++ b/thoughts/shared/research/2026-06-08_21-12-01_orphan-blob-lifecycle.md
@@ -1,0 +1,241 @@
+---
+date: 2026-06-08T21:12:01+09:30
+researcher: Harry.Nguyen@insightfactory.ai
+git_commit: 72a8857ed41978d7fd2de2b6e1e99a6e734a3932
+branch: main
+repository: virtualFS
+topic: "Orphan Blob Lifecycle: How are orphan blobs treated across the codebase?"
+tags: [research, codebase, blobs, gc, garbage-collection, orphan, blob-lifecycle, cas]
+status: complete
+last_updated: 2026-06-08
+last_updated_by: Harry.Nguyen@insightfactory.ai
+---
+
+# Research: Orphan Blob Lifecycle
+
+**Date**: 2026-06-08 21:12:01 ACST
+**Researcher**: Harry.Nguyen@insightfactory.ai
+**Git Commit**: 72a8857ed41978d7fd2de2b6e1e99a6e734a3932
+**Branch**: main
+**Repository**: virtualFS
+
+## Research Question
+
+How are orphan blobs treated across the codebase? (Deep dive into GC triggering, blob lifecycle, and production callsites.)
+
+## Summary
+
+**Orphan blobs are never reclaimed automatically.** The `blobs` table is a global content-addressable store with no FK constraints back to `inodes`. Every write, overwrite, delete, move, copy, or sandbox destruction can produce orphan blob rows — blobs with a valid `sha256` but no inode referencing them. The only mechanism to collect them is `gcOrphanBlobs()`, which runs a global `DELETE … NOT IN (SELECT content_sha256 FROM inodes)` — but this method has **zero production callers**. The CLI entry point (`src/api/cli/gc.ts`) referenced by `pnpm db:gc` does not exist. The admin HTTP endpoint (`routes/admin.ts`) referenced in `CLAUDE.md` does not exist. No scheduled timer fires it. Blobs accumulate indefinitely in production.
+
+A secondary gap: when GC does eventually run, it discards the `RETURNING sha256` values, so Redis blob cache entries for deleted blobs are never explicitly invalidated (they expire only by TTL).
+
+---
+
+## Detailed Findings
+
+### 1. Schema Design: Why Blobs Are Never Cascade-Deleted
+
+**File**: `src/sql-fs/migrations/postgres/0000_create_tables.sql`
+
+```sql
+-- blobs: no sandbox_id, no FK from any other table
+CREATE TABLE IF NOT EXISTS blobs (
+    sha256  BYTEA   PRIMARY KEY,
+    data    BYTEA   NOT NULL,
+    size    BIGINT  NOT NULL DEFAULT 0
+);
+
+-- inodes reference blobs by sha256, but with NO FK constraint
+CREATE TABLE IF NOT EXISTS inodes (
+    id              BIGSERIAL   PRIMARY KEY,
+    sandbox_id      TEXT        NOT NULL REFERENCES sandboxes(id) ON DELETE CASCADE,
+    ...
+    content_sha256  BYTEA,       -- no REFERENCES blobs(sha256)
+    ...
+);
+```
+
+The design is intentional: blobs are a global CAS store shared across all sandboxes for dedup. Adding an FK would prevent blob sharing between sandboxes, or require complex reference counting at the DB level. The tradeoff is that blob cleanup must be application-managed.
+
+`blobs` is also explicitly excluded from Postgres RLS (`0005_enable_rls.sql:40-43`): no `sandbox_id` column means no row-level policy is possible. This is the reason `gcOrphanBlobs` can safely scan all inodes without setting a sandbox context.
+
+**No triggers exist on `blobs` or `inodes` for blob cleanup.**
+
+---
+
+### 2. The Only GC Implementation: `gcOrphanBlobs`
+
+**File**: `src/sql-fs/dialects/postgres.ts:702-711`
+
+```typescript
+// US-014
+async gcOrphanBlobs(tx: PgTx): Promise<number> {
+    const rows = await tx<{ sha256: Buffer }[]>`
+        DELETE FROM blobs
+        WHERE sha256 NOT IN (
+            SELECT content_sha256 FROM inodes WHERE content_sha256 IS NOT NULL
+        )
+        RETURNING sha256
+    `;
+    return rows.length;
+}
+```
+
+**Important details:**
+
+- The `IS NOT NULL` guard is critical for correctness. Without it, `NOT IN` with any `NULL` in the subquery result evaluates to `UNKNOWN` for every row (three-valued logic), meaning no blobs would ever be deleted.
+- The subquery has no `sandbox_id` filter — intentional. It must see all inodes across all sandboxes to avoid deleting a blob still referenced by another sandbox.
+- `RETURNING sha256` values are fetched but immediately **discarded** — only `rows.length` (the count) is returned to the caller. This means any Redis blob cache entries for deleted blobs are never explicitly invalidated. They will continue to serve stale (but harmless) data until `REDIS_BLOB_CACHE_TTL_MS` expires.
+- **MySQL and Azure SQL dialects do not exist on disk** — only `dialects/postgres.ts` is implemented. `gcOrphanBlobs` is declared in the `SqlDialect<Tx>` interface (`types.ts:335`) but only Postgres provides a real implementation.
+
+---
+
+### 3. Production Callers: Zero
+
+A full search across all non-test `.ts` files in `src/` finds:
+
+| Location | Role |
+|---|---|
+| `src/sql-fs/types.ts:335` | Interface declaration only |
+| `src/sql-fs/dialects/postgres.ts:702` | Implementation only |
+
+There are **no production call sites.** The method is exercised only in integration tests (`src/sql-fs/tests/integration/postgres.test.ts:811-941`) covering three behaviours:
+1. Referenced blob survives GC (line 830)
+2. Orphan blob after inode delete is removed (line 856)
+3. Blob shared by two inodes survives after one inode is deleted (line 892)
+
+---
+
+### 4. The Missing Trigger Infrastructure
+
+All three planned mechanisms for invoking GC are either absent or broken:
+
+#### 4a. CLI Script — File Missing
+
+```json
+// package.json:26
+"db:gc": "tsx src/api/cli/gc.ts"
+```
+
+`src/api/cli/gc.ts` **does not exist**. The only file in `src/api/cli/` is `token.ts`. Running `pnpm db:gc` fails immediately with a module-not-found error.
+
+#### 4b. Admin HTTP Route — File Missing
+
+`src/api/routes/admin.ts` referenced in `CLAUDE.md`'s File Layout **does not exist**. The routes directory contains only `exec.ts`, `files.ts`, `ingest.ts`, `sandboxes.ts`, `auth.ts`. No GC endpoint is registered anywhere in `server.ts`.
+
+#### 4c. Scheduled Timer — Not Wired
+
+`src/api/server.ts` starts exactly two background tasks on boot (lines 281-282):
+- `sessionManager.startReaper()` — idle session eviction
+- `startMcpSessionSweeper()` — idle MCP transport eviction
+
+No `setInterval` or cron for `gcOrphanBlobs` exists anywhere in the server.
+
+---
+
+### 5. Blob Lifecycle: When Orphans Are Created
+
+Every operation that removes an inode (or creates a new one for an existing path) leaves the old blob in place:
+
+| Operation | What happens to old blob |
+|---|---|
+| `writeFile` overwriting existing file | Old inode `nlink` decremented → deleted when 0; **old blob row survives** |
+| `appendFile` overwriting existing file | Same as above |
+| `rm` (file or recursive dir) | All inodes deleted; **all blob rows survive** |
+| `mv` displacing a destination file | Destination inode deleted when nlink=0; **blob survives** |
+| `cp` overwriting a destination file | Destination inode deleted when nlink=0; **blob survives** |
+| `destroySandbox` | All inodes cascade-deleted; **ALL blob rows for that sandbox survive** |
+
+The `nlink` decrement + conditional `deleteInode` pattern appears at 6 call sites in `sql-fs.ts` (lines 774-775, 843-844, 978-979, 1003-1004, 1223-1224, 1295-1296). In all cases, `deleteInode` issues `DELETE FROM inodes WHERE id = ?` — no blob row is touched.
+
+The composite wCTE path (`rmComposite`, `writeFileComposite`, `mvComposite`) handles nlink decrement and inode delete inline in SQL, but equally leaves blob rows untouched.
+
+---
+
+### 6. Sandbox Deletion: Full Cascade Map
+
+**File**: `src/sql-fs/dialects/postgres.ts:298-303`
+
+```typescript
+async deleteSandbox(tx: PgTx, sandboxId: string): Promise<void> {
+    await tx`SELECT pg_advisory_xact_lock(hashtextextended(${sandboxId}, 0))`;
+    await tx`DELETE FROM sandboxes WHERE id = ${sandboxId}`;
+}
+```
+
+The single `DELETE FROM sandboxes` cascades via FK:
+
+```
+DELETE FROM sandboxes WHERE id = $1
+  → ON DELETE CASCADE → DELETE FROM inodes WHERE sandbox_id = $1
+    → ON DELETE CASCADE → DELETE FROM dirents WHERE parent_inode_id IN (deleted inodes)
+    → ON DELETE CASCADE → DELETE FROM dirents WHERE inode_id IN (deleted inodes)
+  → ON DELETE CASCADE → DELETE FROM dirents WHERE sandbox_id = $1  (belt-and-suspenders)
+```
+
+**Blobs are not in this cascade chain.** After deletion, the session manager (`session-manager.ts:984-1047`) also cleans up the Redis version key and path snapshot, but not the Redis blob cache.
+
+Full cleanup status after `DELETE /v1/sandboxes/:id`:
+
+| Data | Cleaned? | How |
+|---|---|---|
+| `sandboxes` row | Yes | Explicit `DELETE` in `deleteSandbox` |
+| `inodes` rows | Yes | `ON DELETE CASCADE` |
+| `dirents` rows | Yes | `ON DELETE CASCADE` |
+| `blobs` rows | **No** | No FK, no cascade; GC never called |
+| Redis version key | Yes | `deleteVersionKey()` in session-manager.ts:1027 |
+| Redis path snapshot | Yes (if enabled) | `pathSnapshot.delete()` in session-manager.ts:1033 |
+| Redis blob cache entries | **No** | Expire by `REDIS_BLOB_CACHE_TTL_MS` only |
+
+---
+
+## Code References
+
+- `src/sql-fs/dialects/postgres.ts:702-711` — `gcOrphanBlobs` implementation (the only GC logic)
+- `src/sql-fs/types.ts:335` — `gcOrphanBlobs` interface declaration
+- `src/sql-fs/migrations/postgres/0000_create_tables.sql:38-44` — `blobs` DDL (no FK, no cascade)
+- `src/sql-fs/migrations/postgres/0000_create_tables.sql:14-26` — `inodes` DDL (`content_sha256` has no FK to `blobs`)
+- `src/sql-fs/migrations/postgres/0005_enable_rls.sql:40-43` — explicit exclusion of `blobs` from RLS
+- `src/sql-fs/sql-fs.ts:764` — `upsertBlob` call in `writeFile` (non-composite path)
+- `src/sql-fs/sql-fs.ts:774-775` — `decrementNlink` + conditional `deleteInode` in `writeFile`
+- `src/sql-fs/sql-fs.ts:978-979` — same pattern in `rm` recursive path
+- `src/sql-fs/dialects/postgres.ts:298-303` — `deleteSandbox` (single DELETE, cascade handles the rest)
+- `src/sql-fs/index.ts:105-115` — `destroyPostgresSandbox` (no GC call)
+- `src/api/session-manager.ts:984-1047` — `destroy()` (no GC call)
+- `src/sql-fs/tests/integration/postgres.test.ts:811-941` — the only tests that exercise `gcOrphanBlobs`
+- `package.json:26` — `"db:gc": "tsx src/api/cli/gc.ts"` (broken: file missing)
+
+---
+
+## Architecture Insights
+
+1. **The dedup vs. cleanup tension**: The CAS design correctly enables cross-sandbox blob dedup (two sandboxes with identical files share one blob row). The cost is that cleanup cannot be lazy/cascade — it must be a global scan. The current `NOT IN (SELECT ...)` approach works but will be slow on a large `inodes` table; a `NOT EXISTS` or `LEFT JOIN … WHERE NULL` rewrite would give the planner more options.
+
+2. **The Redis cache gap on GC**: `gcOrphanBlobs` discards the deleted sha256 values. If a Redis blob cache is configured, those entries linger until TTL. This is harmless in practice (an orphan blob in Redis can't be surfaced to any read because no inode references it), but wastes cache memory proportional to churn.
+
+3. **No design history**: The `thoughts/` directory contains no document covering blob GC design. The `db:gc` CLI and `routes/admin.ts` appear to have been specced in `CLAUDE.md` and `package.json` without being implemented, and no design decision record was written.
+
+4. **MySQL/Azure SQL**: These backends are not implemented. When they are, `gcOrphanBlobs` will need dialect-specific equivalents. MySQL lacks `NOT IN` efficiency on large tables (no hash anti-join optimizer); a `LEFT JOIN … WHERE inode.sha256 IS NULL` pattern is recommended.
+
+---
+
+## Open Questions
+
+1. **Why was `gc.ts` never written?** Was it intentionally deferred? There is no ADR or ticket reference.
+2. **Should GC run on sandbox destroy?** Running a global `NOT IN` scan on every sandbox delete is expensive (scans all inodes). A cheaper alternative: track a `refcount` column on `blobs`, decrement on inode delete, GC only blobs with `refcount = 0`. Adds write complexity but eliminates the global scan.
+3. **Should the Redis blob cache be explicitly purged on GC?** The deleted sha256 values from `RETURNING sha256` are available but discarded. Passing them to `RedisBlobCache.mdel()` would keep cache and DB in sync.
+4. **Is `pnpm db:gc` meant to be run externally (cron job, k8s CronJob)?** If so, the missing `gc.ts` is the only blocker. If it's meant to be an admin HTTP endpoint, `routes/admin.ts` needs to be created and wired into `server.ts`.
+
+---
+
+## Historical Context (from thoughts/)
+
+No dedicated design document for blob GC exists in `thoughts/`. The topic appears only incidentally:
+
+- `thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md:136` — lists `gcOrphanBlobs` as one of the `SqlDialect` methods during an inventory, no design discussion.
+- `thoughts/shared/plans/2026-04-24_22-44-38_multi-tenant-postgres-routing.md:34,634` — discusses whether cross-tenant blob dedup should survive in a multi-tenant world, as a side concern.
+
+## Related Research
+
+- `thoughts/shared/research/2026-04-24_21-16-55_session-rehydration-gap.md` — full SqlDialect interface inventory
+- `thoughts/shared/plans/2026-04-24_22-44-38_multi-tenant-postgres-routing.md` — multi-tenant routing and blob cache key design


### PR DESCRIPTION
## Summary

Orphan blobs (rows in `blobs` referenced by zero `inodes`) previously accumulated forever: `gcOrphanBlobs` had **zero production callers** and the `pnpm db:gc` CLI was missing. This PR restores a real, **multi-tenant, race-safe** orphan-blob sweep for an external scheduler (cron / k8s CronJob), and invalidates the Redis blob cache on collection.

## What changed

- **Migration `0006`** adds `blobs.last_referenced_at` — an instant, catalog-only `ADD COLUMN` (legacy rows stay `NULL` and are treated as ancient/collectible, so the existing backlog clears on the first run).
- **Touch-on-reference**: all three blob upserts (`writeFileComposite`, `upsertBlob`, `bulkIngest`) switch from `ON CONFLICT DO NOTHING` to `DO UPDATE SET last_referenced_at = now()`. The `DO UPDATE` row lock serializes a re-adopting writer against GC's `DELETE`, **closing the dedup re-adoption race** (silent content loss).
- **`gcOrphanBlobs(tx, minAgeMs): Promise<Uint8Array[]>`** rewritten to a null-safe `NOT EXISTS` anti-join with a grace window, returning the deleted sha256s. Runs with **no sandbox context** (the RLS escape from migration `0005`) so the anti-join sees every inode — a blob referenced by another sandbox survives.
- **`RedisBlobCache.mdel`** purges collected blobs from the tenant-scoped cache (chunked `UNLINK`, fail-open).
- **`runBlobGc`** orchestrates a resilient per-tenant sweep (one failing tenant doesn't abort the rest; failure logs redact connection-string credentials). The restored **`pnpm db:gc` CLI** adds `--min-age-ms` and `--tenant`; `BLOB_GC_MIN_AGE_MS` sets the grace default (3h).

## Testing

- `pnpm typecheck`, `pnpm lint`, **927 unit tests** — all green (incl. new `blob-gc`, `mdel`, and `gcOrphanBlobs`-signature suites).
- **Integration: 109/109** against real Postgres + Redis (serial). New tests cover grace-window retention→collection, `NULL`-legacy collection, and cross-sandbox survival under no-context GC. `EXPLAIN` confirms the anti-join uses `idx_inodes_content_sha256`.
- **Manual end-to-end** (local Docker: API + Postgres + Redis): a fresh orphan survives the default grace; `pnpm db:gc -- --min-age-ms 0` deletes it from Postgres **and** purges its Redis cache key; `--tenant`/arg validation exit codes verified.

## Notes

- `pnpm db:gc` is intended for an external scheduler — this PR adds **no** HTTP admin endpoint and **no** in-process sweeper (both deferred; `runBlobGc` is factored so either can be layered on later).
- The integration suite is pre-existingly flaky under default parallelism on a single local Postgres (connection contention in unrelated tests, e.g. `listDirents`/`concurrency.pg`); it is deterministically green when run serially. Not introduced by this change.
- A changeset (`minor`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pnpm db:gc` CLI command to garbage-collect orphan blobs across all tenants
  * Introduced `BLOB_GC_MIN_AGE_MS` environment variable to control the retention grace window

* **Documentation**
  * Updated documentation to reference new garbage collection command and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->