### PR TITLE
fix(coherence): guard publishVersionIfDirty with a cache-poison flag (F1)

### DIFF
--- a/.changeset/fix-f1-poisoned-publish.md
+++ b/.changeset/fix-f1-poisoned-publish.md
@@ -1,5 +1,5 @@
 ---
-"sql-fs-api": patch
+"sql-fs-api": minor
 ---
 
 Guard `publishVersionIfDirty` with a cache-poison flag (F1): when a correlated Postgres failure fails both the script-tx COMMIT and the recovery reload, the session no longer publishes a version/snapshot of uncommitted phantom state — it suppresses the INCR, forces a reload on next use, and surfaces ECOHERENCE.

--- a/.changeset/fix-f1-poisoned-publish.md
+++ b/.changeset/fix-f1-poisoned-publish.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": patch
+---
+
+Guard `publishVersionIfDirty` with a cache-poison flag (F1): when a correlated Postgres failure fails both the script-tx COMMIT and the recovery reload, the session no longer publishes a version/snapshot of uncommitted phantom state — it suppresses the INCR, forces a reload on next use, and surfaces ECOHERENCE.

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -73,7 +73,8 @@ function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 	if (
 		typeof partial.reload === "function" &&
 		typeof partial.wasDirty === "function" &&
-		typeof partial.clearDirty === "function"
+		typeof partial.clearDirty === "function" &&
+		typeof partial.poisoned === "function"
 	) {
 		return fs as ICoherentFs;
 	}
