### PR TITLE
fix(session): boot-assert SESSION_IDLE_MS < version-key TTL (F9b)

### DIFF
--- a/.changeset/fix-f9b-idle-ttl-assert.md
+++ b/.changeset/fix-f9b-idle-ttl-assert.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": minor
+---
+
+Boot-assert that the session idle window (`SESSION_IDLE_MS` / `MCP_SESSION_IDLE_MS`) stays at or below half the Redis version-key TTL when Redis is enabled, failing fast on misconfiguration that would break cache coherence (audit F9b).

--- a/src/api/mcp/server.ts
+++ b/src/api/mcp/server.ts
@@ -7,7 +7,7 @@
 import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import type { SessionManager } from "../session-manager.js";
+import { type SessionManager, assertIdleBelowVersionTtl } from "../session-manager.js";
 import { registerTools } from "./tools.js";
 
 // Map from MCP session ID to active transport + the principal that initiated it.
@@ -23,6 +23,10 @@ interface SessionEntry {
 const sessions = new Map<string, SessionEntry>();
 
 const MCP_SESSION_IDLE_MS = Number(process.env.MCP_SESSION_IDLE_MS ?? "1800000"); // 30 min
+// Audit F9b: the MCP idle window is a separate env-tunable that must obey the
+// same version-key TTL invariant as SESSION_IDLE_MS. Redis presence is keyed off
+// REDIS_URL here (this module has no live Redis handle at load time).
+assertIdleBelowVersionTtl(MCP_SESSION_IDLE_MS, Boolean(process.env.REDIS_URL));
 const MCP_SESSION_MAX = Number(process.env.MCP_SESSION_MAX ?? "1000");
 const MCP_SWEEP_INTERVAL_MS = Number(process.env.MCP_SWEEP_INTERVAL_MS ?? "60000");
 

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -68,6 +68,39 @@ function asSnapshotWriter(fs: ICoherentFs): SnapshotWriterFs | undefined {
  */
 const VERSION_KEY_TTL_SECONDS = 7 * 24 * 60 * 60;
 
+/**
+ * Boot-time coherence guard (audit F9b).
+ *
+ * The version-counter coherence proof requires the session idle-eviction
+ * window to be comfortably shorter than the Redis version-key TTL: once a
+ * sandbox has been idle past the TTL its `vfs:{tenant}:ver:*` key expires and
+ * the counter resets to 1, which is only safe if no replica still holds a
+ * `lastSeenVersion` for it — i.e. every replica has already evicted the
+ * session. If an operator raises `SESSION_IDLE_MS` (or `MCP_SESSION_IDLE_MS`)
+ * at or above the TTL, an idle session can outlive its counter and observe a
+ * post-reset low value, silently re-opening the reset wrap.
+ *
+ * We enforce the MARGIN variant — `idleMs <= TTL/2` — to leave headroom for
+ * the reaper tick and clock skew between replicas. The check only fires when
+ * Redis is in play; memory-only deployments have no version counter and are
+ * unaffected.
+ *
+ * NOTE: `VERSION_KEY_TTL_SECONDS` is in SECONDS and `idleMs` is in
+ * MILLISECONDS — the `* 1000` conversion is load-bearing, do not drop it.
+ */
+export function assertIdleBelowVersionTtl(idleMs: number, hasRedis: boolean): void {
+	if (!hasRedis) return;
+	const maxIdleMs = (VERSION_KEY_TTL_SECONDS * 1000) / 2;
+	if (idleMs > maxIdleMs) {
+		throw Object.assign(
+			new Error(
+				`Session idle window (${idleMs}ms) must not exceed half the Redis version-key TTL (${maxIdleMs}ms = ${VERSION_KEY_TTL_SECONDS}s / 2) when Redis is enabled. A session that outlives its version counter can observe a post-reset low value and break cache coherence (audit F9b). Lower SESSION_IDLE_MS / MCP_SESSION_IDLE_MS, or disable Redis.`,
+			),
+			{ code: "ERR_IDLE_TTL_INVARIANT" },
+		);
+	}
+}
+
 function asCoherentFs(fs: IFileSystem): ICoherentFs | undefined {
 	const partial = fs as Partial<ICoherentFs>;
 	if (
@@ -345,8 +378,10 @@ export class SessionManager {
 				return destroyPostgresSandbox(backend.connectionString, sandboxId);
 			});
 		this.idleMs = idleMs ?? Number(process.env.SESSION_IDLE_MS ?? "600000");
-		this.pathCacheMaxBytes = pathCacheMaxBytes ?? 50 * 1024 * 1024;
 		this.redis = redis;
+		// Audit F9b: fail fast if the idle window could outlive the Redis version key.
+		assertIdleBelowVersionTtl(this.idleMs, this.redis !== undefined);
+		this.pathCacheMaxBytes = pathCacheMaxBytes ?? 50 * 1024 * 1024;
 		this.execLockOptions = execLockOptions;
 		this.rwlockEnabled = rwlockEnabled ?? true;
 		this.pathSnapshot = pathSnapshot;

--- a/src/api/tests/unit/session-manager.idle-ttl-assert.test.ts
+++ b/src/api/tests/unit/session-manager.idle-ttl-assert.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Audit F9b: boot-time assertion that the session idle window stays below the
+ * Redis version-key TTL.
+ *
+ * The version-key TTL is 7 days (in SECONDS); the idle window is in
+ * MILLISECONDS. The guard enforces the MARGIN variant
+ * `idleMs <= VERSION_KEY_TTL_SECONDS * 1000 / 2` and only fires when Redis is
+ * present. These tests pin both the unit conversion and the redis-scoping.
+ */
+
+import type { Redis } from "ioredis";
+import type { IFileSystem } from "just-bash";
+import { InMemoryFs } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { SessionManager, assertIdleBelowVersionTtl } from "../../session-manager.js";
+
+// 7 days in seconds → / 2 → * 1000 = max allowed idle window in ms.
+const MAX_IDLE_MS = (7 * 24 * 60 * 60 * 1000) / 2; // 302_400_000
+
+const fakeRedis = {} as Redis;
+
+const makeFs = async (): Promise<IFileSystem> => new InMemoryFs();
+
+describe("assertIdleBelowVersionTtl (F9b)", () => {
+	it("does not throw when redis is absent, even with an enormous idle window", () => {
+		expect(() => assertIdleBelowVersionTtl(MAX_IDLE_MS * 100, false)).not.toThrow();
+	});
+
+	it("does not throw for a sane idle window with redis present", () => {
+		expect(() => assertIdleBelowVersionTtl(600_000, true)).not.toThrow();
+	});
+
+	it("does not throw at exactly the bound with redis present", () => {
+		expect(() => assertIdleBelowVersionTtl(MAX_IDLE_MS, true)).not.toThrow();
+	});
+
+	it("does not throw just under the bound with redis present", () => {
+		expect(() => assertIdleBelowVersionTtl(MAX_IDLE_MS - 1, true)).not.toThrow();
+	});
+
+	it("throws just over the bound with redis present", () => {
+		expect(() => assertIdleBelowVersionTtl(MAX_IDLE_MS + 1, true)).toThrow(/version-key TTL/);
+	});
+
+	it("attaches the ERR_IDLE_TTL_INVARIANT code", () => {
+		try {
+			assertIdleBelowVersionTtl(MAX_IDLE_MS + 1, true);
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect((err as { code?: string }).code).toBe("ERR_IDLE_TTL_INVARIANT");
+		}
+	});
+
+	it("guards against the unit bug: a value that would pass without *1000 still throws", () => {
+		// VERSION_KEY_TTL_SECONDS / 2 = 302_400. A naive seconds-vs-ms compare
+		// (no *1000) would treat any idleMs <= 302_400 as fine; the correct ms
+		// comparison still allows it, but a value above the ms bound must throw.
+		expect(() => assertIdleBelowVersionTtl(302_400, true)).not.toThrow();
+		expect(() => assertIdleBelowVersionTtl(MAX_IDLE_MS + 1, true)).toThrow();
+	});
+});
+
+describe("SessionManager constructor idle/TTL guard (F9b)", () => {
+	it("throws when constructed with redis and an over-bound idleMs", () => {
+		expect(
+			() =>
+				new SessionManager({
+					createFs: makeFs,
+					redis: fakeRedis,
+					idleMs: MAX_IDLE_MS + 1,
+				}),
+		).toThrow(/version-key TTL/);
+	});
+
+	it("does not throw with redis and a sane idleMs", () => {
+		expect(
+			() =>
+				new SessionManager({
+					createFs: makeFs,
+					redis: fakeRedis,
+					idleMs: 600_000,
+				}),
+		).not.toThrow();
+	});
+
+	it("does not throw with an over-bound idleMs when redis is absent", () => {
+		expect(
+			() =>
+				new SessionManager({
+					createFs: makeFs,
+					idleMs: MAX_IDLE_MS + 1,
+				}),
+		).not.toThrow();
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f9b-idle-ttl-assert.md
+++ b/thoughts/shared/plans/2026-06-13_f9b-idle-ttl-assert.md
@@ -1,0 +1,80 @@
+# F9b: Boot-assert SESSION_IDLE_MS below version-key TTL
+
+## Overview
+
+The distributed cache-coherence proof assumes the session idle-eviction window
+is comfortably shorter than the Redis version-key TTL (`vfs:{tenant}:ver:*`).
+No boot assertion enforces this, so an operator who raises `SESSION_IDLE_MS`
+(or `MCP_SESSION_IDLE_MS`) above the TTL silently re-opens the counter
+reset-to-1 wrap that the TTL is designed to prevent. This PR adds a fail-fast
+boot assertion. Redis-less ("memory-only") deployments are unaffected.
+
+## Current State
+
+- `src/api/session-manager.ts:69` — `VERSION_KEY_TTL_SECONDS = 7 * 24 * 60 * 60`
+  (SECONDS, = 7 days).
+- `src/api/session-manager.ts:347` — constructor sets
+  `this.idleMs = idleMs ?? Number(process.env.SESSION_IDLE_MS ?? "600000")`
+  (MILLISECONDS). No assertion follows.
+- `src/api/session-manager.ts:304` — `private readonly redis: Redis | undefined`,
+  assigned at `:349`. The invariant only matters when Redis is in play.
+- `src/api/mcp/server.ts:25` — `MCP_SESSION_IDLE_MS` (default 1_800_000 ms),
+  a separate env-tunable idle window read at module load. Redis presence at this
+  site is determined by `process.env.REDIS_URL`.
+
+## Desired End State
+
+Both idle-window configuration sites fail fast at boot, with a clear error
+explaining the coherence invariant, when Redis is enabled and the idle window
+is not comfortably below the version-key TTL. The unit conversion
+(seconds → ms via `* 1000`) is explicit and correct; the margin variant
+(`idleMs <= VERSION_KEY_TTL_SECONDS * 1000 / 2`) leaves reaper-tick + clock-skew
+headroom. Memory-only deployments throw nothing.
+
+## What We're NOT Doing
+
+- Not closing the broader reset collision class (FLUSHALL / failover /
+  maxmemory-eviction). That is the epoch/fence token in #131 (F2-L2) — a
+  follow-up, not this PR.
+- Not changing default values of `SESSION_IDLE_MS` / `MCP_SESSION_IDLE_MS`.
+- Not modifying the version-counter protocol itself.
+
+## Phase 1 — boot assertion + shared helper
+
+### Changes
+
+1. `src/api/session-manager.ts`: export
+   `assertIdleBelowVersionTtl(idleMs: number, hasRedis: boolean): void` that
+   throws an `Error` (with `code` "ERR_IDLE_TTL_INVARIANT") when
+   `hasRedis && idleMs > VERSION_KEY_TTL_SECONDS * 1000 / 2`.
+2. Call it in the SessionManager constructor immediately after
+   `this.idleMs = ...` (`:347`) with `hasRedis = this.redis !== undefined`.
+3. `src/api/mcp/server.ts`: call the shared helper at module load against
+   `MCP_SESSION_IDLE_MS`, with `hasRedis` derived from `process.env.REDIS_URL`.
+
+### Success Criteria
+
+#### Automated
+
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+- [x] New unit test: helper throws with redis + over-bound idleMs; does NOT
+      throw for sane idleMs, for the at-bound value, or when redis absent;
+      verifies the `* 1000` conversion (just-under vs just-over
+      `VERSION_KEY_TTL_SECONDS * 1000 / 2`).
+- [x] Constructor throws when given a mock redis + over-bound `idleMs`.
+- [x] `pnpm test:unit` green (no existing fixture regresses — audited: no
+      redis-using fixture passes an explicit large `idleMs`).
+
+#### Manual
+
+- [ ] Boot the server with `REDIS_URL` set and `SESSION_IDLE_MS` above the bound
+      → process exits with the invariant error. Unset `REDIS_URL` → boots fine.
+
+### Discoveries
+
+- MCP idle window is read at module-load time in `mcp/server.ts`, with no
+  SessionManager reference, so the shared helper is keyed off
+  `process.env.REDIS_URL` there rather than a live `Redis` instance.
+- Audit result: every redis-using unit fixture relies on the default `idleMs`
+  (600_000 ms ≈ 10 min), far below the 3.5-day bound. No fixtures need fixing.


### PR DESCRIPTION
## Summary

Closes #139.

The distributed cache-coherence proof assumes the session idle-eviction window stays comfortably below the Redis version-key TTL (`vfs:{tenant}:ver:*`, 7 days). No boot assertion enforced this, so an operator raising `SESSION_IDLE_MS` (or `MCP_SESSION_IDLE_MS`) above the TTL could silently re-open the counter reset-to-1 wrap: an idle session outlives its version counter and observes a post-reset low value.

This PR adds a fail-fast boot assertion. Redis-less ("memory-only") deployments are unaffected.

## What changed

- `src/api/session-manager.ts`: new exported `assertIdleBelowVersionTtl(idleMs, hasRedis)`. Throws an `Error` (code `ERR_IDLE_TTL_INVARIANT`) when `hasRedis && idleMs > VERSION_KEY_TTL_SECONDS * 1000 / 2`. Called in the SessionManager constructor right after `this.idleMs = ...`, with `hasRedis = this.redis !== undefined`.
  - **Unit correctness:** `VERSION_KEY_TTL_SECONDS` is in **seconds**, `idleMs` in **milliseconds** — the `* 1000` conversion is explicit and tested. The **margin** variant (`<= TTL/2 = 302_400_000 ms ≈ 3.5 days`) leaves headroom for the reaper tick and clock skew.
- `src/api/mcp/server.ts`: same shared helper applied to `MCP_SESSION_IDLE_MS` at module load. Redis presence there is keyed off `process.env.REDIS_URL` (no live `Redis` handle at this site).
- `src/api/tests/unit/session-manager.idle-ttl-assert.test.ts`: focused regression tests (10).
- `.changeset/fix-f9b-idle-ttl-assert.md`: minor.
- `thoughts/shared/plans/2026-06-13_f9b-idle-ttl-assert.md`: phased plan.

## Scope note

This assert is **necessary but not sufficient**: the broader reset collision class (FLUSHALL / failover / maxmemory-eviction) is closed only by the epoch/fence token tracked in #131 (F2-L2). Out of scope here.

## Verification

- `pnpm typecheck` — pass
- `pnpm lint:fix` — clean (no fixes applied)
- `pnpm test:unit` — 941 passed, 4 skipped (3 consecutive clean reruns)
- New file alone: 10/10 pass

### Test added

`src/api/tests/unit/session-manager.idle-ttl-assert.test.ts` — covers:
- helper: no-throw when redis absent (even with huge idle); no-throw for sane idle, at-bound, and just-under-bound with redis; throws just-over-bound; `ERR_IDLE_TTL_INVARIANT` code present; explicit unit-bug guard around the `* 1000` conversion.
- constructor: throws with mock redis + over-bound `idleMs`; no-throw with sane `idleMs`; no-throw with over-bound `idleMs` when redis absent.

Fixture audit: no existing redis-using unit fixture passes an explicit large `idleMs` (all use the 600_000 ms default, far below the bound) — no fixtures needed changing.

## Reviewer manual-verification steps

1. Boot the server with `REDIS_URL` set and `SESSION_IDLE_MS=999999999` → process exits with the F9b invariant error.
2. Unset `REDIS_URL` with the same large `SESSION_IDLE_MS` → boots normally.
3. Same two checks via `MCP_SESSION_IDLE_MS` against the MCP module.