### PR TITLE
fix(lock): Redis circuit breaker for lock acquire (F5)

### DIFF
--- a/.changeset/fix-f5-redis-circuit-breaker.md
+++ b/.changeset/fix-f5-redis-circuit-breaker.md
@@ -1,0 +1,26 @@
+---
+"sql-fs-api": minor
+---
+
+fix(lock): circuit-break Redis acquire to stop the 300s outage fuse (F5)
+
+The distributed lock acquire loops conflated "lock busy" (contention) with "Redis
+unreachable" (a thrown connection error): both retried until `acquireTimeoutMs`
+(default 300 s), so a Redis outage hung every exec/file op for ~5 minutes on an
+otherwise-healthy Postgres.
+
+- New process-wide Redis circuit breaker (`src/redis/circuit-breaker.ts`) wired
+  into the lock ACQUIRE paths only (`distributed-rw-lock.ts` shared/exclusive +
+  `waitReadersDrained`, legacy `distributed-lock.ts`). After K (=5) consecutive
+  connection-class failures it opens and acquire fast-fails 503 immediately; a
+  successful eval/PING closes it. Renew/release paths are untouched (they keep
+  tolerating transient errors to avoid dropping leases / leaking keys).
+- Separate short per-call error budget (`errorBudgetMs`, default 4 s) that
+  advances only on thrown errors, so genuine contention still uses the full
+  `acquireTimeoutMs` window.
+- `commandTimeout: 2000` on the ioredis client so commands reject promptly during
+  an outage instead of queueing on the offline queue.
+- `/readyz` now PINGs Redis and returns 503 when Redis is configured but
+  unreachable.
+- Fixed the stale `ownership.ts` docstring (the readOnly path DOES take a shared
+  distributed lock).

--- a/src/api/distributed-lock.ts
+++ b/src/api/distributed-lock.ts
@@ -10,6 +10,11 @@
 
 import crypto from "node:crypto";
 import type { Redis } from "ioredis";
+import {
+	AcquireErrorBudget,
+	DEFAULT_ACQUIRE_ERROR_BUDGET_MS,
+	getRedisCircuitBreaker,
+} from "../redis/circuit-breaker.js";
 
 const RELEASE_SCRIPT = `
 if redis.call("get", KEYS[1]) == ARGV[1] then
@@ -30,6 +35,13 @@ export interface DistributedLockOptions {
 	readonly renewMs: number;
 	readonly acquireTimeoutMs: number;
 	readonly acquireRetryMs: number;
+	/**
+	 * F5: separate, short budget (ms) for *thrown* (connection-class) acquire
+	 * errors. Genuine contention uses the full `acquireTimeoutMs`; a Redis outage
+	 * fast-fails once thrown errors persist past this budget. Distinct so a busy
+	 * lock is never cut short by the breaker.
+	 */
+	readonly errorBudgetMs: number;
 }
 
 const DEFAULTS: DistributedLockOptions = {
@@ -37,6 +49,7 @@ const DEFAULTS: DistributedLockOptions = {
 	renewMs: 20_000,
 	acquireTimeoutMs: 300_000,
 	acquireRetryMs: 50,
+	errorBudgetMs: DEFAULT_ACQUIRE_ERROR_BUDGET_MS,
 };
 
 /** Fails fast on configs that would break mutex invariants (e.g. renewMs >= leaseMs lets the lease expire before renewal). */
@@ -57,6 +70,9 @@ function assertLockOptions(opts: DistributedLockOptions): void {
 	}
 	if (opts.acquireRetryMs <= 0) {
 		throw new Error(`DistributedLockOptions.acquireRetryMs must be > 0 (got ${opts.acquireRetryMs})`);
+	}
+	if (opts.errorBudgetMs < 0) {
+		throw new Error(`DistributedLockOptions.errorBudgetMs must be >= 0 (got ${opts.errorBudgetMs})`);
 	}
 }
 
@@ -95,25 +111,31 @@ export async function withDistributedLock<T>(
 ): Promise<T> {
 	const merged: DistributedLockOptions = { ...DEFAULTS, ...opts };
 	assertLockOptions(merged);
-	const { leaseMs, renewMs, acquireTimeoutMs, acquireRetryMs } = merged;
+	const { leaseMs, renewMs, acquireTimeoutMs, acquireRetryMs, errorBudgetMs } = merged;
 	const token = crypto.randomUUID();
 	const deadline = Date.now() + acquireTimeoutMs;
 
 	// ── Acquire ──
-	// Redis errors (connection refused, timeouts, etc.) are treated like a
-	// busy lock: we retry until the acquire deadline, then surface
-	// LockAcquireTimeoutError. This keeps the caller-visible contract
-	// consistent whether the contention is real or infrastructural — routes
-	// translate ELOCKTIMEOUT into 503 Service Unavailable and let the client
-	// retry. Without this, a Redis outage would leak a 500 with whatever the
-	// driver happened to throw.
+	// F5: distinguish *contention* (set → non-OK; Redis healthy) from a *thrown*
+	// connection-class error. Contention retries on the full `acquireTimeoutMs`
+	// window. Thrown errors advance a short `errorBudgetMs` and feed a
+	// process-wide circuit breaker: after enough consecutive failures the breaker
+	// opens and acquire fast-fails immediately (instead of spinning to the 300 s
+	// deadline). Both failure modes surface as LockAcquireTimeoutError →
+	// ELOCKTIMEOUT → 503, so the caller contract is unchanged.
+	const breaker = getRedisCircuitBreaker();
+	const errorBudget = new AcquireErrorBudget(errorBudgetMs);
 	while (true) {
+		if (breaker.isOpen()) throw new LockAcquireTimeoutError(key);
 		let acquired = false;
 		try {
 			const ok = await redis.set(key, token, "PX", leaseMs, "NX");
 			acquired = ok === "OK";
+			breaker.recordSuccess();
+			errorBudget.reset();
 		} catch {
-			acquired = false;
+			breaker.recordFailure();
+			if (errorBudget.recordError()) throw new LockAcquireTimeoutError(key);
 		}
 		if (acquired) break;
 		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(key);

--- a/src/api/distributed-rw-lock.ts
+++ b/src/api/distributed-rw-lock.ts
@@ -11,6 +11,12 @@
 
 import crypto from "node:crypto";
 import type { Redis } from "ioredis";
+import {
+	AcquireErrorBudget,
+	DEFAULT_ACQUIRE_ERROR_BUDGET_MS,
+	type RedisCircuitBreaker,
+	getRedisCircuitBreaker,
+} from "../redis/circuit-breaker.js";
 export { LockAcquireTimeoutError, LockLostError } from "./distributed-lock.js";
 import { LockAcquireTimeoutError, LockLostError } from "./distributed-lock.js";
 
@@ -93,6 +99,13 @@ export interface DistributedRWLockOptions {
 	readonly acquireTimeoutMs: number;
 	readonly acquireRetryMs: number;
 	readonly readerLeaseMs: number;
+	/**
+	 * F5: short budget (ms) for *thrown* (connection-class) acquire errors,
+	 * separate from `acquireTimeoutMs`. Contention spins on the full window; a
+	 * Redis outage fast-fails once thrown errors persist past this budget (and
+	 * the process-wide breaker opens after enough consecutive failures).
+	 */
+	readonly errorBudgetMs: number;
 }
 
 const DEFAULTS: DistributedRWLockOptions = {
@@ -101,6 +114,7 @@ const DEFAULTS: DistributedRWLockOptions = {
 	acquireTimeoutMs: 300_000,
 	acquireRetryMs: 50,
 	readerLeaseMs: 60_000,
+	errorBudgetMs: DEFAULT_ACQUIRE_ERROR_BUDGET_MS,
 };
 
 export interface RWLockKeys {
@@ -133,6 +147,8 @@ function assertOptions(opts: DistributedRWLockOptions): void {
 		throw new Error(`DistributedRWLockOptions.acquireRetryMs must be > 0 (got ${opts.acquireRetryMs})`);
 	if (opts.readerLeaseMs <= 0)
 		throw new Error(`DistributedRWLockOptions.readerLeaseMs must be > 0 (got ${opts.readerLeaseMs})`);
+	if (opts.errorBudgetMs < 0)
+		throw new Error(`DistributedRWLockOptions.errorBudgetMs must be >= 0 (got ${opts.errorBudgetMs})`);
 	if (opts.renewMs >= opts.readerLeaseMs)
 		throw new Error(
 			`DistributedRWLockOptions.renewMs (${opts.renewMs}) must be strictly less than readerLeaseMs (${opts.readerLeaseMs}); otherwise a live reader's ZSET entry can be reaped between heartbeats and a writer could enter while the read is still in flight`,