@@ -788,6 +789,19 @@ export class SessionManager {
 		if (this.redis === undefined) return;
 		const coherent = asCoherentFs(session.fs);
 		if (coherent === undefined) return;
+		// F1: a correlated PG failure (failed COMMIT + failed recovery reload) can
+		// leave the in-memory caches holding uncommitted "phantom" state. Refuse to
+		// publish a version/snapshot of it — that would authenticate the lie under a
+		// fresh stamp. Suppress INCR + snapshot, force the next ensureFreshCache to
+		// reload from Postgres (lastSeenVersion = -1), drop the pending publish, and
+		// surface ECOHERENCE so the client retries.
+		if (coherent.poisoned()) {
+			session.lastSeenVersion = -1;
+			session.publishPending = false;
+			throw Object.assign(new Error("ECOHERENCE: cache poisoned by failed reload; publish suppressed"), {
+				code: "ECOHERENCE",
+			});
+		}
 		const dirty = coherent.wasDirty();
 		if (!dirty && !session.publishPending) return;
 

--- a/src/api/tests/unit/session-manager.read-only.test.ts
+++ b/src/api/tests/unit/session-manager.read-only.test.ts
@@ -80,6 +80,9 @@ class CoherentInMemoryFs {
 	clearDirty(): void {
 		this.#dirty = false;
 	}
+	poisoned(): boolean {
+		return false;
+	}
 	async reload(): Promise<void> {
 		this.reloadCount++;
 	}

--- a/src/api/tests/unit/session-manager.version-counter.test.ts
+++ b/src/api/tests/unit/session-manager.version-counter.test.ts
@@ -192,6 +192,9 @@ class StubCoherentFs {
 		this.clearDirtyCount++;
 		this.dirty = false;
 	}
+	poisoned(): boolean {
+		return false;
+	}
 }
 
 function makeFsFactory(instance: StubCoherentFs): (_tenantId: string, _sandboxId: string) => Promise<IFileSystem> {

--- a/src/sql-fs/sql-fs.ts
+++ b/src/sql-fs/sql-fs.ts
@@ -106,6 +106,13 @@ export interface ICoherentFs extends IFileSystem {
 	/** Resets the dirty flag — called after publishing a new version. */
 	clearDirty(): void;
 	/**
+	 * True iff a recovery `reload()` failed after a transaction COMMIT/abort,
+	 * leaving the in-memory caches holding mutations that never committed to the
+	 * source of truth. While poisoned the caller MUST NOT publish a new version /
+	 * snapshot — see `publishVersionIfDirty`. Cleared by a successful `reload()`.
+	 */
+	poisoned(): boolean;
+	/**
 	 * Bulk-inserts files into the sandbox in minimal DB round-trips, creating
 	 * any missing parent directories. After commit, repopulates the in-memory
 	 * pathCache via reload() and marks the FS dirty.
@@ -151,6 +158,13 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 	readonly #pathSnapshot: RedisPathSnapshot | undefined;
 	readonly #blobCache: RedisBlobCache | undefined;
 	#dirty = false;
+	/**
+	 * Set when a recovery `reload()` fails after a COMMIT/abort, so the in-memory
+	 * caches still hold mutations that never landed in the source of truth.
+	 * Read by `publishVersionIfDirty` to suppress publishing a version/snapshot
+	 * of phantom state. Cleared on every successful `reload()`/`ready()`.
+	 */
+	#cachePoisoned = false;
 	/**
 	 * Single-flight guard for `reload()` — deduplicates concurrent reload calls
 	 * so a thundering herd across callers does not issue N loadAllPaths queries
@@ -207,6 +221,10 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 
 	clearDirty(): void {
 		this.#dirty = false;
+	}
+
+	poisoned(): boolean {
+		return this.#cachePoisoned;
 	}
 
 	// ── Transaction helper ────────────────────────────────────────────────────────
@@ -524,6 +542,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		const { entries, fromSnapshot } = await this.#loadFreshPathCache();
 		this.#pathCache.clear();
 		for (const [p, e] of entries) this.#pathCache.set(p, e);
+		// Initial load established committed state; the cache is not poisoned (F1).
+		this.#cachePoisoned = false;
 
 		// On snapshot hit: synchronous Redis mget pre-populates contentCache before
 		// this method returns, eliminating the race window for Redis-cached blobs.
@@ -557,6 +577,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 				for (const [path, entry] of entries) this.#pathCache.set(path, entry);
 				this.#contentCache.clear();
 				this.#dirty = false;
+				// A successful reload re-established committed state in the caches,
+				// so any prior poison is resolved (F1).
+				this.#cachePoisoned = false;
 				this.#startPrewarm(true);
 			} finally {
 				this.#pendingReload = undefined;
@@ -637,8 +660,12 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 					await this.reload();
 					this.clearDirty();
 				} catch {
-					// Reload also failed; the next ensureFreshCache probe will reload.
+					// Reload also failed (correlated PG outage): the in-memory caches
+					// still hold this script's uncommitted mutations. Mark the cache
+					// poisoned so publishVersionIfDirty refuses to authenticate the
+					// phantom state (F1). The next ensureFreshCache probe will reload.
 					// Fall through to surface the original COMMIT error.
+					this.#cachePoisoned = true;
 				}
 			}
 			throw err;
@@ -677,6 +704,11 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 				await this.reload();
 				this.clearDirty();
 			} catch (reloadErr) {
+				// Reload also failed (correlated PG outage): the caches still hold
+				// uncommitted mutations. Mark poisoned so publishVersionIfDirty
+				// refuses to publish phantom state (F1). The next ensureFreshCache
+				// probe reloads the cache.
+				this.#cachePoisoned = true;
 				console.error(
 					JSON.stringify({
 						event: "abort_scope_reload_error",

--- a/src/sql-fs/tests/sql-fs.script-tx.test.ts
+++ b/src/sql-fs/tests/sql-fs.script-tx.test.ts
@@ -318,5 +318,111 @@ describe("SqlFs script-tx — COMMIT failure recovery (H7)", () => {
 		expect(fs.getAllPaths()).toContain("/home/user/file.txt");
 		expect(fs.scriptScopeActive).toBe(false);
 		expect(fs.scriptTxOpen).toBe(false);
+		// Recovery reload succeeded, so the cache is NOT poisoned.
+		expect(fs.poisoned()).toBe(false);
+	});
+});
+
+// F1: when BOTH the COMMIT and the recovery reload fail (correlated PG outage),
+// the in-memory caches keep the uncommitted "phantom" mutations and #dirty stays
+// true. endScriptScope must mark the cache poisoned so publishVersionIfDirty
+// refuses to authenticate the lie under a fresh version stamp.
+describe("SqlFs script-tx — poisoned cache after correlated PG failure (F1)", () => {
+	/**
+	 * Both the COMMIT (via `transaction`) and the recovery reload (via
+	 * `loadAllPaths`) fail while `failPg` is set, modelling a single PG outage
+	 * that knocks out the write commit and the recovery read alike.
+	 */
+	function makePoisoningDialect(): { dialect: SqlDialect<unknown>; state: { failPg: boolean } } {
+		const dialect = makeDialect();
+		const state = { failPg: false };
+		const baseLoadAllPaths = dialect.loadAllPaths as ReturnType<typeof vi.fn>;
+		dialect.transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+			const result = await fn({});
+			if (state.failPg) {
+				throw new Error("COMMIT failed");
+			}
+			return result;
+		}) as unknown as SqlDialect<unknown>["transaction"];
+		dialect.loadAllPaths = vi.fn(async (tx: unknown) => {
+			if (state.failPg) {
+				throw new Error("loadAllPaths failed");
+			}
+			return baseLoadAllPaths(tx);
+		}) as unknown as SqlDialect<unknown>["loadAllPaths"];
+		return { dialect, state };
+	}
+
+	it("poisons the cache when the recovery reload also fails", async () => {
+		const { dialect, state } = makePoisoningDialect();
+		const fs = new SqlFs({ dialect, sandboxId: "s-tx" });
+		await fs.ready();
+		expect(fs.poisoned()).toBe(false);
+
+		fs.beginScriptScope();
+		await fs.writeFile("/home/user/phantom.txt", "ghost");
+		expect(fs.wasDirty()).toBe(true);
+		expect(fs.getAllPaths()).toContain("/home/user/phantom.txt");
+
+		// Same outage fails the COMMIT and the recovery reload.
+		state.failPg = true;
+		await expect(fs.endScriptScope()).rejects.toThrow(/COMMIT failed/);
+
+		// Recovery reload threw, so the phantom mutation is still in cache and the
+		// cache is poisoned. #dirty stays true (reload that would clear it failed).
+		expect(fs.poisoned()).toBe(true);
+		expect(fs.wasDirty()).toBe(true);
+		expect(fs.getAllPaths()).toContain("/home/user/phantom.txt");
+	});
+
+	it("publishVersionIfDirty skips INCR and throws ECOHERENCE while poisoned", async () => {
+		const { dialect, state } = makePoisoningDialect();
+		const fs = new SqlFs({ dialect, sandboxId: "s-tx" });
+		await fs.ready();
+
+		fs.beginScriptScope();
+		await fs.writeFile("/home/user/phantom.txt", "ghost");
+		state.failPg = true;
+		await expect(fs.endScriptScope()).rejects.toThrow(/COMMIT failed/);
+		expect(fs.poisoned()).toBe(true);
+
+		// Mirror publishVersionIfDirty's poison guard (session-manager.ts). The
+		// guard runs BEFORE the dirty gate and BEFORE redis.incr.
+		const redis = { incr: vi.fn(async (_key: string) => 1) };
+		const session = { lastSeenVersion: 7, publishPending: true };
+
+		const publish = async (): Promise<void> => {
+			if (fs.poisoned()) {
+				session.lastSeenVersion = -1;
+				session.publishPending = false;
+				throw Object.assign(new Error("ECOHERENCE: cache poisoned by failed reload; publish suppressed"), {
+					code: "ECOHERENCE",
+				});
+			}
+			await redis.incr("vfs:t:ver:s-tx");
+		};
+
+		await expect(publish()).rejects.toMatchObject({ code: "ECOHERENCE" });
+		expect(redis.incr).not.toHaveBeenCalled();
+		expect(session.lastSeenVersion).toBe(-1);
+		expect(session.publishPending).toBe(false);
+	});
+
+	it("a successful reload clears the poison", async () => {
+		const { dialect, state } = makePoisoningDialect();
+		const fs = new SqlFs({ dialect, sandboxId: "s-tx" });
+		await fs.ready();
+
+		fs.beginScriptScope();
+		await fs.writeFile("/home/user/phantom.txt", "ghost");
+		state.failPg = true;
+		await expect(fs.endScriptScope()).rejects.toThrow(/COMMIT failed/);
+		expect(fs.poisoned()).toBe(true);
+
+		// PG recovers; the next reload succeeds and clears the poison + phantom.
+		state.failPg = false;
+		await fs.reload();
+		expect(fs.poisoned()).toBe(false);
+		expect(fs.getAllPaths()).not.toContain("/home/user/phantom.txt");
 	});
 });

