### PR TITLE
fix(blob): decouple CAS blob upsert from the script-tx (F6)

### DIFF
--- a/.changeset/fix-f6-blob-decoupled-tx.md
+++ b/.changeset/fix-f6-blob-decoupled-tx.md
@@ -1,0 +1,14 @@
+---
+"sql-fs-api": minor
+---
+
+fix(blob): commit the CAS blob upsert in its own short, self-committing
+transaction (own connection, no advisory lock) BEFORE the inode/dirent composite,
+and run the composite without its `blob_insert` CTE. This removes hot-blob
+contention (F6): previously the `ON CONFLICT (sha256) DO UPDATE SET
+last_referenced_at = now()` tuple lock on a deduplicated hot blob (empty file,
+`.gitkeep`, common lockfiles) was held for the whole script, serializing
+unrelated sandboxes within one tenant DB and risking pool-exhaustion → 503. The
+touch stays unconditional so the GC grace window protects the freshly-committed
+blob until its inode commits; the blob-gc REPEATABLE READ + 40001 re-adoption
+handshake is preserved. Applies to `writeFile`, `appendFile`, and `bulkIngest`.

--- a/src/sql-fs/dialects/postgres.ts
+++ b/src/sql-fs/dialects/postgres.ts
@@ -167,19 +167,17 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		sha256: Uint8Array,
 		data: Uint8Array,
 	): Promise<bigint> {
+		// F6: the CAS blob is committed by `commitBlob` in its own short tx BEFORE
+		// this composite runs, so there is no `blob_insert` CTE here — the
+		// script-tx must not hold the hot-blob `ON CONFLICT DO UPDATE` tuple lock.
 		const rows = await tx<{ new_inode_id: string }[]>`
 			WITH ctx AS (
 				SELECT set_config('app.sandbox_id', ${sandboxId}, true),
 				       pg_advisory_xact_lock(hashtextextended(${sandboxId}, 0))
 			),
-			blob_insert AS (
-				INSERT INTO blobs (sha256, data, size)
-				SELECT ${sha256}, ${data}, ${size} FROM ctx
-				ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
-			),
 			new_inode AS (
 				INSERT INTO inodes (sandbox_id, kind, mode, size, content_sha256)
-				VALUES (${sandboxId}, 1, ${mode}, ${size}, ${sha256})
+				SELECT ${sandboxId}, 1, ${mode}, ${size}, ${sha256} FROM ctx
 				RETURNING id
 			),
 			old_dirent AS (
@@ -613,6 +611,28 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		}
 	}
 
+	// F6
+	async commitBlob(sha256: Uint8Array, data: Uint8Array): Promise<void> {
+		// Self-committing single-statement INSERT on its OWN pool connection — no
+		// surrounding BEGIN, no advisory lock, no sandbox context (`blobs` is
+		// unscoped CAS). The `ON CONFLICT DO UPDATE` tuple lock on a hot blob is
+		// thus released at statement COMMIT instead of being pinned to the
+		// long-lived script-tx, which is the F6 fix. The touch is unconditional so
+		// the GC grace window protects this blob until its referencing inode
+		// commits in the following composite tx.
+		await runTrustedDbAsync(
+			() => this.db()`
+				INSERT INTO blobs (sha256, data, size)
+				VALUES (${sha256}, ${data}, ${data.length})
+				ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()
+			`,
+		);
+		// Fire-and-forget Redis backfill — see upsertBlob.
+		if (this.#blobCache !== undefined) {
+			void this.#blobCache.set(sha256, data);
+		}
+	}
+
 	async getBlob(tx: PgTx, sha256: Uint8Array): Promise<Uint8Array | null> {
 		if (this.#blobCache !== undefined) {
 			const cached = await this.#blobCache.get(sha256);
@@ -984,6 +1004,12 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		}
 
 		// ── Phase C: bulk insert blobs ────────────────────────────────────────────
+		// F6: commit the CAS blobs in their OWN short tx (own pool connection, no
+		// advisory lock — `blobs` is unscoped CAS) BEFORE the inode/dirent work in
+		// the script-tx, so the hot-blob `ON CONFLICT DO UPDATE` tuple lock is
+		// released at this statement's COMMIT instead of being pinned to the
+		// long-lived script-tx. The touch is unconditional so the GC grace window
+		// protects these blobs until their referencing inodes commit below.
 
 		const uniqueBlobs = new Map<string, { sha256: Buffer; data: Uint8Array; size: number }>();
 		for (const f of filesWithHash) {
@@ -998,7 +1024,13 @@ export class PostgresDialect implements SqlDialect<PgTx> {
 		}
 		if (uniqueBlobs.size > 0) {
 			const blobRows = [...uniqueBlobs.values()];
-			await tx`INSERT INTO blobs ${tx(blobRows)} ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()`;
+			const db = this.db();
+			await runTrustedDbAsync(
+				() => db`INSERT INTO blobs ${db(blobRows)} ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()`,
+			);
+			if (this.#blobCache !== undefined) {
+				for (const b of blobRows) void this.#blobCache.set(new Uint8Array(b.sha256), b.data);
+			}
 		}
 
 		// ── Phase D: bulk insert file inodes ─────────────────────────────────────

--- a/src/sql-fs/sql-fs.ts
+++ b/src/sql-fs/sql-fs.ts
@@ -794,6 +794,11 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		const sha256 = new Uint8Array(createHash("sha256").update(bytes).digest());
 		const mtime = new Date();
 
+		// F6: commit the CAS blob in its own short tx FIRST, so the composite
+		// (which runs on the long-lived script-tx) no longer holds the hot-blob
+		// tuple lock for the script duration.
+		if (this.#dialect.commitBlob) await this.#dialect.commitBlob(sha256, bytes);
+
 		const inodeId = this.#dialect.writeFileComposite
 			? await this.#withBareTx((tx) =>
 					this.#dialect.writeFileComposite!(
@@ -808,7 +813,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 					),
 				)
 			: await this.#withTx(async (tx) => {
-					await this.#dialect.upsertBlob(tx, sha256, bytes);
+					if (!this.#dialect.commitBlob) await this.#dialect.upsertBlob(tx, sha256, bytes);
 					const id = await this.#dialect.createInode(tx, {
 						sandboxId: this.#sandboxId,
 						kind: INODE_KIND.FILE,
@@ -871,6 +876,9 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		const sha256 = new Uint8Array(createHash("sha256").update(fullBytes).digest());
 		const { name, parentEntry } = this.#requireParentDir(path);
 
+		// F6: commit the CAS blob in its own short tx FIRST (see writeFile).
+		if (this.#dialect.commitBlob) await this.#dialect.commitBlob(sha256, fullBytes);
+
 		const inodeId = this.#dialect.writeFileComposite
 			? await this.#withBareTx((tx) =>
 					this.#dialect.writeFileComposite!(
@@ -885,7 +893,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 					),
 				)
 			: await this.#withTx(async (tx) => {
-					await this.#dialect.upsertBlob(tx, sha256, fullBytes);
+					if (!this.#dialect.commitBlob) await this.#dialect.upsertBlob(tx, sha256, fullBytes);
 					const id = await this.#dialect.createInode(tx, {
 						sandboxId: this.#sandboxId,
 						kind: INODE_KIND.FILE,

--- a/src/sql-fs/tests/integration/blob-decoupled-tx.integration.test.ts
+++ b/src/sql-fs/tests/integration/blob-decoupled-tx.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * F6 integration: decoupled CAS blob commit.
+ *
+ * Proves (a) `commitBlob` dedups + round-trips, and (b) the decoupled-tx fix —
+ * a `commitBlob` of a hot blob does NOT serialize behind a concurrent long-lived
+ * script-tx that has already written (touched) the same blob row.
+ *
+ * Before the fix, `writeFileComposite`'s `blob_insert` CTE ran inside the
+ * advisory-locked script-tx, holding the `ON CONFLICT DO UPDATE` tuple lock on
+ * the hot blob until COMMIT; a concurrent touch of the same row would block for
+ * the whole script. After the fix the blob is touched in its own short tx, so
+ * the second `commitBlob` returns promptly even while the first script-tx is
+ * open.
+ *
+ * Skipped when DATABASE_URL is not set so CI without a DB still passes.
+ */
+
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PostgresDialect } from "../../dialects/postgres.js";
+
+const SKIP = !process.env.DATABASE_URL;
+
+function timed<T>(label: string, p: Promise<T>, timeoutMs = 5_000): Promise<T> {
+	return Promise.race([
+		p,
+		new Promise<never>((_, reject) => {
+			setTimeout(() => reject(new Error(`${label}: timeout after ${timeoutMs}ms`)), timeoutMs);
+		}),
+	]);
+}
+
+describe.skipIf(SKIP)("PostgresDialect — F6 decoupled blob commit", () => {
+	let dialectA: PostgresDialect;
+	let dialectB: PostgresDialect;
+	const createdSandboxIds: string[] = [];
+
+	beforeAll(async () => {
+		dialectA = new PostgresDialect(process.env.DATABASE_URL!);
+		dialectB = new PostgresDialect(process.env.DATABASE_URL!);
+		await Promise.all([dialectA.connect(), dialectB.connect()]);
+	});
+
+	afterAll(async () => {
+		for (const sandboxId of createdSandboxIds) {
+			try {
+				await dialectA.transaction(async (tx) => {
+					await tx`DELETE FROM sandboxes WHERE id = ${sandboxId}`;
+				});
+			} catch {
+				// already gone
+			}
+		}
+		await Promise.all([dialectA.disconnect(), dialectB.disconnect()]);
+	});
+
+	it("commitBlob dedups and round-trips identical content under one sha", async () => {
+		const data = new TextEncoder().encode(`f6-dedup-${Date.now()}-${Math.random()}`);
+		const sha = new Uint8Array(createHash("sha256").update(data).digest());
+
+		await dialectA.commitBlob(sha, data);
+		await dialectA.commitBlob(sha, data); // idempotent touch
+
+		const rows = await dialectA.transaction(
+			async (tx) => tx<{ n: string }[]>`SELECT count(*)::text AS n FROM blobs WHERE sha256 = ${sha}`,
+		);
+		expect(rows[0]?.n).toBe("1");
+
+		const fetched = await dialectA.getBlobNoTx(sha);
+		expect(fetched).not.toBeNull();
+		expect(Buffer.from(fetched!).equals(Buffer.from(data))).toBe(true);
+	});
+
+	it("writeFileComposite no longer touches the blob, so a held script-tx does not pin the hot-blob lock", async () => {
+		// Model the F6 scenario: sandbox A commits the hot blob (short tx) then runs
+		// a long script that writes a file referencing it via writeFileComposite and
+		// holds the script-tx open. Sandbox B then commitBlobs the SAME bytes — with
+		// the fix, writeFileComposite no longer touches the blob row, so B's short
+		// upsert is not blocked by A's open script-tx.
+		const data = new TextEncoder().encode(`f6-hot-${Date.now()}-${Math.random()}`);
+		const sha = new Uint8Array(createHash("sha256").update(data).digest());
+		const holdMs = 1_500;
+
+		// Set up sandbox A with a root dir we can write into.
+		const sandboxId = `f6-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		createdSandboxIds.push(sandboxId);
+		const rootInodeId = await dialectA.transaction(async (tx) => {
+			await dialectA.setSandboxContextWithLock(tx, sandboxId);
+			const { rootInodeId } = await dialectA.createSandbox(tx, sandboxId);
+			return rootInodeId;
+		});
+
+		// A: commit the blob first (short tx), as the SqlFs write path now does.
+		await dialectA.commitBlob(sha, data);
+
+		let inComposite!: () => void;
+		const inCompositePromise = new Promise<void>((resolve) => {
+			inComposite = resolve;
+		});
+		let release!: () => void;
+		const releasePromise = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		// A: open a long-lived script-tx and run writeFileComposite (which must NOT
+		// touch the blob row anymore), then hold the tx open.
+		const longTx = dialectA.transaction(async (tx) => {
+			await dialectA.writeFileComposite!(tx, sandboxId, rootInodeId, "hot.txt", 0o644, data.length, sha, data);
+			inComposite();
+			await releasePromise;
+		});
+
+		await timed("wait for composite", inCompositePromise);
+
+		// B: commit the SAME blob in its own short tx. Must NOT block on A's open tx.
+		const start = Date.now();
+		await timed("concurrent commitBlob", dialectB.commitBlob(sha, data), 2_000);
+		const elapsed = Date.now() - start;
+		expect(elapsed).toBeLessThan(holdMs);
+
+		release();
+		await timed("release long tx", longTx);
+	});
+});

