### PR TITLE
fix(cache): evict displaced contentCache entry on writeFile overwrite (F9a)

### DIFF
--- a/.changeset/fix-f9a-contentcache-leak.md
+++ b/.changeset/fix-f9a-contentcache-leak.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": minor
+---
+
+fix(cache): writeFile now evicts the displaced inode's contentCache entry on overwrite (including empty-file overwrite), preventing orphaned LRU weight (F9a, #138).

--- a/src/sql-fs/sql-fs.ts
+++ b/src/sql-fs/sql-fs.ts
@@ -195,6 +195,11 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		return this.#pathCache;
 	}
 
+	/** @internal exposed for tests asserting contentCache eviction (F9a). */
+	_getContentCache(): LRUCache<bigint, Uint8Array> {
+		return this.#contentCache;
+	}
+
 	async disconnect(): Promise<void> {
 		await this.#dialect.disconnect();
 	}
@@ -777,6 +782,14 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 					return id;
 				});
 
+		// Evict the displaced inode's bytes from contentCache so the dead entry
+		// (ids are never reused) is not left as orphaned LRU weight. This must run
+		// before the `set` below, and crucially also when overwriting with an empty
+		// file — where there is no overwriting `set` to displace the old entry.
+		const displaced = this.#pathCache.get(path);
+		if (displaced !== undefined && displaced.inodeId !== inodeId) {
+			this.#contentCache.delete(displaced.inodeId);
+		}
 		this.#pathCache.set(path, {
 			inodeId,
 			kind: INODE_KIND.FILE,