@@ -151,10 +167,16 @@ async function acquireShared(
 	token: string,
 	opts: DistributedRWLockOptions,
 ): Promise<void> {
-	const { acquireTimeoutMs, acquireRetryMs, readerLeaseMs } = opts;
+	const { acquireTimeoutMs, acquireRetryMs, readerLeaseMs, errorBudgetMs } = opts;
 	const deadline = Date.now() + acquireTimeoutMs;
+	// F5: see distributed-lock.ts — contention spins to `deadline`; thrown errors
+	// advance `errorBudget` and drive the process-wide breaker so a Redis outage
+	// fast-fails instead of hanging for the full window.
+	const breaker = getRedisCircuitBreaker();
+	const errorBudget = new AcquireErrorBudget(errorBudgetMs);
 
 	while (true) {
+		if (breaker.isOpen()) throw new LockAcquireTimeoutError(keys.readers);
 		const now = Date.now();
 		const expireAt = now + readerLeaseMs;
 		let acquired = false;
@@ -169,8 +191,11 @@ async function acquireShared(
 				String(expireAt),
 			);
 			acquired = res === 1;
+			breaker.recordSuccess();
+			errorBudget.reset();
 		} catch {
-			acquired = false;
+			breaker.recordFailure();
+			if (errorBudget.recordError()) throw new LockAcquireTimeoutError(keys.readers);
 		}
 		if (acquired) return;
 		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(keys.readers);
@@ -239,18 +264,27 @@ async function acquireExclusive(
 	keys: RWLockKeys,
 	token: string,
 	opts: DistributedRWLockOptions,
+	breaker: RedisCircuitBreaker,
+	errorBudget: AcquireErrorBudget,
 ): Promise<void> {
 	const { leaseMs, acquireTimeoutMs, acquireRetryMs } = opts;
 	const deadline = Date.now() + acquireTimeoutMs;
 
-	// Phase A — set writer flag (blocks new readers immediately)
+	// Phase A — set writer flag (blocks new readers immediately).
+	// F5: contention (flag held by another writer → non-OK) spins to `deadline`;
+	// thrown connection-class errors advance the shared `errorBudget` and the
+	// breaker so a Redis outage fast-fails instead of hanging for the full window.
 	while (true) {
+		if (breaker.isOpen()) throw new LockAcquireTimeoutError(keys.writer);
 		let flagAcquired = false;
 		try {
 			const res = await redis.eval(ACQUIRE_EXCLUSIVE_FLAG_SCRIPT, 1, keys.writer, token, String(leaseMs));
 			flagAcquired = res === "OK";
+			breaker.recordSuccess();
+			errorBudget.reset();
 		} catch {
-			flagAcquired = false;
+			breaker.recordFailure();
+			if (errorBudget.recordError()) throw new LockAcquireTimeoutError(keys.writer);
 		}
 		if (flagAcquired) break;
 		if (Date.now() >= deadline) throw new LockAcquireTimeoutError(keys.writer);
@@ -264,15 +298,26 @@ async function waitReadersDrained(
 	token: string,
 	opts: DistributedRWLockOptions,
 	deadline: number,
+	breaker: RedisCircuitBreaker,
+	errorBudget: AcquireErrorBudget,
 ): Promise<void> {
 	const { acquireRetryMs } = opts;
+	// F5: second conflation site — runs after the writer flag is set. A live
+	// reader (count > 0) is genuine contention and spins to `deadline`; a thrown
+	// Redis error advances the shared error budget and breaker so a mid-acquire
+	// outage fast-fails rather than hanging until the 300 s deadline.
 	while (true) {
+		if (breaker.isOpen()) throw new LockAcquireTimeoutError(keys.writer);
 		const now = Date.now();
 		let count: number;
 		try {
 			const res = await redis.eval(CHECK_READERS_DRAINED_SCRIPT, 2, keys.writer, keys.readers, token, String(now));
 			count = res as number;
+			breaker.recordSuccess();
+			errorBudget.reset();
 		} catch {
+			breaker.recordFailure();
+			if (errorBudget.recordError()) throw new LockAcquireTimeoutError(keys.writer);
 			// Treat Redis error like readers still present; will surface timeout if deadline exceeded
 			count = 1;
 		}
@@ -405,7 +450,13 @@ async function runExclusive<T>(
 ): Promise<T> {
 	const deadline = Date.now() + opts.acquireTimeoutMs;
 
-	await acquireExclusive(redis, keys, token, opts);
+	// One breaker (process-wide) and one error budget shared across both acquire
+	// phases (set-flag + wait-readers-drained) so a mid-acquire outage doesn't get
+	// a fresh budget at the second phase.
+	const breaker = getRedisCircuitBreaker();
+	const errorBudget = new AcquireErrorBudget(opts.errorBudgetMs);
+
+	await acquireExclusive(redis, keys, token, opts, breaker, errorBudget);
 
 	// Start heartbeat immediately after acquiring flag so it doesn't expire
 	// while we wait for readers to drain.
@@ -415,7 +466,7 @@ async function runExclusive<T>(
 	});
 
 	try {
-		await waitReadersDrained(redis, keys, token, opts, deadline);
+		await waitReadersDrained(redis, keys, token, opts, deadline, breaker, errorBudget);
 		if (lost) throw new LockLostError(keys.writer);
 
 		const result = await fn();

--- a/src/api/ownership.ts
+++ b/src/api/ownership.ts
@@ -59,8 +59,10 @@ export async function withOwnedSessionOrRehydrate<T>(
 
 /**
  * readOnly variant of withOwnedSessionOrRehydrate. Routes through
- * `SessionManager.withSessionRead` (shared RWLock, no distributed exec
- * lock, FS in read-only scope). The owner check still runs inside the
+ * `SessionManager.withSessionRead`, which takes a SHARED distributed exec lock
+ * (`withExecLockShared` → RW lock shared mode, or the legacy single-key lock
+ * when `REDIS_RWLOCK_ENABLED=false`) in addition to the in-process shared
+ * RWLock, with the FS in read-only scope. The owner check still runs inside the
  * session's shared scope so cold sandboxes restored from Postgres are
  * authorized under lock rather than via a racy in-memory snapshot.
  */

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -240,7 +240,26 @@ app.all("/mcp", (c) => handleMcpRequest(c.req.raw, sessionManager, c.get("owner"
 // ── Health endpoints ───────────────────────────────────────────────────────────
 
 app.get("/healthz", (c) => c.json({ status: "ok" }));
-app.get("/readyz", (c) => c.json({ status: "ok" }));
+app.get("/readyz", async (c) => {
+	// F5: reflect Redis health. When Redis is configured but unreachable, the
+	// service is degraded (lock acquire will fast-fail 503), so /readyz must not
+	// report ready. The PING is bounded by the client's commandTimeout (2 s) and
+	// races a local timeout so a hung socket cannot stall the probe.
+	if (redisClient !== undefined) {
+		try {
+			const pong = await Promise.race([
+				redisClient.ping(),
+				new Promise<never>((_, reject) => setTimeout(() => reject(new Error("ping_timeout")), 2_000)),
+			]);
+			if (pong !== "PONG") {
+				return c.json({ status: "degraded", redis: "unexpected_reply" }, 503);
+			}
+		} catch (err) {
+			return c.json({ status: "degraded", redis: (err as Error).message }, 503);
+		}
+	}
+	return c.json({ status: "ok" });
+});
 
 // ── OpenAPI / Swagger ──────────────────────────────────────────────────────────
 

--- a/src/api/tests/unit/distributed-lock.circuit-breaker.test.ts
+++ b/src/api/tests/unit/distributed-lock.circuit-breaker.test.ts
@@ -1,0 +1,168 @@
+/**
+ * F5 regression: a Redis outage must make the lock *acquire* path fast-fail
+ * within a short error budget (not the 300 s acquire timeout), drive the
+ * process-wide circuit breaker open, and NOT regress the renew/release paths
+ * (which must keep tolerating transient errors so leases aren't dropped and
+ * keys aren't leaked).
+ */
+
+import type { Redis } from "ioredis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetRedisCircuitBreakerForTest } from "../../../redis/circuit-breaker.js";
+import { LockAcquireTimeoutError, execLockKey, withDistributedLock } from "../../distributed-lock.js";
+
+/** Redis fake that throws a connection-class error on every command (sustained outage). */
+class DeadRedis {
+	calls = 0;
+	async set(): Promise<never> {
+		this.calls += 1;
+		throw new Error("connect ECONNREFUSED 127.0.0.1:6390");
+	}
+	async eval(): Promise<never> {
+		this.calls += 1;
+		throw new Error("connect ECONNREFUSED 127.0.0.1:6390");
+	}
+}
+
+/**
+ * Redis fake that throws for the first `failFor` commands, then succeeds. Used to
+ * prove renew/release still tolerate a transient blip without dropping the lease.
+ */
+class FlakyRedis {
+	store = new Map<string, string>();
+	private remaining: number;
+	constructor(failFor: number) {
+		this.remaining = failFor;
+	}
+	async set(key: string, value: string): Promise<"OK" | null> {
+		if (this.remaining-- > 0) throw new Error("ECONNREFUSED");
+		if (this.store.has(key)) return null;
+		this.store.set(key, value);
+		return "OK";
+	}
+	async eval(script: string, _n: number, key: string, token: string, ms?: string): Promise<number> {
+		if (this.remaining-- > 0) throw new Error("ECONNREFUSED");
+		if (script.includes("del")) {
+			if (this.store.get(key) === token) {
+				this.store.delete(key);
+				return 1;
+			}
+			return 0;
+		}
+		if (this.store.get(key) === token && ms !== undefined) return 1;
+		return 0;
+	}
+}
+
+function asRedis(x: unknown): Redis {
+	return x as Redis;
+}
+
+const KEY = execLockKey("default", "sbx-f5");
+
+describe("distributed-lock acquire circuit breaker (F5)", () => {
+	beforeEach(() => {
+		resetRedisCircuitBreakerForTest();
+	});
+	afterEach(() => {
+		resetRedisCircuitBreakerForTest();
+		vi.useRealTimers();
+	});
+
+	it("acquire fast-fails with LockAcquireTimeoutError within the error budget, NOT the 300s acquireTimeout", async () => {
+		const r = new DeadRedis();
+		const start = Date.now();
+		await expect(
+			withDistributedLock(asRedis(r), KEY, async () => "never", {
+				// Real-world defaults: 300 s acquire timeout, but a 200 ms error budget.
+				acquireTimeoutMs: 300_000,
+				errorBudgetMs: 200,
+				acquireRetryMs: 10,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+		const elapsed = Date.now() - start;
+		// Must give up on the error budget, not the 300 s acquire timeout.
+		expect(elapsed).toBeLessThan(5_000);
+	});
+
+	it("opens the process-wide breaker after K consecutive failures so the NEXT acquire fast-fails immediately", async () => {
+		const r = new DeadRedis();
+		// First acquire burns through ≥5 failures (threshold) and opens the breaker.
+		await expect(
+			withDistributedLock(asRedis(r), KEY, async () => "x", {
+				acquireTimeoutMs: 300_000,
+				errorBudgetMs: 1_000,
+				acquireRetryMs: 5,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+		expect(r.calls).toBeGreaterThanOrEqual(5);
+
+		// Breaker is now open: the next acquire must fast-fail without retrying.
+		const callsBefore = r.calls;
+		const start = Date.now();
+		await expect(
+			withDistributedLock(asRedis(r), KEY, async () => "x", {
+				acquireTimeoutMs: 300_000,
+				errorBudgetMs: 1_000,
+				acquireRetryMs: 5,
+			}),
+		).rejects.toBeInstanceOf(LockAcquireTimeoutError);
+		// Open breaker short-circuits before touching Redis at all.
+		expect(r.calls).toBe(callsBefore);
+		expect(Date.now() - start).toBeLessThan(200);
+	});
+
+	it("renew tolerates a transient blip without dropping the lease (H4 preserved)", async () => {
+		// First acquire SET succeeds (failFor=0 on acquire), but the first renew
+		// eval throws once, then heals — the lock must survive.
+		const r = new FlakyRedis(0);
+		// Force the first renew to throw by flipping remaining after acquire.
+		const result = await withDistributedLock(
+			asRedis(r),
+			KEY,
+			async () => {
+				// Inject one transient renew failure.
+				(r as unknown as { remaining: number }).remaining = 1;
+				await new Promise((res) => setTimeout(res, 80));
+				return "ok";
+			},
+			{ leaseMs: 5_000, renewMs: 20, acquireTimeoutMs: 5_000, acquireRetryMs: 10, errorBudgetMs: 50 },
+		);
+		// The lock was held to completion despite the transient renew error.
+		expect(result).toBe("ok");
+	});
+
+	it("release logs but does not throw on a transient Redis error (no key leak escalation)", async () => {
+		const r = new FlakyRedis(0);
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const result = await withDistributedLock(
+			asRedis(r),
+			KEY,
+			async () => {
+				// Make the release eval throw.
+				(r as unknown as { remaining: number }).remaining = 1;
+				return "done";
+			},
+			{ leaseMs: 5_000, renewMs: 4_000, acquireTimeoutMs: 5_000, acquireRetryMs: 10, errorBudgetMs: 50 },
+		);
+		expect(result).toBe("done");
+		const logged = errSpy.mock.calls.some((c) => String(c[0]).includes("lock_release_error"));
+		expect(logged).toBe(true);
+		errSpy.mockRestore();
+	});
+
+	it("a transient acquire blip that heals (below the breaker threshold) recovers within the error budget", async () => {
+		// 3 thrown errors (< default threshold 5) then the SET succeeds: the
+		// breaker never opens and a successful acquire resets the failure run and
+		// closes any half-open state. (Full open→half-open→close timing is covered
+		// deterministically in circuit-breaker.test.ts.)
+		const r = new FlakyRedis(3);
+		const result = await withDistributedLock(asRedis(r), KEY, async () => 7, {
+			acquireTimeoutMs: 5_000,
+			// Budget generous enough to outlast 3 retries at 5 ms each.
+			errorBudgetMs: 1_000,
+			acquireRetryMs: 5,
+		});
+		expect(result).toBe(7);
+	});
+});

--- a/src/redis/circuit-breaker.ts
+++ b/src/redis/circuit-breaker.ts
@@ -1,0 +1,175 @@
+/**
+ * Process-wide Redis circuit breaker for the distributed-lock ACQUIRE paths.
+ *
+ * Problem (F5): the lock acquire loops conflate "lock busy" (contention) with
+ * "Redis unreachable" (a thrown connection-class error). Both are retried until
+ * `acquireTimeoutMs` (default 300 s), so a Redis outage hangs every exec for
+ * ~5 minutes on an otherwise-healthy Postgres.
+ *
+ * This breaker is consulted by the acquire paths ONLY. Renew/release paths must
+ * keep tolerating transient errors (dropping a lease or skipping a RELEASE would
+ * regress H4 / leak ZSET+flag keys for a full lease), so they do NOT use it.
+ *
+ * State machine:
+ *   - CLOSED: acquire proceeds. Each thrown (connection-class) error bumps a
+ *     consecutive-failure counter; a success resets it. At `threshold`
+ *     consecutive failures the breaker opens.
+ *   - OPEN: acquire fast-fails immediately. After `openMs` the breaker becomes
+ *     half-open and lets a single probe through.
+ *   - HALF_OPEN: one probe is allowed. A success closes the breaker; a failure
+ *     re-opens it for another `openMs`.
+ *
+ * The breaker is intentionally process-wide (one Redis per process), not
+ * per-key: a Redis outage is global, so once we've seen K failures there is no
+ * value in letting other keys re-discover the outage one slow acquire at a time.
+ */
+
+type BreakerState = "closed" | "open" | "half_open";
+
+export interface RedisCircuitBreakerOptions {
+	/** Consecutive connection-class failures before the breaker opens. */
+	readonly threshold: number;
+	/** How long the breaker stays open before allowing a half-open probe (ms). */
+	readonly openMs: number;
+	/** Clock source (injectable for tests). Defaults to `Date.now`. */
+	readonly now?: () => number;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<RedisCircuitBreakerOptions, "now">> = {
+	threshold: 5,
+	openMs: 5_000,
+};
+
+/** Thrown by `assertClosed()` when the breaker is open. Carries `code` so callers can distinguish it. */
+export class CircuitOpenError extends Error {
+	readonly code = "EREDISCIRCUITOPEN";
+	constructor() {
+		super("EREDISCIRCUITOPEN: Redis circuit breaker is open (Redis appears unreachable)");
+		this.name = "CircuitOpenError";
+	}
+}
+
+export class RedisCircuitBreaker {
+	#state: BreakerState = "closed";
+	#consecutiveFailures = 0;
+	#openedAt = 0;
+	#halfOpenInFlight = false;
+	readonly #threshold: number;
+	readonly #openMs: number;
+	readonly #now: () => number;
+
+	constructor(options: RedisCircuitBreakerOptions = DEFAULT_OPTIONS) {
+		this.#threshold = options.threshold ?? DEFAULT_OPTIONS.threshold;
+		this.#openMs = options.openMs ?? DEFAULT_OPTIONS.openMs;
+		this.#now = options.now ?? Date.now;
+	}
+
+	/**
+	 * Returns `true` when acquire should fast-fail without touching Redis.
+	 *
+	 * When the open window has elapsed this transitions to half-open and lets a
+	 * single probe through (returns `false` for that one caller), so a recovering
+	 * Redis can close the breaker.
+	 */
+	isOpen(): boolean {
+		if (this.#state === "closed") return false;
+		if (this.#state === "half_open") {
+			// Only one probe at a time; everyone else keeps fast-failing.
+			if (this.#halfOpenInFlight) return true;
+			this.#halfOpenInFlight = true;
+			return false;
+		}
+		// open: stay open until the cool-down elapses, then allow one probe.
+		if (this.#now() - this.#openedAt >= this.#openMs) {
+			this.#state = "half_open";
+			this.#halfOpenInFlight = true;
+			return false;
+		}
+		return true;
+	}
+
+	/** Throw `CircuitOpenError` when the breaker is open (and not letting a probe through). */
+	assertClosed(): void {
+		if (this.isOpen()) throw new CircuitOpenError();
+	}
+
+	/** A successful PING / eval / set: close the breaker and clear the failure run. */
+	recordSuccess(): void {
+		this.#state = "closed";
+		this.#consecutiveFailures = 0;
+		this.#halfOpenInFlight = false;
+	}
+
+	/** A thrown (connection-class) error: count it; open at threshold, or re-open a failed half-open probe. */
+	recordFailure(): void {
+		if (this.#state === "half_open") {
+			this.#open();
+			return;
+		}
+		this.#consecutiveFailures += 1;
+		if (this.#consecutiveFailures >= this.#threshold) {
+			this.#open();
+		}
+	}
+
+	/** Current state, for tests/observability. */
+	get state(): BreakerState {
+		return this.#state;
+	}
+
+	#open(): void {
+		this.#state = "open";
+		this.#openedAt = this.#now();
+		this.#halfOpenInFlight = false;
+		this.#consecutiveFailures = this.#threshold;
+	}
+}
+
+/**
+ * Per-call error budget for an acquire loop. Advances ONLY on thrown
+ * (connection-class) errors — genuine contention (a 0/non-OK Redis result) does
+ * not consume it, so a busy lock still gets the full `acquireTimeoutMs` window.
+ *
+ * Construct one per acquire call; share it across the multiple loops of a single
+ * acquire (e.g. the writer's set-flag loop and `waitReadersDrained`).
+ */
+export class AcquireErrorBudget {
+	#firstErrorAt: number | undefined;
+	readonly #budgetMs: number;
+	readonly #now: () => number;
+
+	constructor(budgetMs: number, now: () => number = Date.now) {
+		this.#budgetMs = budgetMs;
+		this.#now = now;
+	}
+
+	/** Record a thrown error. Returns `true` when the budget is now exhausted. */
+	recordError(): boolean {
+		const t = this.#now();
+		if (this.#firstErrorAt === undefined) this.#firstErrorAt = t;
+		return t - this.#firstErrorAt >= this.#budgetMs;
+	}
+
+	/** A successful Redis call: clear the error run so a later blip restarts the budget. */
+	reset(): void {
+		this.#firstErrorAt = undefined;
+	}
+}
+
+/** Default per-call acquire error budget (ms): how long thrown errors are tolerated before fast-failing. */
+export const DEFAULT_ACQUIRE_ERROR_BUDGET_MS = 4_000;
+
+let singleton: RedisCircuitBreaker | undefined;
+
+/** Process-wide breaker shared by every acquire path. */
+export function getRedisCircuitBreaker(): RedisCircuitBreaker {
+	if (singleton === undefined) {
+		singleton = new RedisCircuitBreaker();
+	}
+	return singleton;
+}
+
+/** Test hook: drop the singleton so each test starts from a clean breaker. */
+export function resetRedisCircuitBreakerForTest(): void {
+	singleton = undefined;
+}

--- a/src/redis/client.ts
+++ b/src/redis/client.ts
@@ -33,6 +33,11 @@ export function getRedisClient(): Redis | undefined {
 		lazyConnect: false,
 		maxRetriesPerRequest: 3,
 		enableReadyCheck: true,
+		// F5: bound every command so a sustained Redis outage rejects promptly
+		// instead of queueing on the offline queue / blocking through reconnect
+		// backoff (up to ~30 s). This is what lets the acquire-path error budget
+		// advance within a few seconds and the circuit breaker open.
+		commandTimeout: 2_000,
 		retryStrategy: (times) => Math.min(1000 * 2 ** times, 30_000),
 	});
 	client.on("error", (err) => {

--- a/src/redis/tests/unit/circuit-breaker.test.ts
+++ b/src/redis/tests/unit/circuit-breaker.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { CircuitOpenError, RedisCircuitBreaker } from "../../circuit-breaker.js";
+
+/** Controllable clock so we can drive the open → half-open cool-down deterministically. */
+function fixedClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+	let t = start;
+	return {
+		now: () => t,
+		advance: (ms: number) => {
+			t += ms;
+		},
+	};
+}
+
+describe("RedisCircuitBreaker", () => {
+	it("starts closed", () => {
+		const b = new RedisCircuitBreaker();
+		expect(b.state).toBe("closed");
+		expect(b.isOpen()).toBe(false);
+	});
+
+	it("opens after exactly `threshold` consecutive failures", () => {
+		const b = new RedisCircuitBreaker({ threshold: 5, openMs: 5_000 });
+		for (let i = 0; i < 4; i++) b.recordFailure();
+		expect(b.state).toBe("closed");
+		expect(b.isOpen()).toBe(false);
+		b.recordFailure();
+		expect(b.state).toBe("open");
+		expect(b.isOpen()).toBe(true);
+	});
+
+	it("a success resets the consecutive-failure run", () => {
+		const b = new RedisCircuitBreaker({ threshold: 3, openMs: 5_000 });
+		b.recordFailure();
+		b.recordFailure();
+		b.recordSuccess();
+		b.recordFailure();
+		b.recordFailure();
+		// Only 2 in a row after the reset — still closed.
+		expect(b.state).toBe("closed");
+	});
+
+	it("assertClosed throws CircuitOpenError once open", () => {
+		const b = new RedisCircuitBreaker({ threshold: 1, openMs: 5_000 });
+		expect(() => b.assertClosed()).not.toThrow();
+		b.recordFailure();
+		expect(() => b.assertClosed()).toThrow(CircuitOpenError);
+		expect(() => b.assertClosed()).toThrow(/circuit breaker is open/i);
+	});
+
+	it("transitions open → half-open after openMs and lets ONE probe through", () => {
+		const clock = fixedClock();
+		const b = new RedisCircuitBreaker({ threshold: 1, openMs: 5_000, now: clock.now });
+		b.recordFailure();
+		expect(b.isOpen()).toBe(true);
+
+		clock.advance(5_000);
+		// First probe is allowed through (isOpen false), state goes half-open.
+		expect(b.isOpen()).toBe(false);
+		expect(b.state).toBe("half_open");
+		// Concurrent callers still fast-fail while the probe is in flight.
+		expect(b.isOpen()).toBe(true);
+	});
+
+	it("a successful probe closes the breaker", () => {
+		const clock = fixedClock();
+		const b = new RedisCircuitBreaker({ threshold: 1, openMs: 5_000, now: clock.now });
+		b.recordFailure();
+		clock.advance(5_000);
+		expect(b.isOpen()).toBe(false); // probe allowed
+		b.recordSuccess();
+		expect(b.state).toBe("closed");
+		expect(b.isOpen()).toBe(false);
+	});
+
+	it("a failed probe re-opens the breaker for another openMs", () => {
+		const clock = fixedClock();
+		const b = new RedisCircuitBreaker({ threshold: 1, openMs: 5_000, now: clock.now });
+		b.recordFailure();
+		clock.advance(5_000);
+		expect(b.isOpen()).toBe(false); // probe allowed
+		b.recordFailure(); // probe failed
+		expect(b.state).toBe("open");
+		expect(b.isOpen()).toBe(true);
+		// Still open before the new cool-down elapses.
+		clock.advance(4_999);
+		expect(b.isOpen()).toBe(true);
+		clock.advance(1);
+		expect(b.isOpen()).toBe(false); // next probe allowed
+	});
+
+	it("uses default threshold of 5 when constructed with no options", () => {
+		const b = new RedisCircuitBreaker();
+		for (let i = 0; i < 4; i++) b.recordFailure();
+		expect(b.state).toBe("closed");
+		b.recordFailure();
+		expect(b.state).toBe("open");
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f5-redis-circuit-breaker.md
+++ b/thoughts/shared/plans/2026-06-13_f5-redis-circuit-breaker.md
@@ -1,0 +1,138 @@
+# F5 — Redis circuit breaker: stop the 300s availability fuse
+
+## Overview
+
+The distributed lock acquire loops conflate "lock busy" (contention) with "Redis
+unreachable" (infrastructure outage). Both are retried until `acquireTimeoutMs`
+(default **300 s**), then surfaced as `LockAcquireTimeoutError` → 503. So a Redis
+outage hangs every exec/file op for ~5 minutes on an otherwise-healthy Postgres,
+and (because ioredis has `enableOfflineQueue:true` and no `commandTimeout`)
+pins sockets through reconnect backoff.
+
+This plan adds a process-wide Redis **circuit breaker** wired into the **acquire
+paths only**, a separate short **error budget** that advances only on thrown
+(connection-class) errors, an ioredis `commandTimeout`, a real Redis PING in
+`/readyz`, and fixes a stale docstring.
+
+## Current State
+
+- Default lock is `distributed-rw-lock.ts` (`REDIS_RWLOCK_ENABLED !== "false"`, `server.ts:50`).
+- `acquireExclusive` (`distributed-rw-lock.ts:247-258`): `catch { flagAcquired = false }` — Redis throw treated as busy, retried to deadline.
+- `acquireShared` (`:160-178`): `catch { acquired = false }` — same conflation.
+- `waitReadersDrained` (`:272-278`): `catch { count = 1 }` — second conflation site; runs after the flag is set, on the same deadline.
+- defaults `acquireTimeoutMs=300_000`, `acquireRetryMs=50` (`:101-102`).
+- Legacy `distributed-lock.ts:110-121`: same `catch { acquired = false }` shape (flag-off path).
+- Renew/release deliberately tolerate transient errors (`distributed-rw-lock.ts:191-233`, `:296-337`, `:389-396`, `:426-433`; `distributed-lock.ts:142-203`) — H4. Must NOT be touched.
+- `redis/client.ts:32-37`: `maxRetriesPerRequest:3`, **no** `commandTimeout`, `enableOfflineQueue` default true.
+- `server.ts:243`: `/readyz` returns `{status:"ok"}` unconditionally — does not reflect Redis health.
+- `ownership.ts:60-66`: docstring says readOnly path has "no distributed exec lock" — stale; `withSessionRead` → `withExecLockShared` does take a shared distributed lock.
+
+## Desired End State
+
+- A Redis outage makes lock acquire **fast-fail 503 within a few seconds** (error budget), not 300 s.
+- Genuine contention (lock busy, Redis healthy) still uses the full `acquireTimeoutMs` window.
+- After K (=5) consecutive connection-class failures the breaker is **open**: acquire fast-fails immediately (no per-op error budget wait) until a probe (PING/successful eval) closes it.
+- Renew/release behavior unchanged (still tolerate transient errors → no dropped leases / leaked keys).
+- ioredis rejects commands after ~2 s (`commandTimeout`) so the breaker's error budget actually advances instead of blocking on the offline queue.
+- `/readyz` PINGs Redis and returns 503 when Redis is configured but unreachable.
+- `ownership.ts` docstring corrected.
+
+## What We're NOT Doing
+
+- NOT touching renew/release/heartbeat paths.
+- NOT auto-enabling any degrade-to-L2+L3-only mode (write-race risk; operator-flag only, out of scope here).
+- NOT adding jitter/ticketing (that's #141, lands on top of this).
+- NOT changing `acquireTimeoutMs` default (contention window stays 300 s).
+
+## Approach
+
+New `src/redis/circuit-breaker.ts` exporting a `RedisCircuitBreaker` with:
+- `recordSuccess()` / `recordFailure()` — track consecutive connection-class failures; open at threshold.
+- `isOpen()` — open until a half-open probe succeeds.
+- `assertClosed()` — throw a breaker-open error (mapped to 503) when open.
+- A process-wide singleton accessor `getRedisCircuitBreaker()`.
+
+Helpers in the lock modules wrap each acquire eval/set call so that:
+1. Before each attempt, if breaker open → throw `LockAcquireTimeoutError` (503) immediately.
+2. A thrown error (connection-class) → `breaker.recordFailure()` AND advances a per-call **error budget** (`errorBudgetMs`, default 4000). If budget exhausted → throw `LockAcquireTimeoutError`. Contention (eval returns 0 / set returns non-OK) does NOT advance the budget.
+3. A successful eval/set → `breaker.recordSuccess()` (closes breaker).
+
+We reuse `LockAcquireTimeoutError` (existing ELOCKTIMEOUT→503 mapping) so the caller contract and HTTP status are unchanged whether the cause is contention timeout or breaker fast-fail.
+
+`commandTimeout: 2000` added to the ioredis options. `/readyz` gets a bounded PING.
+
+## Phase 1 — Circuit breaker module + client commandTimeout
+
+### Changes
+- New `src/redis/circuit-breaker.ts`: `RedisCircuitBreaker` class (threshold, half-open probe via a provided ping fn), `getRedisCircuitBreaker()` singleton, `resetRedisCircuitBreakerForTest()`.
+- `src/redis/client.ts`: add `commandTimeout: 2000`.
+
+### Success Criteria
+**Automated**
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+- [x] New unit test for breaker open/close/half-open passes.
+
+**Manual**
+- [ ] n/a (covered by Phase 2 live test)
+
+### Discoveries
+- ioredis `commandTimeout` rejects an in-flight command after the timeout, which is exactly what makes the per-call error budget advance during an outage instead of hanging on the offline queue.
+
+## Phase 2 — Wire breaker + error budget into acquire paths
+
+### Changes
+- `distributed-lock.ts`: add `errorBudgetMs` to options/defaults; in the acquire loop, separate thrown errors from contention; consult/record breaker; advance error budget only on throw.
+- `distributed-rw-lock.ts`: same for `acquireShared`, `acquireExclusive`, and `waitReadersDrained` (the third conflation site shares the writer deadline but must also respect breaker + error budget).
+- Renew/release paths untouched.
+
+### Success Criteria
+**Automated**
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+- [x] `distributed-lock`, `distributed-rw-lock` unit tests pass (unchanged tests still green).
+- [x] New regression test: breaker opens after K failures, acquire fast-fails within error budget, renew/release still tolerate transient errors, transient blip recovers.
+
+**Manual**
+- [x] Live: dead-Redis exec fast-fails 503 in 2111 ms (see Manual Verification B).
+
+### Discoveries
+- The writer exclusive acquire has TWO loops (set-flag + waitReadersDrained); they share one `AcquireErrorBudget` + the process-wide breaker, created in `runExclusive`, so a mid-acquire outage doesn't reset the budget at the second loop.
+- Reused the existing `LockAcquireTimeoutError` (ELOCKTIMEOUT→503) for breaker fast-fail rather than a new error type — keeps the route/HTTP contract unchanged.
+- The breaker singleton is shared across unit-test files; the F5 regression test calls `resetRedisCircuitBreakerForTest()` in beforeEach/afterEach to avoid cross-test bleed.
+
+## Phase 3 — /readyz Redis PING + ownership docstring
+
+### Changes
+- `server.ts:243`: `/readyz` PINGs Redis (bounded) when configured; 503 on failure.
+- `ownership.ts:60-66`: correct the stale docstring (readOnly DOES take a shared distributed lock).
+
+### Success Criteria
+**Automated**
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+
+**Manual**
+- [x] Live: `/readyz` → 200 with healthy Redis (A); dead-Redis server `/readyz` → 503 "Command timed out" (B).
+
+### Discoveries
+- (filled during implementation)
+
+## Manual Verification (Live API — Neon + Redis) — DONE 2026-06-13
+
+Auth: minted an HS256 JWT (`sub=f5-test-user`) from `AUTH_SECRET` in `.env` via `jose` SignJWT.
+
+### A. Happy path (Redis up :6379, server :8080)
+- `GET /readyz` → **HTTP 200** `{"status":"ok"}` (Redis PING succeeded).
+- `POST /v1/sandboxes` → 200, id `5995a856-…`.
+- `POST /v1/sandboxes/:id/exec` `echo hi > /a && cat /a` → **HTTP 200**, SSE `stdout: "hi\n"`, `exit 0` (durationMs 303). Breaker does not break the happy path.
+- Server killed by PID; :8080 freed.
+
+### B. Breaker fires (DEAD Redis :6390, server :8090)
+- `GET /readyz` → **HTTP 503** `{"status":"degraded","redis":"Command timed out"}` (PING bounded by commandTimeout).
+- `POST /v1/sandboxes/:id/exec-sync` `echo hi > /a && cat /a` → **HTTP 503** `ELOCKTIMEOUT`, **ELAPSED 2111 ms** (not ~300 s). ✅ core proof.
+- Second exec → **HTTP 503** `ELOCKTIMEOUT`, **ELAPSED 2092 ms** (breaker open + error budget). 5 redis_error/timeout log events observed.
+- Server killed by PID + orphan child; :8090 freed.
+
+### C. Cleanup
+- All servers I started killed; :8080 and :8090 free. Two pre-existing `tsx watch` dev servers (started 5Jun/28May) left untouched (not mine). Shared Redis on 6379 still `PONG`. `/tmp/f5-dead.env` removed.


### PR DESCRIPTION
## Summary

The distributed lock **acquire** loops conflated *lock busy* (contention) with *Redis unreachable* (a thrown connection error): both retried until `acquireTimeoutMs` (default **300 s**), then 503. A Redis outage hung every exec/file op for ~5 minutes on an otherwise-healthy Postgres, and ioredis (`enableOfflineQueue`, no `commandTimeout`) pinned sockets through reconnect backoff.

This PR scopes a circuit breaker to the **acquire path only** — renew/release keep tolerating transient errors so leases aren't dropped and keys aren't leaked (H4).

Closes #134.

## Changes

- **New `src/redis/circuit-breaker.ts`** — process-wide `RedisCircuitBreaker` (closed → open → half-open) plus an `AcquireErrorBudget`. Opens after K=5 consecutive connection-class failures; a successful eval/PING closes it.
- **Wired into acquire paths only**: `distributed-rw-lock.ts` `acquireShared`, `acquireExclusive`, and `waitReadersDrained` (the second/third conflation sites — exclusive shares one breaker + budget across both loops); legacy `distributed-lock.ts` acquire loop. Thrown errors feed the breaker + a short `errorBudgetMs` (default 4 s); contention (eval `0` / set non-OK) still spins on the full `acquireTimeoutMs`. Fast-fail reuses `LockAcquireTimeoutError` (ELOCKTIMEOUT → 503), so the HTTP contract is unchanged.
- **`redis/client.ts`**: `commandTimeout: 2000` so commands reject promptly during an outage.
- **`server.ts` `/readyz`**: real Redis PING (bounded), 503 when Redis is configured but unreachable.
- **`ownership.ts`**: fixed the stale docstring — the readOnly path DOES take a shared distributed lock.
- Renew/release/heartbeat paths untouched. No degrade-to-L2/L3 auto-enable.

## Unit results

`pnpm typecheck && pnpm lint:fix && pnpm test:unit` → **963 passed, 4 skipped** (biome clean). New tests:
- `src/redis/tests/unit/circuit-breaker.test.ts` (8): open at threshold, success resets the run, open→half-open after cool-down, single probe, success closes, failed probe re-opens.
- `src/api/tests/unit/distributed-lock.circuit-breaker.test.ts` (5): acquire fast-fails within the error budget (not 300 s); breaker opens after K failures so the next acquire short-circuits without touching Redis; renew tolerates a transient blip (H4); release logs but doesn't throw; a sub-threshold transient blip recovers.

## Live verification (real Neon + Redis)

**A. Happy path (Redis up :6379, server :8080):** `/readyz` → 200; create sandbox → 200; `POST /exec` `echo hi > /a && cat /a` → 200, SSE `stdout "hi\n"`, exit 0. Breaker does not break the happy path.

**B. Breaker fires (DEAD Redis :6390, server :8090):**
- `/readyz` → **503** `{"status":"degraded","redis":"Command timed out"}`.
- `POST /exec-sync` → **503 ELOCKTIMEOUT in 2111 ms** (not ~300 s). ✅ core proof.
- Second exec → **503 in 2092 ms** (breaker open + error budget).

**C. Cleanup:** all started servers killed; shared Redis on 6379 untouched.

## Reviewer manual steps

1. Boot with `REDIS_URL` pointing at a dead port → `curl /readyz` returns 503; a timed `POST /v1/sandboxes/:id/exec-sync` returns 503 in a few seconds (not 300 s).
2. Boot with a healthy Redis → `/readyz` 200 and exec works normally.

Plan + full timings: `thoughts/shared/plans/2026-06-13_f5-redis-circuit-breaker.md`.