--- a/src/sql-fs/tests/integration/postgres.test.ts
+++ b/src/sql-fs/tests/integration/postgres.test.ts
@@ -1165,9 +1165,13 @@ describe.skipIf(!process.env.DATABASE_URL)("PostgresDialect — nlink=0 tombston
 		const dataA = new TextEncoder().encode("AAA");
 		const dataB = new TextEncoder().encode("BBBB");
 
+		// F6: the blob is now committed in its own short tx BEFORE the composite,
+		// which no longer carries the blob_insert CTE — mirror the SqlFs write path.
+		await dialect.commitBlob(shaA, dataA);
 		const inodeA = await dialect.transaction(async (tx) =>
 			dialect.writeFileComposite(tx, sandboxId, rootInodeId, "ow.txt", 0o644, dataA.length, shaA, dataA),
 		);
+		await dialect.commitBlob(shaB, dataB);
 		const inodeB = await dialect.transaction(async (tx) =>
 			dialect.writeFileComposite(tx, sandboxId, rootInodeId, "ow.txt", 0o644, dataB.length, shaB, dataB),
 		);

--- a/src/sql-fs/tests/unit/sql-fs.commit-blob.test.ts
+++ b/src/sql-fs/tests/unit/sql-fs.commit-blob.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "../../sql-fs.js";
+import type { PathCacheEntry, SqlDialect } from "../../types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+function dirEntry(path: string, inodeId: bigint): { path: string } & PathCacheEntry {
+	return { path, inodeId, kind: 2, mode: 0o755, size: 0, mtime: now, contentSha256: null, symlinkTarget: null };
+}
+
+/**
+ * F6 regression: the CAS blob upsert must be committed in its OWN tx/connection
+ * BEFORE the inode/dirent composite, so the long-lived script-tx never holds the
+ * hot-blob `ON CONFLICT DO UPDATE` tuple lock for the script duration.
+ *
+ * The mock records the order of `commitBlob` vs the script-tx-bound composite and
+ * the tx handle each receives, so we can assert (a) ordering and (b) that
+ * `commitBlob` does NOT run on the composite's transaction handle.
+ */
+function makeDialect(): {
+	dialect: SqlDialect<unknown>;
+	calls: string[];
+	commitBlobMock: ReturnType<typeof vi.fn>;
+	writeFileCompositeMock: ReturnType<typeof vi.fn>;
+	upsertBlobMock: ReturnType<typeof vi.fn>;
+	compositeTx: { value: unknown };
+} {
+	const calls: string[] = [];
+	const compositeTx: { value: unknown } = { value: undefined };
+	// A sentinel tx handle so we can prove commitBlob never receives it.
+	const SCRIPT_TX = { __script_tx: true };
+
+	const commitBlobMock = vi.fn(async () => {
+		calls.push("commitBlob");
+	});
+	const writeFileCompositeMock = vi.fn(async (tx: unknown) => {
+		calls.push("writeFileComposite");
+		compositeTx.value = tx;
+		return 10n;
+	});
+	const upsertBlobMock = vi.fn(async () => {
+		calls.push("upsertBlob");
+	});
+
+	const dialect: SqlDialect<unknown> = {
+		connect: vi.fn(),
+		disconnect: vi.fn(),
+		// transaction() always passes the SCRIPT_TX sentinel as the tx handle.
+		transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(SCRIPT_TX)),
+		setSandboxContext: vi.fn(),
+		setSandboxContextWithLock: vi.fn(),
+		loadAllPaths: vi.fn(async () => [dirEntry("/", 1n), dirEntry("/dir", 2n)]),
+		createSandbox: vi.fn(),
+		deleteSandbox: vi.fn(),
+		createInode: vi.fn(async () => 10n),
+		getInode: vi.fn(),
+		updateInode: vi.fn(),
+		deleteInode: vi.fn(),
+		incrementNlink: vi.fn(),
+		decrementNlink: vi.fn(async () => 0),
+		insertDirent: vi.fn(),
+		upsertDirent: vi.fn(async () => null),
+		deleteDirent: vi.fn(),
+		listDirents: vi.fn(),
+		moveDirent: vi.fn(),
+		upsertBlob: upsertBlobMock,
+		commitBlob: commitBlobMock,
+		getBlob: vi.fn(async () => null),
+		gcOrphanBlobs: vi.fn(),
+		getBlobsForSandbox: vi.fn(async () => []),
+		loadSubtreeInodes: vi.fn(async () => []),
+		bulkIngest: vi.fn(),
+		resolvePath: vi.fn(),
+		writeFileComposite: writeFileCompositeMock,
+		mkdirComposite: vi.fn(),
+		rmComposite: vi.fn(),
+		mvComposite: vi.fn(),
+	} as unknown as SqlDialect<unknown>;
+
+	return { dialect, calls, commitBlobMock, writeFileCompositeMock, upsertBlobMock, compositeTx };
+}
+
+describe("SqlFs writeFile — F6 decoupled blob commit", () => {
+	let fs: SqlFs;
+	let m: ReturnType<typeof makeDialect>;
+
+	beforeEach(async () => {
+		m = makeDialect();
+		fs = new SqlFs({ dialect: m.dialect, sandboxId: "s1" });
+		await fs.ready();
+	});
+
+	it("commits the blob via commitBlob before the inode/dirent composite", async () => {
+		await fs.writeFile("/dir/a.txt", "hot bytes");
+
+		expect(m.commitBlobMock).toHaveBeenCalledOnce();
+		expect(m.writeFileCompositeMock).toHaveBeenCalledOnce();
+		expect(m.calls).toEqual(["commitBlob", "writeFileComposite"]);
+	});
+
+	it("does NOT run the in-transaction upsertBlob when commitBlob is available", async () => {
+		await fs.writeFile("/dir/a.txt", "hot bytes");
+
+		expect(m.upsertBlobMock).not.toHaveBeenCalled();
+	});
+
+	it("does not pass the composite's script-tx handle to commitBlob (separate connection)", async () => {
+		await fs.writeFile("/dir/a.txt", "hot bytes");
+
+		// commitBlob's signature has no tx parameter; assert it was called with
+		// exactly the (sha256, data) pair and never the composite's tx sentinel.
+		const [arg0, arg1, ...rest] = m.commitBlobMock.mock.calls[0]!;
+		expect(arg0).toBeInstanceOf(Uint8Array); // sha256
+		expect(arg1).toBeInstanceOf(Uint8Array); // data
+		expect(rest).toEqual([]);
+		expect(m.commitBlobMock.mock.calls[0]).not.toContain(m.compositeTx.value);
+	});
+
+	it("dedups: writing identical bytes twice commits the same sha256 both times", async () => {
+		await fs.writeFile("/dir/a.txt", "same");
+		await fs.writeFile("/dir/b.txt", "same");
+
+		expect(m.commitBlobMock).toHaveBeenCalledTimes(2);
+		const sha1 = m.commitBlobMock.mock.calls[0]![0] as Uint8Array;
+		const sha2 = m.commitBlobMock.mock.calls[1]![0] as Uint8Array;
+		expect(Buffer.from(sha1).toString("hex")).toBe(Buffer.from(sha2).toString("hex"));
+	});
+
+	it("appendFile also commits the blob via commitBlob before the composite", async () => {
+		m.calls.length = 0;
+		await fs.appendFile("/dir/log.txt", "line\n");
+
+		expect(m.commitBlobMock).toHaveBeenCalledOnce();
+		expect(m.calls).toEqual(["commitBlob", "writeFileComposite"]);
+	});
+});

