### PR TITLE
fix(session): ESESSIONCLOSING for reaper-race straggler (F9c)

### DIFF
--- a/.changeset/fix-f9c-session-closing.md
+++ b/.changeset/fix-f9c-session-closing.md
@@ -1,0 +1,13 @@
+---
+"sql-fs-api": minor
+---
+
+Surface a retryable `ESESSIONCLOSING` (HTTP 503) instead of a generic 500 when a request
+loses the reaper-vs-straggler race (F9c). A request that captured a session reference just
+before the idle/overBudget reaper marked it `closing` could run the pre-lock
+`ensureFreshCache` probe against a Postgres pool being disconnected, producing an unmapped
+error (e.g. `PostgresDialect: not connected`, which carries no `code`) that defaulted to a
+500. Both pre-lock probe sites (`withSessionEntry`, `withSessionReadEntry`) now re-check the
+session state on probe failure and convert it into a clean, retryable `ESESSIONCLOSING`
+(already mapped to 503) so clients retry instead of seeing a non-retryable 500. No
+concurrency-model change.

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -599,6 +599,16 @@ export class SessionManager {
 		return this.sessions.get(this.sessionKey(tenantId, sandboxId));
 	}
 
+	/**
+	 * Reads `session.state` *live*. The reaper mutates `state` asynchronously, so
+	 * a value the control-flow analyser narrowed to `"active"` at an earlier guard
+	 * may already be `"closing"` by the time a probe rejects. Reading through a
+	 * function call defeats that stale narrowing (F9c).
+	 */
+	private isClosing(session: Session): boolean {
+		return session.state === "closing";
+	}
+
 	private async withExecLockExclusive<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
 		assertValidSandboxId(sandboxId);
 		if (this.redis === undefined) return fn();
@@ -635,7 +645,23 @@ export class SessionManager {
 			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 		}
 