--- a/src/sql-fs/tests/unit/sql-fs.writefile-cache-evict.test.ts
+++ b/src/sql-fs/tests/unit/sql-fs.writefile-cache-evict.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for F9a (issue #138): SqlFs.writeFile must evict the displaced
+ * inode's bytes from #contentCache on overwrite. inode ids are never reused
+ * (BIGSERIAL), so a non-evicted old entry is dead LRU weight. The empty-file
+ * overwrite case is the critical one: the seeding `set` is guarded by
+ * `byteLength > 0`, so without an explicit evict the old entry is never
+ * displaced by an overwriting `set`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "../../sql-fs.js";
+import type { PathCacheEntry, SqlDialect } from "../../types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+function dirEntry(path: string, inodeId: bigint): { path: string } & PathCacheEntry {
+	return { path, inodeId, kind: 2, mode: 0o755, size: 0, mtime: now, contentSha256: null, symlinkTarget: null };
+}
+
+function fileEntry(path: string, inodeId: bigint, size: number): { path: string } & PathCacheEntry {
+	return {
+		path,
+		inodeId,
+		kind: 1,
+		mode: 0o644,
+		size,
+		mtime: now,
+		contentSha256: new Uint8Array(32),
+		symlinkTarget: null,
+	};
+}
+
+function makeDialect(): {
+	dialect: SqlDialect<unknown>;
+	createInodeMock: ReturnType<typeof vi.fn>;
+	upsertDirentMock: ReturnType<typeof vi.fn>;
+	decrementNlinkMock: ReturnType<typeof vi.fn>;
+} {
+	// Sequential (non-composite) write path: each createInode hands out a fresh id.
+	let nextInode = 11n;
+	const createInodeMock = vi.fn(async () => nextInode++);
+	const upsertDirentMock = vi.fn(async () => 4n as bigint | null); // existing.txt currently maps to inode 4n
+	const decrementNlinkMock = vi.fn(async () => 0);
+
+	const dialect: SqlDialect<unknown> = {
+		connect: vi.fn(),
+		disconnect: vi.fn(),
+		transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+		setSandboxContext: vi.fn(),
+		setSandboxContextWithLock: vi.fn(),
+		loadAllPaths: vi.fn(async () => [
+			dirEntry("/", 1n),
+			dirEntry("/home", 2n),
+			dirEntry("/home/user", 3n),
+			fileEntry("/home/user/existing.txt", 4n, 20),
+		]),
+		createSandbox: vi.fn(),
+		deleteSandbox: vi.fn(),
+		createInode: createInodeMock,
+		getInode: vi.fn(),
+		updateInode: vi.fn(),
+		deleteInode: vi.fn(async () => undefined),
+		incrementNlink: vi.fn(),
+		decrementNlink: decrementNlinkMock,
+		insertDirent: vi.fn(),
+		upsertDirent: upsertDirentMock,
+		deleteDirent: vi.fn(),
+		listDirents: vi.fn(),
+		moveDirent: vi.fn(),
+		upsertBlob: vi.fn(async () => undefined),
+		getBlob: vi.fn(async () => null as Uint8Array | null),
+		getBlobNoTx: vi.fn(async () => null as Uint8Array | null),
+		gcOrphanBlobs: vi.fn(),
+		getBlobsForSandbox: vi.fn(async () => []),
+		loadSubtreeInodes: vi.fn(async () => []),
+		bulkIngest: vi.fn(),
+		resolvePath: vi.fn(),
+	} as unknown as SqlDialect<unknown>;
+
+	return { dialect, createInodeMock, upsertDirentMock, decrementNlinkMock };
+}
+
+describe("SqlFs.writeFile — contentCache eviction on overwrite (F9a)", () => {
+	let fs: SqlFs;
+	let mocks: ReturnType<typeof makeDialect>;
+
+	beforeEach(async () => {
+		mocks = makeDialect();
+		fs = new SqlFs({ dialect: mocks.dialect, sandboxId: "s1" });
+		await fs.ready();
+	});
+
+	it("evicts the displaced inode when overwriting a cached non-empty file with non-empty content", async () => {
+		// First write: existing.txt → inode 11n (seeded in contentCache).
+		await fs.writeFile("/home/user/existing.txt", "version one");
+		const firstInode = mocks.createInodeMock.mock.results[0]!.value as bigint;
+		expect(fs._getContentCache().has(await firstInode)).toBe(true);
+
+		// Overwrite: existing.txt → inode 12n; old inode 11n must be evicted.
+		await fs.writeFile("/home/user/existing.txt", "version two");
+		const secondInode = mocks.createInodeMock.mock.results[1]!.value as bigint;
+
+		expect(fs._getContentCache().has(await firstInode)).toBe(false);
+		expect(fs._getContentCache().has(await secondInode)).toBe(true);
+		// New content is served from cache (no DB read).
+		expect(await fs.readFile("/home/user/existing.txt")).toBe("version two");
+	});
+
+	it("evicts the displaced inode when overwriting a cached non-empty file with an EMPTY file", async () => {
+		// First write: existing.txt → inode 11n (seeded in contentCache).
+		await fs.writeFile("/home/user/existing.txt", "version one");
+		const firstInode = mocks.createInodeMock.mock.results[0]!.value as bigint;
+		const byteCountBefore = fs._getContentCache().calculatedSize;
+		expect(fs._getContentCache().has(await firstInode)).toBe(true);
+		expect(byteCountBefore).toBeGreaterThan(0);
+
+		// Overwrite with empty content: there is no seeding `set` (guarded by
+		// byteLength > 0), so the old entry must be evicted explicitly.
+		await fs.writeFile("/home/user/existing.txt", "");
+		const secondInode = mocks.createInodeMock.mock.results[1]!.value as bigint;
+
+		expect(fs._getContentCache().has(await firstInode)).toBe(false);
+		expect(fs._getContentCache().has(await secondInode)).toBe(false); // empty file not cached
+		// LRU byte count drops back to zero — no orphaned weight.
+		expect(fs._getContentCache().calculatedSize).toBe(0);
+	});
+
+	it("does not evict when the path is new (no displaced inode)", async () => {
+		await fs.writeFile("/home/user/brand-new.txt", "fresh");
+		const inode = mocks.createInodeMock.mock.results[0]!.value as bigint;
+
+		expect(fs._getContentCache().has(await inode)).toBe(true);
+		expect(await fs.readFile("/home/user/brand-new.txt")).toBe("fresh");
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f9a-contentcache-leak.md
+++ b/thoughts/shared/plans/2026-06-13_f9a-contentcache-leak.md
@@ -1,0 +1,76 @@
+# F9a: writeFile leaks displaced inode's contentCache entry
+
+## Overview
+
+`SqlFs.writeFile` creates a new inode on every write and updates `#pathCache`,
+but never evicts the **old** (displaced) inode's bytes from the `#contentCache`
+LRU. Because inode ids are BIGSERIAL and never reused, the old entry becomes
+dead, unreachable LRU weight. `appendFile`, `bulkIngest`, and `rm` all already
+evict. Memory-only, self-healing (reload clears the cache; the dead entry is
+LRU-evicted first), but a warm session looping large-file overwrites without a
+reload accumulates orphans up to the 50 MB cap, reducing effective live
+capacity. Issue: Hazzng/sql-fs#138.
+
+## Current State
+
+- `src/sql-fs/sql-fs.ts:738-791` — `writeFile`: pathCache lookup at `:743`
+  (kind check only), `#contentCache.set(inodeId, bytes)` at `:789` guarded by
+  `byteLength > 0`. No eviction of the displaced inode.
+- `src/sql-fs/sql-fs.ts:716-720` — `bulkIngest` evicts: `const old =
+  this.#pathCache.get(path); if (old !== undefined && old.inodeId !==
+  entry.inodeId) this.#contentCache.delete(old.inodeId);` — the pattern to mirror.
+- `src/sql-fs/sql-fs.ts:849` — `appendFile` evicts via `existing.inodeId`.
+- Critical sub-case: overwriting a non-empty cached file with an **empty** file
+  takes no seeding `set` (guarded by `byteLength > 0`), so nothing displaces the
+  old entry — it must be evicted explicitly.
+
+## Desired End State
+
+`writeFile` evicts the displaced inode's `#contentCache` entry before seeding the
+new one, for both the non-empty and empty-overwrite cases, matching `bulkIngest`.
+
+## What We're NOT Doing
+
+- Not changing `appendFile`, `bulkIngest`, `rm` (already correct).
+- Not refactoring the write transaction or the composite/sequential split.
+- Not adding a shared helper (the inline guard mirrors `bulkIngest` and reads
+  cleanly; a helper would not reduce the diff meaningfully).
+
+## Phase 1 — Evict displaced inode in writeFile
+
+### Changes
+
+1. `src/sql-fs/sql-fs.ts` — in `writeFile`, before the `#contentCache.set` at
+   `:789`, look up the current pathCache entry for `path` and, if its `inodeId`
+   differs from the freshly created `inodeId`, `#contentCache.delete` it. Runs
+   unconditionally (not behind `byteLength > 0`) so the empty-overwrite case is
+   covered.
+2. `src/sql-fs/sql-fs.ts` — add `@internal _getContentCache()` accessor
+   mirroring `_getPathCache()`, so a unit test can assert eviction directly.
+3. `src/sql-fs/tests/unit/sql-fs.writefile-cache-evict.test.ts` — new focused
+   test: non-empty overwrite evicts old inode + caches new; empty overwrite
+   evicts old inode and drops `calculatedSize` to 0; new-path write does not
+   over-evict.
+
+### Success Criteria
+
+#### Automated
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` clean
+- [x] `pnpm test:unit` passes, including the new test file
+- [x] New test fails without the source fix (verified by reverting locally)
+
+#### Manual
+- [x] Diff is minimal and F9a-scoped (one guard block + test accessor + test).
+- [x] Eviction guard mirrors `bulkIngest`'s at `:716-720`.
+
+### Discoveries
+- inode ids are BIGSERIAL and never reused — confirmed; the displaced entry can
+  never be re-read by id, so deletion is always safe.
+- `#contentCache` had no test accessor; added `_getContentCache()` (mirrors the
+  existing `_getPathCache()` `@internal` pattern) rather than asserting eviction
+  indirectly through the LRU cap (which self-heals for equal-size overwrites and
+  would not be a clean discriminator).
+- The empty-overwrite case is the only path with no overwriting `set`, so the
+  eviction must be unconditional — confirmed by the dedicated test asserting
+  `calculatedSize === 0` afterwards.


### PR DESCRIPTION
## Summary

Fixes **F9a** (#138): `SqlFs.writeFile` created a new inode and updated `#pathCache` on every write, but never evicted the **displaced** (old) inode's bytes from the `#contentCache` LRU. Because inode ids are BIGSERIAL and never reused, the old entry became dead, unreachable LRU weight. `appendFile`, `bulkIngest`, and `rm` all already evict.

Memory-only and self-healing, but a warm session looping large-file overwrites without a reload accumulates orphans up to the 50 MB cap, reducing effective live cache capacity.

## What changed

- `src/sql-fs/sql-fs.ts` — in `writeFile`, before the `#contentCache.set`, look up the current pathCache entry for the path and `#contentCache.delete` the displaced inode when its id differs from the newly created inode. Mirrors `bulkIngest`'s guard. Runs **unconditionally** (not behind `byteLength > 0`) so the critical empty-file-overwrite case — where there is no overwriting `set` to displace the old entry — is also covered.
- `src/sql-fs/sql-fs.ts` — added `@internal _getContentCache()` accessor mirroring the existing `_getPathCache()`, so tests can assert eviction directly.
- `src/sql-fs/tests/unit/sql-fs.writefile-cache-evict.test.ts` — new focused unit test.
- `.changeset/fix-f9a-contentcache-leak.md` — minor.
- `thoughts/shared/plans/2026-06-13_f9a-contentcache-leak.md` — plan.

## Tests added

`SqlFs.writeFile — contentCache eviction on overwrite (F9a)`:
- evicts the displaced inode when overwriting a cached non-empty file with non-empty content (and the new content is served from cache)
- evicts the displaced inode when overwriting a cached non-empty file with an **EMPTY** file (LRU `calculatedSize` drops to 0)
- does not evict when the path is new (no over-eviction)

## Verification

- `pnpm typecheck` — pass
- `pnpm lint:fix` — clean (no fixes applied)
- `pnpm test:unit` — 934 passed, 4 skipped
- Red/green confirmed: with the eviction block removed, the two eviction tests fail; with it in place, all 3 pass.

## Reviewer manual-verification steps

1. Revert the eviction block in `writeFile` and run `npx vitest run src/sql-fs/tests/unit/sql-fs.writefile-cache-evict.test.ts` — the two eviction tests should fail.
2. Restore and re-run — all pass.

Closes #138