--- a/src/sql-fs/types.ts
+++ b/src/sql-fs/types.ts
@@ -306,6 +306,22 @@ export interface SqlDialect<Tx = unknown> {
 	upsertBlob(tx: Tx, sha256: Uint8Array, data: Uint8Array): Promise<void>;
 
 	/**
+	 * Commits a content-addressable blob in its OWN short, self-committing
+	 * transaction (own connection, NO advisory lock — `blobs` is unscoped CAS,
+	 * no `sandbox_id`, no RLS). Decouples the hot-blob `ON CONFLICT DO UPDATE`
+	 * tuple lock from the long-lived script-tx so unrelated sandboxes sharing a
+	 * hot blob (empty file, `.gitkeep`) do not serialize for the script duration
+	 * (F6). The touch (`last_referenced_at = now()`) is unconditional so the GC
+	 * grace window protects the freshly-committed-but-not-yet-referenced blob
+	 * during the gap before the referencing inode commits.
+	 *
+	 * Callers MUST invoke this BEFORE the inode/dirent composite, which runs
+	 * without the blob insert. Optional: dialects without it fall back to the
+	 * in-transaction `upsertBlob` path.
+	 */
+	commitBlob?(sha256: Uint8Array, data: Uint8Array): Promise<void>;
+
+	/**
 	 * Retrieves blob content by its SHA-256 hash.
 	 * Returns null if no blob with that hash exists.
 	 */

--- a/thoughts/shared/plans/2026-06-13_f6-blob-decoupled-tx.md
+++ b/thoughts/shared/plans/2026-06-13_f6-blob-decoupled-tx.md
@@ -1,0 +1,174 @@
+# F6: Hot CAS blob contention — decouple blob upsert into its own short tx
+
+## Overview
+
+Deduplicated "hot" blobs (the empty-file sha, `.gitkeep`, common lockfiles) are a
+single `blobs` row whose `INSERT ... ON CONFLICT (sha256) DO UPDATE SET
+last_referenced_at = now()` tuple lock is held for the **whole script** when the
+touch runs inside the long-lived, advisory-locked script-tx. Postgres holds the
+conflicting-tuple lock to end-of-tx even when a conditional `WHERE` filters out
+the update, so conditional-WHERE alone does NOT fix it. The result: unrelated
+sandboxes **within one tenant DB** serialize on that single hot row, and combined
+with the `max=2` PG pool and no `lock_timeout`, this is a fleet-wide
+pool-exhaustion → 503 path.
+
+This PR ships the issue's "Fix to ship" — the **decoupled-tx** shape:
+
+- Add `PostgresDialect.commitBlob(sha256, data)`: commits the CAS blob upsert in
+  its **own short, self-committing transaction** on a separate pool connection,
+  with **no advisory lock** (`blobs` is unscoped CAS — no `sandbox_id`, no RLS).
+- `writeFileComposite` runs **without** its `blob_insert` CTE; the SqlFs layer
+  calls `commitBlob` **before** the composite (and before the legacy
+  `upsertBlob` fallback path).
+- `bulkIngest` commits its unique blobs via `commitBlob` first, then runs the
+  inode/dirent composite without the in-tx blob insert.
+- The touch stays **unconditional** so the GC grace window
+  (`BLOB_GC_MIN_AGE_MS`, default 3h) protects the freshly-committed-but-not-yet-
+  referenced blob during the gap between blob-commit and inode-commit.
+- Preserve the GC re-adoption handshake (`blob-gc.ts` REPEATABLE READ + 40001
+  retry) and RLS / `set_config('app.sandbox_id')` / `runTrustedDbAsync`
+  (defense-in-depth) wrapping.
+
+## Current State Analysis
+
+- `src/sql-fs/dialects/postgres.ts:170-218` — `writeFileComposite`: the
+  `blob_insert` CTE at `:175-179` runs the `ON CONFLICT (sha256) DO UPDATE SET
+  last_referenced_at = now()` inside the script-tx (advisory-locked via the `ctx`
+  CTE). This holds the hot-blob tuple lock to COMMIT.
+- `src/sql-fs/dialects/postgres.ts:598-614` — `upsertBlob`: same touch, in-tx
+  (used only by the non-composite fallback path).
+- `src/sql-fs/dialects/postgres.ts:1001` — `bulkIngest`: `INSERT INTO blobs ...
+  ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()` in the script-tx.
+- `src/sql-fs/dialects/postgres.ts:58` — pool `max=2`.
+- `src/sql-fs/dialects/postgres.ts:272` — `db()` returns the pool; a bare
+  `this.db()` call auto-commits a single statement (own connection, own tx).
+- `src/sql-fs/sql-fs.ts:797-825` / `:874-902` — `writeFile` / `appendFile` route
+  the composite through `#withBareTx` (which routes to the open script-tx when a
+  scope is active), with a non-composite fallback that calls `upsertBlob` inside
+  `#withTx`.
+- `src/sql-fs/sql-fs.ts:760` — `bulkIngest` routes through `#withTx`.
+- `src/api/blob-gc.ts:39-61` — GC runs at REPEATABLE READ, retrying 40001. The
+  handshake: a writer touches (`last_referenced_at = now()`) + locks an existing
+  orphan blob, then inserts the referencing inode; under RR that conflicts with
+  GC's snapshot and raises 40001, so GC retries and then sees the inode. The
+  decoupled tx commits the touch FIRST (own tx) and the inode SECOND (composite
+  tx); the grace window covers the gap so a GC sweep landing between the two
+  commits keeps the blob (its `last_referenced_at` is now-fresh, younger than
+  `minAgeMs`).
+- `src/sql-fs/types.ts:300-306` — `SqlDialect.upsertBlob`; new optional
+  `commitBlob` added alongside.
+
+## Desired End State
+
+- The CAS blob row is touched in a sub-second self-committing tx and released
+  immediately. The script-tx no longer holds any lock on the `blobs` row.
+- Two sandboxes writing the same hot bytes do not serialize on the blob row for
+  the script duration.
+- Dedup + content round-trip unchanged. GC re-adoption invariant preserved.
+
+## What We're NOT Doing
+
+- Not changing MySQL / Azure SQL dialects (Postgres is the only live backend; the
+  optional `commitBlob` is absent there and SqlFs falls back to the existing
+  in-tx `upsertBlob` path).
+- Not adding `lock_timeout` (separate concern, out of scope for F6).
+- Not removing the unconditional touch (the grace window depends on it).
+
+## Implementation Phases
+
+### Phase 1 — Add `commitBlob` to the dialect interface + Postgres impl; drop `blob_insert` CTE
+
+- Add optional `commitBlob(sha256, data)` to `SqlDialect` in `types.ts`.
+- Implement `PostgresDialect.commitBlob`: `runTrustedDbAsync(() => this.db()\`INSERT
+  INTO blobs ... ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()\`)`.
+  Own connection, auto-committing single statement, no advisory lock. Fire the
+  Redis blob cache set after (like `upsertBlob`).
+- Remove the `blob_insert` CTE from `writeFileComposite` (keep the Redis set).
+- Replace the in-tx blob INSERT in `bulkIngest` with a `commitBlob` loop over the
+  unique blobs (committed before the inode/dirent work).
+
+**Automated success criteria:**
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm lint:fix` clean.
+
+**Manual success criteria:**
+- [x] `writeFileComposite` SQL no longer contains `blob_insert`.
+
+### Phase 2 — Call `commitBlob` from SqlFs before the composite / upsertBlob
+
+- In `writeFile` / `appendFile`: call `this.#dialect.commitBlob?.(...)` (await)
+  BEFORE the composite when `commitBlob` is present; otherwise the existing
+  fallback `upsertBlob` inside `#withTx` is unchanged.
+- `bulkIngest`: blobs are committed inside `dialect.bulkIngest` via `commitBlob`,
+  so SqlFs needs no change there — verify the composite no longer needs the blob.
+
+**Automated success criteria:**
+- [x] `pnpm typecheck` passes.
+- [x] `pnpm test:unit` green.
+
+**Manual success criteria:**
+- [x] Composite-path write still dedups and round-trips (live A + integration).
+
+### Phase 3 — Regression test
+
+- Unit (mock dialect): assert `commitBlob` is invoked and that it runs on a tx/
+  connection separate from the composite (the mock records call order: `commitBlob`
+  before `writeFileComposite`, and `commitBlob` is NOT passed the script-tx handle).
+- Integration (gated `skipIf(!DATABASE_URL)`): two writes of identical bytes both
+  succeed, dedup holds (same sha, one blob row), and the second write does not
+  block on a lock held by the first's still-open script-tx.
+
+**Automated success criteria:**
+- [x] New unit test passes; `pnpm test:unit` green (959 tests).
+
+**Manual success criteria:**
+- [x] Integration test passes locally against Neon.
+
+### Phase 4 — LIVE API verification (see Manual Verification below)
+
+## Manual Verification
+
+Live server booted on :8081 (`tsx --env-file .env src/api/server.ts`) against
+real Neon + Redis 6379. `/healthz` + `/readyz` → 200. Token via
+`POST /v1/auth/bootstrap` (X-Auth-Secret). Server killed by PID afterward; Redis
+6379 left running.
+
+### A. Dedup + correctness — PASS
+- Sandbox created; `printf "hot-dedup-content" > /a.txt; cp /a.txt /b.txt`.
+- Both files round-trip the exact content; `sha256sum` identical for /a.txt and
+  /b.txt (`14c3886b…29407`) → dedup holds, content correct. exec 200, exitCode 0.
+
+### B. Concurrency (the F6 point) — PASS
+- Two sandboxes, two CONCURRENT `exec-sync` each writing the SAME hot bytes
+  (`> /k` universal empty blob, then `printf "shared-hot-bytes" > /hot.txt`).
+- Both 200, exitCode 0. Wall clock: **single write = 498 ms**, **concurrent
+  (both sandboxes) = 586 ms** — ≈ a single write, NOT ~2× (which is what
+  serialization on the shared blob row would produce). No multi-second mutual
+  block.
+- Longer-script variant (50-line loop) also ran in parallel: wall ≈ 6.67 s ≈ the
+  max of the two (~6.3 s / ~6.6 s), not the sum (~13 s).
+- DB check: exactly **1** blob row for the `shared-hot-bytes` sha despite two
+  sandboxes writing it → CAS dedup intact.
+
+### GC re-adoption handshake — preserved
+- `commitBlob`'s touch (`last_referenced_at = now()`) is unconditional; the
+  blob commits FIRST (own tx), the referencing inode commits SECOND (composite
+  tx). A GC sweep landing in the gap sees a now-fresh `last_referenced_at` (well
+  inside `BLOB_GC_MIN_AGE_MS`, default 3h) and keeps the blob. `blob-gc.ts`
+  REPEATABLE READ + 40001 retry is unchanged; integration GC tests in
+  `postgres.test.ts` still pass.
+
+### Note: pre-existing RLS test failures (NOT this change)
+- `rls.integration.test.ts` has 3 failing assertions on this Neon DB; verified
+  they fail identically on the base `main` worktree (environmental — the Neon
+  role/policy state, unrelated to F6). Left untouched.
+
+## Discoveries
+
+- `#withBareTx` routes composite writes through the open script-tx when a scope is
+  active (the long-lived advisory-locked tx) — that is exactly why the in-tx blob
+  touch held the lock for the whole script. `commitBlob` deliberately bypasses
+  `#withBareTx`/`#withTx` and goes straight to `this.db()` so it commits
+  independently of the script scope.
+- `blobs` has no RLS policy and no `sandbox_id` (migration 0000), so `commitBlob`
+  correctly skips `set_config('app.sandbox_id')` and the advisory lock.


### PR DESCRIPTION
## Summary
Fixes **F6 — hot CAS blob contention** (#135). A deduplicated "hot" blob (the empty-file sha, `.gitkeep`, common lockfiles) is a single `blobs` row whose `INSERT ... ON CONFLICT (sha256) DO UPDATE SET last_referenced_at = now()` tuple lock was held for the **whole script** because the touch ran inside the long-lived, advisory-locked script-tx. This serialized unrelated sandboxes **within one tenant DB** and — with the `max=2` PG pool and no `lock_timeout` — was a fleet-wide pool-exhaustion → 503 path.

Per the issue's "Fix to ship" (decoupled-tx, **not** conditional-WHERE alone — PG pins the conflicting tuple to end-of-tx even when WHERE filters out the update), the blob upsert now commits in its **own short, self-committing transaction** (own pool connection, no advisory lock — `blobs` is unscoped CAS) **before** the inode/dirent composite, which runs without its `blob_insert` CTE.

## Changes
- `src/sql-fs/types.ts` — new optional `SqlDialect.commitBlob(sha256, data)`.
- `src/sql-fs/dialects/postgres.ts`:
  - `commitBlob`: single-statement `ON CONFLICT DO UPDATE` on `this.db()` (no BEGIN envelope, no advisory lock, no sandbox context), wrapped in `runTrustedDbAsync` (defense-in-depth). Fires the Redis blob-cache set.
  - `writeFileComposite`: dropped the `blob_insert` CTE; `new_inode` now `SELECT … FROM ctx` so the advisory lock is still acquired.
  - `bulkIngest`: unique blobs committed via a bare `this.db()` multi-row INSERT (own connection) before the inode/dirent work.
- `src/sql-fs/sql-fs.ts` — `writeFile`/`appendFile` call `commitBlob` before the composite when present; the non-composite fallback keeps in-tx `upsertBlob` only when `commitBlob` is absent.
- Touch stays **unconditional** so the GC grace window protects the freshly-committed-but-not-yet-referenced blob during the blob-commit → inode-commit gap.

## GC re-adoption handshake — preserved
`commitBlob`'s touch (`last_referenced_at = now()`) is unconditional. The blob commits FIRST (own tx), the referencing inode commits SECOND (composite tx). A GC sweep landing in the gap sees a now-fresh `last_referenced_at` (well inside `BLOB_GC_MIN_AGE_MS`, default 3h) and keeps the blob. `blob-gc.ts` REPEATABLE READ + 40001 retry is unchanged; the GC integration tests in `postgres.test.ts` still pass.

## Unit results
`pnpm typecheck` ✓ · `pnpm lint:fix` clean ✓ · `pnpm test:unit` → **955 passed, 4 skipped (959)** ✓ (includes 5 new tests in `sql-fs.commit-blob.test.ts` asserting `commitBlob` runs before the composite and is not handed the script-tx handle).

## Live results (real Neon + Redis, server on :8081)
- **A. Dedup + correctness:** two paths written with identical content round-trip correctly, identical `sha256` → dedup holds (exec 200, exitCode 0).
- **B. Concurrency (the F6 point):** two sandboxes, two concurrent `exec-sync` each writing the same hot bytes (`> /k` universal empty blob, then `printf "shared-hot-bytes" > /hot.txt`). Both 200/exitCode 0. **Single write = 498 ms vs concurrent (both) = 586 ms** — ≈ a single write, NOT ~2× → no serialization on the shared blob row. DB check: exactly **1** blob row for the shared sha. A 50-line-loop variant also ran in parallel (wall ≈ max, not sum).

## Reviewer manual steps
1. `pnpm typecheck && pnpm lint:fix && pnpm test:unit`.
2. With `DATABASE_URL` set: run `src/sql-fs/tests/integration/blob-decoupled-tx.integration.test.ts` (dedup round-trip + concurrent `commitBlob` not blocked by an open script-tx) and the `postgres.test.ts` GC suite.
3. Optional live: bootstrap a token, fire two concurrent execs writing the same hot bytes across two sandboxes; confirm concurrent wall ≈ single-write wall.

Note: `rls.integration.test.ts` has 3 pre-existing assertion failures on this Neon DB (verified identical on base `main`) — environmental, unrelated to this change.

Closes #135