-		await this.ensureFreshCache(tenantId, sandboxId, session);
+		// F9c: a straggler that passed the `closing` check above can still run
+		// the pre-lock cache probe *after* the reaper begins disconnecting this
+		// session's pool. `ensureFreshCache` → `reload()` would then hit a pool
+		// being torn down (`PostgresDialect: not connected`, or driver
+		// `CONNECTION_DESTROYED`/`ENDED`) — an unmapped error that defaults to a
+		// 500. Re-check `state` and convert that into a clean, retryable
+		// ESESSIONCLOSING (503) so the client retries instead of seeing a 500.
+		try {
+			await this.ensureFreshCache(tenantId, sandboxId, session);
+		} catch (err) {
+			if (this.isClosing(session)) {
+				throw Object.assign(new Error("ESESSIONCLOSING: session is shutting down, retry"), {
+					code: "ESESSIONCLOSING",
+				});
+			}
+			throw err;
+		}
 
 		return session.lock.runExclusive(async () => {
 			if (session.state === "closing") {
@@ -700,7 +726,20 @@ export class SessionManager {
 			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 		}
 
-		await this.ensureFreshCache(tenantId, sandboxId, session);
+		// F9c: same reaper-vs-straggler race as withSessionEntry — a reader that
+		// passed the `closing` check can still probe a pool being disconnected.
+		// Re-check `state` and surface a retryable ESESSIONCLOSING (503) instead
+		// of the unmapped error → 500.
+		try {
+			await this.ensureFreshCache(tenantId, sandboxId, session);
+		} catch (err) {
+			if (this.isClosing(session)) {
+				throw Object.assign(new Error("ESESSIONCLOSING: session is shutting down, retry"), {
+					code: "ESESSIONCLOSING",
+				});
+			}
+			throw err;
+		}
 
 		return session.lock.runShared(async () => {
 			if (session.state === "closing") {

--- a/src/api/tests/unit/session-manager.f9c-session-closing.test.ts
+++ b/src/api/tests/unit/session-manager.f9c-session-closing.test.ts
@@ -1,0 +1,280 @@
+/**
+ * F9c regression: reaper-vs-straggler probe must surface ESESSIONCLOSING (503),
+ * not an unmapped error (500).
+ *
+ * The reaper sets `session.state = "closing"` synchronously before disconnecting
+ * the FS. A request that already passed the top-of-entry `closing` guard can
+ * still run the pre-lock `ensureFreshCache` probe against a pool being torn down
+ * — the reload then throws `PostgresDialect: not connected` (no `code` → default
+ * 500). The fix wraps both pre-lock probes (`withSessionEntry`,
+ * `withSessionReadEntry`) in a try/catch that, when `state === "closing"`,
+ * converts the failure into a retryable ESESSIONCLOSING (503).
+ *
+ * These tests faithfully simulate the race by having `reload()` flip the session
+ * into `"closing"` and then throw (as if the reaper fired mid-probe).
+ */
+
+import type { Redis } from "ioredis";
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { mapFsErrorToStatus } from "../../errors.js";
+import { SessionManager } from "../../session-manager.js";
+
+const T = "default";
+
+/** A reload error that carries NO `code`, exactly like `PostgresDialect: not connected`. */
+const POOL_GONE = new Error("PostgresDialect: not connected");
+
+/**
+ * Coherent InMemoryFs whose `reload()` runs a test-supplied hook. The hook lets
+ * a test flip the owning session's `state` and throw, simulating the reaper
+ * disconnecting the pool while the straggler's probe is on the wire.
+ */
+class CoherentInMemoryFs {
+	readonly inner: InMemoryFs;
+	#dirty = false;
+	onReload: () => void = () => {};
+	constructor() {
+		this.inner = new InMemoryFs();
+	}
+	wasDirty(): boolean {
+		return this.#dirty;
+	}
+	clearDirty(): void {
+		this.#dirty = false;
+	}
+	poisoned(): boolean {
+		return false;
+	}
+	async reload(): Promise<void> {
+		this.onReload();
+	}
+}
+
+function adaptCoherentFs(host: CoherentInMemoryFs): IFileSystem {
+	const fs = host.inner as unknown as Record<string, unknown>;
+	return new Proxy(host as unknown as Record<string, unknown>, {
+		get(target, prop, receiver) {
+			if (prop in target) return Reflect.get(target, prop, receiver);
+			const v = fs[prop as string];
+			return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(host.inner) : v;
+		},
+	}) as unknown as IFileSystem;
+}
+
+/**
+ * ZSET-aware FakeRedis — same lock-script implementation used by
+ * session-manager.exec-lock.test.ts, so both the shared (read) and exclusive
+ * (write) distributed RW locks acquire/renew/release correctly. Extended with
+ * the version-counter surface (`getex`) that `ensureFreshCache` probes; it
+ * returns `99` so a session whose `lastSeenVersion` is reset to `0` always sees
+ * a mismatch and calls `reload()`.
+ */
+interface StringEntry {
+	value: string;
+	expiresAt: number;
+}
+
+class FakeRedis {
+	strings = new Map<string, StringEntry>();
+	zsets = new Map<string, Map<string, number>>();
+
+	private gcStrings(): void {
+		const now = Date.now();
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
+	async getex(_key: string, ..._rest: unknown[]): Promise<string> {
+		return "99";
+	}
+
+	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
+		this.gcStrings();
+		if (this.strings.has(key)) return null;
+		this.strings.set(key, { value, expiresAt: Date.now() + ms });
+		return "OK";
+	}
+
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		this.gcStrings();
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		if (script.includes("PEXPIRE")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("DEL")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
+	}
+}
+
+function makeFakeRedis(): Redis {
+	return new FakeRedis() as unknown as Redis;
+}
+
+describe("F9c: reaper-vs-straggler probe surfaces ESESSIONCLOSING (503)", () => {
+	it("withSessionRead: a probe that fails while state==='closing' throws ESESSIONCLOSING (→503), not 500", async () => {
+		const host = new CoherentInMemoryFs();
+		const sm = new SessionManager({ createFs: async () => adaptCoherentFs(host), redis: makeFakeRedis() });
+		await sm.getOrCreate(T, "sb-race-read");
+		const session = sm.getSession(T, "sb-race-read");
+		if (session === undefined) throw new Error("setup: session missing");
+		// Force a version mismatch (Redis reports 99) so ensureFreshCache calls reload().
+		session.lastSeenVersion = 0;
+
+		// Simulate the reaper firing during the pre-lock probe: reload() marks the
+		// session closing and then throws the (uncoded) pool-gone error.
+		host.onReload = () => {
+			session.state = "closing";
+			throw POOL_GONE;
+		};
+
+		const err = await sm
+			.withSessionRead(T, "sb-race-read", async () => "unreachable")
+			.then(
+				() => undefined,
+				(e: unknown) => e as Error & { code?: string },
+			);
+
+		expect(err).toBeDefined();
+		expect(err?.code).toBe("ESESSIONCLOSING");
+		expect(err?.message).toBe("ESESSIONCLOSING: session is shutting down, retry");
+		expect(mapFsErrorToStatus(err as Error)).toBe(503);
+		// The raw, uncoded pool error must NOT leak through (it would map to 500).
+		expect(err).not.toBe(POOL_GONE);
+
+		await sm.shutdown();
+	});
+
+	it("withSession: a probe that fails while state==='closing' throws ESESSIONCLOSING (→503), not 500", async () => {
+		const host = new CoherentInMemoryFs();
+		const sm = new SessionManager({ createFs: async () => adaptCoherentFs(host), redis: makeFakeRedis() });
+		await sm.getOrCreate(T, "sb-race-write");
+		const session = sm.getSession(T, "sb-race-write");
+		if (session === undefined) throw new Error("setup: session missing");
+		session.lastSeenVersion = 0;
+
+		host.onReload = () => {
+			session.state = "closing";
+			throw POOL_GONE;
+		};
+
+		const err = await sm
+			.withSession(T, "sb-race-write", async () => "unreachable")
+			.then(
+				() => undefined,
+				(e: unknown) => e as Error & { code?: string },
+			);
+
+		expect(err).toBeDefined();
+		expect(err?.code).toBe("ESESSIONCLOSING");
+		expect(err?.message).toBe("ESESSIONCLOSING: session is shutting down, retry");
+		expect(mapFsErrorToStatus(err as Error)).toBe(503);
+		expect(err).not.toBe(POOL_GONE);
+
+		await sm.shutdown();
+	});
+
+	it("negative control: a probe failure while state is normal propagates the ORIGINAL error (→500)", async () => {
+		const host = new CoherentInMemoryFs();
+		const sm = new SessionManager({ createFs: async () => adaptCoherentFs(host), redis: makeFakeRedis() });
+		await sm.getOrCreate(T, "sb-no-race");
+		const session = sm.getSession(T, "sb-no-race");
+		if (session === undefined) throw new Error("setup: session missing");
+		session.lastSeenVersion = 0;
+
+		// reload throws but the session is NOT closing — the original (uncoded)
+		// error must surface unchanged, mapping to a 500 as before the fix.
+		host.onReload = () => {
+			throw POOL_GONE;
+		};
+
+		const err = await sm
+			.withSessionRead(T, "sb-no-race", async () => "unreachable")
+			.then(
+				() => undefined,
+				(e: unknown) => e as Error & { code?: string },
+			);
+
+		expect(err).toBe(POOL_GONE);
+		expect(err?.code).toBeUndefined();
+		expect(mapFsErrorToStatus(err as Error)).toBe(500);
+
+		await sm.shutdown();
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f9c-session-closing.md
+++ b/thoughts/shared/plans/2026-06-13_f9c-session-closing.md
@@ -1,0 +1,114 @@
+# F9c: Reaper vs straggler probe — surface ESESSIONCLOSING not 500
+
+GitHub issue: Hazzng/sql-fs#140 · Branch: `fix/f9c-session-closing`
+
+## Problem
+
+The reaper (`runReaper`, `session-manager.ts:1192`) marks `session.state = "closing"`
+synchronously **before** disconnecting the FS, then deletes the session and kicks off
+`disconnectFs` (→ `PostgresDialect.disconnect` → `pool.end()`, `postgres.ts:76`).
+
+A request that already captured the session ref and passed the `state === "closing"`
+guard at the top of `withSessionEntry` (`:634`) / `withSessionReadEntry` (`:699`) can then
+run the **pre-lock** `ensureFreshCache` probe (`:638`, `:703`). If the reaper's
+`disconnect()` has already nulled the pool (`postgres.ts:273` → `throw new Error("PostgresDialect: not connected")`)
+or `end()` has begun rejecting (`CONNECTION_DESTROYED`/`ENDED`), the reload throws an
+**unmapped** error. The `PostgresDialect: not connected` error carries **no `code`**, so
+`mapFsErrorToStatus` (`api/errors.ts:68`) hits `default → 500`. The client sees a
+non-retryable 500 for what is really a transient "session is being recycled" condition.
+
+Only the **overBudget** reap trigger is realistic — the IDLE trigger is closed because
+`getOrCreate` bumps `lastUsed` (`:451`). A query already on the wire is not aborted
+(`pool.end()` has no timeout); the surviving vector is the reload's `db()` issued *after*
+disconnect begins.
+
+## Fix to ship (per issue)
+
+Wrap the two pre-lock `ensureFreshCache` calls in try/catch. On failure, if
+`session.state === "closing"`, re-throw a clean `ESESSIONCLOSING`-coded error (maps to
+503 retryable); otherwise re-throw the original. Zero concurrency-model change.
+
+`ESESSIONCLOSING` is **already** mapped to 503 in `mapFsErrorToStatus` and already in
+`SAFE_FS_ERROR_CODES` (`api/errors.ts:24,85`) — no error-layer change required.
+
+---
+
+## Phase 1 — Wrap the pre-lock probes
+
+**Changes:** `src/api/session-manager.ts`
+- `withSessionEntry` (`:638`): wrap `ensureFreshCache` in try/catch; on `state==='closing'`
+  throw `ESESSIONCLOSING`, else rethrow.
+- `withSessionReadEntry` (`:703`): same.
+
+**Automated criteria:**
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` clean
+- [x] existing `pnpm test:unit` still passes (no weakened tests)
+
+**Manual criteria:**
+- [x] Diff is minimal — only the two probe sites wrapped; no lock/state changes.
+
+**Discoveries:**
+- File in this worktree is 1368 lines (branched from `c6b29f4`), so the issue's `~593`/`~658`
+  line refs map to actual call sites `:638` (`withSessionEntry`) and `:703`
+  (`withSessionReadEntry`). Both confirmed as the only pre-lock `ensureFreshCache` calls.
+- `ensureFreshCache` no-ops when `redis === undefined` (`:789`) — so the race only exists
+  on Redis-backed multi-replica deployments, matching the issue's `area:distributed` label.
+
+## Phase 2 — Regression test
+
+**Changes:** new `src/api/tests/unit/session-manager.f9c-session-closing.test.ts`
+- Drive a session into `state==='closing'`, make the cache probe (`reload`) throw, and
+  assert the surfaced error is `ESESSIONCLOSING` (→503), NOT the raw error (→500).
+- Negative control: when `state` is normal, the original probe error propagates unchanged.
+
+**Automated criteria:**
+- [x] New test passes
+- [x] `pnpm test:unit` whole-suite green
+
+**Manual criteria:**
+- [x] Test asserts the `code` property and message, and the 503 mapping via `mapFsErrorToStatus`.
+
+**Discoveries:**
+- Reusing the `FakeFs`/`createFs` mock pattern from `session-manager.lifecycle.test.ts`.
+- `ensureFreshCache` requires `redis !== undefined` and a coherent FS (`asCoherentFs`).
+  Rather than stand up a real Redis + coherent FS, the test injects a fake `redis` and a
+  coherent-FS stub whose `reload()` throws — the minimal surface that exercises the probe.
+
+## Phase 3 — Live API verification
+
+**Manual criteria (recorded below):**
+- [x] Happy path: server on :8083, health OK, create sandbox + normal exec → 200, correct output.
+- [x] Reaper-race attempt on a second instance with `SESSION_IDLE_MS=800`.
+- [x] All started servers killed by PID; shared Redis 6379 untouched.
+
+### Manual Verification — Live results (real Neon + Redis 6379)
+
+**A. Happy path (server :8083, default config):**
+- `GET /healthz` → `{"status":"ok"}`.
+- `POST /v1/auth/bootstrap` (X-Auth-Secret) → JWT minted.
+- `POST /v1/sandboxes` → 201, id `be0ef03b-…`.
+- `POST /v1/sandboxes/{id}/exec-sync {"script":"echo hello-f9c"}` → **HTTP 200**,
+  `stdout:"hello-f9c\n"`. No regression.
+
+**B. Reaper-race attempt (second instance :8093, `SESSION_IDLE_MS=800`):**
+- Warmed a sandbox, then fired 62 concurrent bursts (8 reqs each, 496 total) over ~72 s,
+  crossing at least one 60 s reaper tick, sleeping 0.9 s between bursts to let the session
+  go idle.
+- Result: **496/496 → HTTP 200**, zero 500s, and no `closing`/`ESESSIONCLOSING` events in
+  the server log.
+- **Honest conclusion:** the live race did NOT reproduce. Two structural reasons (both
+  called out in the issue): (1) the idle trigger is effectively closed because every
+  request bumps `lastUsed`, so a continuously-probed session never goes idle at a tick;
+  (2) the server's reaper interval is hardcoded to 60 s and the closing→disconnect window
+  is microseconds, so landing a straggler in it from outside the process is impractical.
+  The realistic trigger is **overBudget**, which needs a >budget pathCache — not feasible to
+  force from the HTTP surface in a smoke test without code changes (out of F9c scope).
+  **The unit test (`session-manager.f9c-session-closing.test.ts`) is the authoritative
+  proof:** it deterministically simulates the reaper firing mid-probe and asserts
+  ESESSIONCLOSING→503; it was verified to FAIL without the fix (raw error → 500) and PASS
+  with it. The live server confirmed the happy-path smoke only (no regression).
+
+**C. Cleanup:** both sandboxes deleted (204); both dev servers killed by PID
+(35800, 42508). Shared Redis 6379 left running. (Two unrelated `tsx watch` procs from the
+main `virtualFS` checkout were left untouched — not started by this task.)


### PR DESCRIPTION
## Summary

Fixes the F9c reaper-vs-straggler race (#140). The reaper sets `session.state = "closing"` synchronously **before** disconnecting the FS pool. A request that captured the session reference and passed the top-of-entry `closing` guard could then run the **pre-lock** `ensureFreshCache` probe against a pool being torn down. The reload throws an **unmapped** error — e.g. `PostgresDialect: not connected` (`postgres.ts` `db()`, carries **no `code`**) or a driver `CONNECTION_DESTROYED`/`ENDED` — which falls through `mapFsErrorToStatus`'s `default` to a non-retryable **500**.

The fix wraps the two pre-lock probe sites and, on failure with `state === "closing"`, re-throws a clean retryable **`ESESSIONCLOSING`** (already mapped to **503** in `api/errors.ts`). Zero concurrency-model change.

## Changes

- `src/api/session-manager.ts`
  - `withSessionEntry` (write path) and `withSessionReadEntry` (readOnly path): wrap the pre-lock `ensureFreshCache` call in try/catch; on a closing session, surface `ESESSIONCLOSING` (503), else re-throw the original error unchanged.
  - Added a tiny `isClosing(session)` helper so the live `state` re-read defeats TS's stale control-flow narrowing to `"active"` (the reaper mutates `state` asynchronously).
- `src/api/tests/unit/session-manager.f9c-session-closing.test.ts` — new regression test.
- `.changeset/fix-f9c-session-closing.md` — `sql-fs-api: minor`.
- Plan: `thoughts/shared/plans/2026-06-13_f9c-session-closing.md`.

No change was needed in `api/errors.ts`: `ESESSIONCLOSING` is already in `SAFE_FS_ERROR_CODES` and already maps to 503.

## Unit test results

`pnpm test:unit` → **953 passed, 4 skipped**. The new file has 3 tests:
- write path (`withSession`): probe fails while `state==='closing'` → `ESESSIONCLOSING` (503), raw error does not leak.
- readOnly path (`withSessionRead`): same.
- negative control: probe fails while `state` is normal → **original** uncoded error propagates (→500), unchanged.

Verified the test is a genuine guard: with the fix's two catch bodies neutralised, the two race tests **FAIL** (raw error → 500) and the negative control still passes; with the fix they all pass.

`pnpm typecheck` + `pnpm lint:fix` clean.

## Live verification (real Neon + Redis 6379)

- **Happy path (server :8083, default config):** `/healthz` ok; bootstrap JWT; create sandbox (201); `exec-sync {"script":"echo hello-f9c"}` → **HTTP 200**, `stdout:"hello-f9c\n"`. No regression.
- **Reaper-race attempt (second instance :8093, `SESSION_IDLE_MS=800`):** warmed a sandbox, fired 62 concurrent bursts (496 requests) over ~72 s crossing a 60 s reaper tick. Result: **496/496 → 200**, zero 500s, and no `closing` events. **The live race did not reproduce** — honestly, for the two structural reasons noted in the issue: the idle trigger is closed because every request bumps `lastUsed`, and the closing→disconnect window is microseconds against a 60 s reaper interval. The realistic trigger is `overBudget`, not forceable from the HTTP surface in a smoke test (out of F9c scope). **The unit test is the authoritative proof** (deterministic simulation, fails without the fix). Both dev servers killed by PID; shared Redis 6379 left running.

## Reviewer manual steps

1. `pnpm test:unit` — confirm green.
2. Optionally neutralise the two catch bodies in `withSessionEntry`/`withSessionReadEntry` and re-run `session-manager.f9c-session-closing.test.ts` — the two race tests should fail, proving the guard.

Closes #140