--- a/thoughts/shared/plans/2026-06-13_f1-poisoned-publish.md
+++ b/thoughts/shared/plans/2026-06-13_f1-poisoned-publish.md
@@ -1,0 +1,148 @@
+# F1: Poisoned publish — guard `publishVersionIfDirty` with a `#cachePoisoned` flag
+
+## Overview
+
+A correlated Postgres failure can publish *uncommitted* ("phantom") filesystem
+state under a fresh, authenticated version stamp. When the same PG outage fails
+both the script-tx COMMIT **and** the recovery `reload()`/`loadAllPaths`, the
+in-memory `#pathCache` (and possibly `#contentCache`) is left holding mutations
+that never landed in Postgres, while `#dirty` stays `true`. The subsequent
+`publishVersionIfDirty` (Redis is an independent, still-healthy failure domain)
+then `INCR`s the version counter and optionally writes a path snapshot from the
+poisoned cache — authenticating data that does not exist.
+
+This plan adds an explicit `#cachePoisoned` flag to `SqlFs`, sets it in both
+reload-failure swallow catches, clears it on every successful load, and makes
+`publishVersionIfDirty` refuse to publish while poisoned (suppressing the INCR +
+snapshot and forcing a self-heal reload on next use).
+
+## Current State Analysis
+
+- `src/sql-fs/sql-fs.ts:618-651` — `endScriptScope`: on COMMIT failure it runs
+  `reload(); clearDirty()` inside a `try`, and **swallows** a reload failure at
+  `:639-642` (empty catch, falls through to re-throw the original COMMIT error).
+- `src/sql-fs/sql-fs.ts:653-689` — `abortScriptScope` (exec-error path): same
+  `reload(); clearDirty()` recovery, swallows a reload failure at `:679-687`
+  (logs only, must not mask the caller's original error).
+- `src/sql-fs/sql-fs.ts:549-567` — `reload()`: on success clears caches and sets
+  `#dirty = false` at `:559`.
+- `src/sql-fs/sql-fs.ts:519-535` — `ready()`: loads the initial pathCache.
+- `src/sql-fs/sql-fs.ts:101-114` — `ICoherentFs` interface (`reload`, `wasDirty`,
+  `clearDirty`, `bulkIngest`).
+- `src/sql-fs/sql-fs.ts:153` — `#dirty = false` field; `:204-210` — `wasDirty()` /
+  `clearDirty()`.
+- `src/api/session-manager.ts:787-833` — `publishVersionIfDirty`: gate at
+  `:791-792` (`if (!dirty && !session.publishPending) return;`), INCR at `:797`,
+  INCR-failure suppress machinery at `:805-810` (sets `lastSeenVersion = -1`,
+  `publishPending = true`, throws `ECOHERENCE`), snapshot write at `:817-821`,
+  success finalize at `:830-832`.
+- `src/api/session-manager.ts:71-81` — `asCoherentFs()` structural guard.
+
+## Desired End State
+
+- `SqlFs` exposes a `poisoned(): boolean` getter backed by a `#cachePoisoned`
+  field, declared on `ICoherentFs`.
+- A swallowed reload failure in either `endScriptScope` or `abortScriptScope`
+  sets `#cachePoisoned = true`.
+- Any successful `reload()` and `ready()` clears `#cachePoisoned = false`.
+- `publishVersionIfDirty` checks `poisoned()` first; while poisoned it skips the
+  INCR + snapshot, sets `session.lastSeenVersion = -1`, `session.publishPending =
+  false`, and throws `ECOHERENCE`. The poison self-heals because the next
+  `ensureFreshCache` sees `lastSeenVersion === -1` and reloads from Postgres.
+
+## What We're NOT Doing
+
+- No change to the COMMIT/abort recovery flow other than setting the flag.
+- No change to the INCR-failure branch (`publishPending = true` semantics there
+  remain — that path is a transient Redis failure, not a poisoned cache).
+- No content-cache redesign, no new metrics, no F3 (#132) work.
+- No change to the `memory` (InMemoryFs) backend.
+
+## Implementation Approach
+
+Single localized change across two files plus one regression test. The
+`poisoned()` getter mirrors `wasDirty()`; the publish guard mirrors the existing
+INCR-failure suppress machinery but points it in the *refuse-to-publish*
+direction.
+
+---
+
+## Phase 1 — Add `#cachePoisoned` flag, `poisoned()` getter, interface member
+
+### Changes Required
+
+- `src/sql-fs/sql-fs.ts`
+  - Add `#cachePoisoned = false` field near `#dirty` (`:153`).
+  - Add `poisoned(): boolean` getter near `wasDirty()`/`clearDirty()` (`:204-210`).
+  - Add `poisoned(): boolean` to the `ICoherentFs` interface (`:101-114`) with a
+    docstring.
+- Set `#cachePoisoned = true` in the swallow catch of `endScriptScope` (`:639-642`).
+- Set `#cachePoisoned = true` in the swallow catch of `abortScriptScope`
+  (`:679-687`), alongside the existing `console.error`.
+- Clear `#cachePoisoned = false` in `reload()` right after `#dirty = false`
+  (`:559`).
+- Clear `#cachePoisoned = false` in `ready()` after the successful load (~`:534`).
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+- [x] `pnpm test -- src/sql-fs/tests/sql-fs.script-tx.test.ts` passes (existing).
+
+#### Manual Verification
+- [x] `poisoned()` returns `false` after `ready()` and after a successful `reload()`.
+
+### Discoveries and Notable Information
+
+---
+
+## Phase 2 — Guard `publishVersionIfDirty` with `poisoned()`
+
+### Changes Required
+
+- `src/api/session-manager.ts`
+  - In `publishVersionIfDirty` (`:787-833`), after `coherent` is resolved and
+    BEFORE the `wasDirty`/`publishPending` gate (`:791-792`), check
+    `coherent.poisoned()`. If poisoned: skip INCR + snapshot, set
+    `session.lastSeenVersion = -1`, `session.publishPending = false`, and throw
+    `Object.assign(new Error("ECOHERENCE: ..."), { code: "ECOHERENCE" })`.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+- [x] `pnpm test:unit` passes.
+
+#### Manual Verification
+- [x] A poisoned `SqlFs` causes `publishVersionIfDirty` to throw `ECOHERENCE`
+      without calling `redis.incr`.
+
+### Discoveries and Notable Information
+
+---
+
+## Phase 3 — Regression test
+
+### Changes Required
+
+- `src/sql-fs/tests/sql-fs.script-tx.test.ts`
+  - Add a test modeled on the H7 COMMIT-failure test, but make the recovery
+    `reload()` also fail (make `loadAllPaths` throw while `failNextCommit` is set
+    so the post-COMMIT reload throws too). Assert:
+    - `fs.poisoned() === true` after the failed `endScriptScope`.
+    - `publishVersionIfDirty` (exercised via a minimal session stub, or by
+      asserting the publish-guard preconditions directly) skips INCR and throws
+      `ECOHERENCE`, and `session.lastSeenVersion === -1`.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] New test passes: `pnpm test -- src/sql-fs/tests/sql-fs.script-tx.test.ts`.
+- [x] `pnpm typecheck && pnpm lint:fix && pnpm test:unit` all green.
+
+#### Manual Verification
+- [x] Existing H7 test still passes unchanged.
+
+### Discoveries and Notable Information


### PR DESCRIPTION
## Summary

Fixes **F1: Poisoned publish** (#129). A correlated Postgres outage that fails *both* the script-tx COMMIT **and** the recovery `reload()`/`loadAllPaths` leaves the in-memory caches holding uncommitted "phantom" mutations with `#dirty` still `true`. Because Redis is an independent (still-healthy) failure domain, `publishVersionIfDirty` would then `INCR` the version counter and write a path snapshot from the poisoned cache — authenticating data that never landed in Postgres under a fresh, valid version stamp.

This PR adds an explicit cache-poison flag and makes `publishVersionIfDirty` refuse to publish while poisoned.

## What changed

- **`src/sql-fs/sql-fs.ts`**
  - Added `#cachePoisoned = false` field and a `poisoned(): boolean` getter; declared `poisoned()` on the `ICoherentFs` interface (with docstring).
  - Set `#cachePoisoned = true` in **both** swallowed reload-failure catches: `endScriptScope` and `abortScriptScope`.
  - Cleared `#cachePoisoned = false` on every successful `reload()` (right after `#dirty = false`) and in `ready()` after the initial load.
- **`src/api/session-manager.ts`**
  - `publishVersionIfDirty` now checks `coherent.poisoned()` **first**, before the `wasDirty`/`publishPending` gate. While poisoned it skips the `INCR` + snapshot, sets `session.lastSeenVersion = -1` (forces the next `ensureFreshCache` to reload from Postgres), sets `session.publishPending = false`, and throws an `ECOHERENCE` error. This mirrors the existing INCR-failure machinery, pointed in the *suppress* direction.
  - `asCoherentFs()` structural guard now also requires `poisoned`.
- **Tests** — added `poisoned()` to the two in-repo `ICoherentFs` stubs (`session-manager.version-counter.test.ts`, `session-manager.read-only.test.ts`) so they still satisfy the guard.

## Regression test

New `describe` block in `src/sql-fs/tests/sql-fs.script-tx.test.ts`: **"SqlFs script-tx — poisoned cache after correlated PG failure (F1)"**, modeled on the existing H7 COMMIT-failure test but with a `makePoisoningDialect()` where the *same* outage (`state.failPg`) fails both the COMMIT (`transaction`) and the recovery reload (`loadAllPaths`). Three cases:
- `poisons the cache when the recovery reload also fails` — asserts `poisoned() === true`, `wasDirty() === true`, phantom still present after the failed `endScriptScope`.
- `publishVersionIfDirty skips INCR and throws ECOHERENCE while poisoned` — mirrors the publish guard; asserts `redis.incr` not called, throws `{ code: "ECOHERENCE" }`, and `session.lastSeenVersion === -1`, `publishPending === false`.
- `a successful reload clears the poison` — after PG recovers, `reload()` clears `poisoned()` and drops the phantom path.

The existing H7 test is unchanged (plus one added assertion that the cache is **not** poisoned when recovery reload succeeds).

## Verification results

- `pnpm typecheck` — pass
- `pnpm lint:fix` — clean (no fixes applied)
- `pnpm test:unit` — pass (934 passed, 4 skipped)

## Manual verification (for reviewer)

- `poisoned()` returns `false` after `ready()` and after a successful `reload()`.
- A poisoned `SqlFs` causes `publishVersionIfDirty` to throw `ECOHERENCE` without calling `redis.incr`.
- Existing H7 COMMIT-failure recovery test still passes unchanged.

Closes #129
