### PR TITLE
fix(lock): abort exec on definitive lease loss before commit (F2-L1)

### DIFF
--- a/.changeset/fix-f2l1-lease-loss-abort.md
+++ b/.changeset/fix-f2l1-lease-loss-abort.md
@@ -1,0 +1,24 @@
+---
+"sql-fs-api": minor
+---
+
+fix(lock): abort the exec on definitive lease loss before commit (F2-L1)
+
+The distributed exec lock wrappers ran the critical section to completion and only
+then checked the loss flag, so a writer whose lease lapsed mid-script still
+committed its script-tx and bumped the version before throwing `ELOCKLOST` — a
+write that durably happened surfaced as an error, causing retrying agents to
+double-apply.
+
+The lock now wires its DEFINITIVE-loss signal (lease expiry / ownership taken —
+not transient renew blips) into an `AbortController` that is plumbed through to
+`bash.exec`. On a definitive loss the in-flight exec is aborted, its script-tx
+rolls back BEFORE any commit (no `INCR`), and the client receives a clean,
+retryable `ELOCKLOST` (now mapped to 503). Because just-bash treats an aborted
+run as a resolved result rather than a rejection, the runtime explicitly rolls
+back and re-raises `LockLostError` when the lock-lost signal fired, instead of
+committing the partial script. A plain timeout abort still commits (unchanged,
+audit L7) — only the dedicated lock-lost signal triggers rollback.
+
+This is Layer 1 of the F2 fix; the complete epoch/version fence is tracked
+separately (#131).

--- a/src/api/distributed-lock.ts
+++ b/src/api/distributed-lock.ts
@@ -79,6 +79,12 @@ export class LockLostError extends Error {
 /**
  * Runs `fn` while holding the distributed lock identified by `key`.
  *
+ * `fn` receives a `lostSignal` (`AbortSignal`) that aborts on a DEFINITIVE
+ * ownership loss (token mismatch or lease expiry) — NOT on a transient renew
+ * blip. Callers plumb this into long-running work so a lapsed lease aborts it
+ * BEFORE it commits, rather than committing then surfacing `LockLostError` for
+ * a write that durably happened (F2-L1).
+ *
  * - Throws `LockAcquireTimeoutError` when the acquire loop exceeds
  *   `acquireTimeoutMs` without obtaining the lock.
  * - Throws `LockLostError` when the heartbeat discovers the lease is no
@@ -90,7 +96,7 @@ export class LockLostError extends Error {
 export async function withDistributedLock<T>(
 	redis: Redis,
 	key: string,
-	fn: () => Promise<T>,
+	fn: (lostSignal: AbortSignal) => Promise<T>,
 	opts: Partial<DistributedLockOptions> = {},
 ): Promise<T> {
 	const merged: DistributedLockOptions = { ...DEFAULTS, ...opts };
@@ -130,6 +136,14 @@ export async function withDistributedLock<T>(
 	let lost = false;
 	let stopped = false;
 	let renewTimer: ReturnType<typeof setTimeout> | undefined;
+	// F2-L1: abort in-flight work the instant ownership is DEFINITIVELY lost so it
+	// rolls back BEFORE committing, instead of running to completion and then
+	// surfacing LockLostError for a write that already happened.
+	const lostController = new AbortController();
+	const markLost = (): void => {
+		lost = true;
+		if (!lostController.signal.aborted) lostController.abort(new LockLostError(key));
+	};
 	// The lock is safely held until this instant. Updated on every SUCCESSFUL
 	// renewal; a transient renew failure does NOT move it. Audit H4: a single
 	// transient renew timeout/error must NOT abandon a still-valid lease — we
@@ -168,11 +182,11 @@ export async function withDistributedLock<T>(
 				leaseExpiresAt = Date.now() + leaseMs;
 				scheduleRenew(renewMs);
 			} else if (outcome === "ownership_lost") {
-				lost = true;
+				markLost();
 			} else if (Date.now() >= leaseExpiresAt) {
 				// Transient failures persisted past the lease — we can no longer be
 				// sure we hold the lock. Relinquish.
-				lost = true;
+				markLost();
 			} else {
 				// Transient blip with lease still valid — retry soon, do not give up.
 				scheduleRenew(renewRetryMs);
@@ -183,7 +197,17 @@ export async function withDistributedLock<T>(
 
 	// ── Critical section ──
 	try {
-		const result = await fn();
+		let result: T;
+		try {
+			result = await fn(lostController.signal);
+		} catch (err) {
+			// If ownership was definitively lost, `fn` likely threw an AbortError
+			// from the lost-signal abort. Surface the canonical, retryable
+			// LockLostError instead so the client sees a single coherent code and
+			// treats it as "not committed" (the abort fired before any commit).
+			if (lost) throw new LockLostError(key);
+			throw err;
+		}
 		if (lost) throw new LockLostError(key);
 		return result;
 	} finally {

--- a/src/api/distributed-rw-lock.ts
+++ b/src/api/distributed-rw-lock.ts
@@ -346,6 +346,13 @@ function startExclusiveHeartbeat(
  * - `mode='exclusive'`: sets writer flag (halting new readers), then waits for
  *   all live readers to drain before entering the critical section.
  *
+ * `fn` receives a `lostSignal` (`AbortSignal`) that aborts on a DEFINITIVE
+ * ownership loss (token mismatch or lease expiry) — NOT on a transient renew
+ * blip (the heartbeat already distinguishes them). Callers should plumb this
+ * into long-running work so a lapsed lease aborts it BEFORE it commits, rather
+ * than committing and then surfacing a `LockLostError` for a write that durably
+ * happened (F2-L1).
+ *
  * Throws `LockAcquireTimeoutError` if acquisition exceeds `acquireTimeoutMs`.
  * Throws `LockLostError` if the heartbeat detects ownership was lost.
  */
@@ -353,7 +360,7 @@ export async function withDistributedRWLock<T>(
 	redis: Redis,
 	keys: RWLockKeys,
 	mode: RWLockMode,
-	fn: () => Promise<T>,
+	fn: (lostSignal: AbortSignal) => Promise<T>,
 	opts: Partial<DistributedRWLockOptions> = {},
 ): Promise<T> {
 	const merged: DistributedRWLockOptions = { ...DEFAULTS, ...opts };
@@ -371,17 +378,32 @@ async function runShared<T>(
 	keys: RWLockKeys,
 	token: string,
 	opts: DistributedRWLockOptions,
-	fn: () => Promise<T>,
+	fn: (lostSignal: AbortSignal) => Promise<T>,
 ): Promise<T> {
 	await acquireShared(redis, keys, token, opts);
 
 	let lost = false;
+	// F2-L1: abort in-flight work the instant ownership is DEFINITIVELY lost so it
+	// rolls back BEFORE committing, instead of running to completion and then
+	// surfacing LockLostError for a write that already happened.
+	const lostController = new AbortController();
 	const stopHeartbeat = startSharedHeartbeat(redis, keys, token, opts, () => {
 		lost = true;
+		if (!lostController.signal.aborted) lostController.abort(new LockLostError(keys.readers));
 	});
 
 	try {
-		const result = await fn();
+		let result: T;
+		try {
+			result = await fn(lostController.signal);
+		} catch (err) {
+			// If ownership was definitively lost, `fn` likely threw an AbortError
+			// from the lost-signal abort. Surface the canonical, retryable
+			// LockLostError instead so the client sees a single coherent code and
+			// treats it as "not committed" (the abort fired before any commit).
+			if (lost) throw new LockLostError(keys.readers);
+			throw err;
+		}
 		if (lost) throw new LockLostError(keys.readers);
 		return result;
 	} finally {
@@ -401,7 +423,7 @@ async function runExclusive<T>(
 	keys: RWLockKeys,
 	token: string,
 	opts: DistributedRWLockOptions,
-	fn: () => Promise<T>,
+	fn: (lostSignal: AbortSignal) => Promise<T>,
 ): Promise<T> {
 	const deadline = Date.now() + opts.acquireTimeoutMs;
 
@@ -410,15 +432,30 @@ async function runExclusive<T>(
 	// Start heartbeat immediately after acquiring flag so it doesn't expire
 	// while we wait for readers to drain.
 	let lost = false;
+	// F2-L1: abort in-flight work the instant ownership is DEFINITIVELY lost so it
+	// rolls back BEFORE committing, instead of running to completion and then
+	// surfacing LockLostError for a write that already committed + INCR'd.
+	const lostController = new AbortController();
 	const stopHeartbeat = startExclusiveHeartbeat(redis, keys, token, opts, () => {
 		lost = true;
+		if (!lostController.signal.aborted) lostController.abort(new LockLostError(keys.writer));
 	});
 
 	try {
 		await waitReadersDrained(redis, keys, token, opts, deadline);
 		if (lost) throw new LockLostError(keys.writer);
 
-		const result = await fn();
+		let result: T;
+		try {
+			result = await fn(lostController.signal);
+		} catch (err) {
+			// If ownership was definitively lost, `fn` likely threw an AbortError
+			// from the lost-signal abort. Surface the canonical, retryable
+			// LockLostError instead so the client sees a single coherent code and
+			// treats it as "not committed" (the abort fired before any commit).
+			if (lost) throw new LockLostError(keys.writer);
+			throw err;
+		}
 		if (lost) throw new LockLostError(keys.writer);
 		return result;
 	} finally {

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -62,7 +62,10 @@ export function clientSafeErrorMessage(err: unknown, fallback = "Internal server
  * ELOOP          → 400  Bad Request (symlink loop)
  * EINVAL         → 400  Bad Request (invalid argument)
  * ELOCKTIMEOUT   → 503  Service Unavailable (distributed lock acquire timed out)
- * ELOCKLOST      → 500  Internal Server Error (distributed lock heartbeat failed mid-operation)
+ * ELOCKLOST      → 503  Service Unavailable, RETRYABLE. As of F2-L1 the exec is
+ *                       aborted (script-tx rolled back) BEFORE any commit when the
+ *                       lease is definitively lost, so ELOCKLOST now genuinely
+ *                       means "not committed" — safe for the client to retry.
  * others         → 500  Internal Server Error
  */
 export function mapFsErrorToStatus(err: Error): number {
@@ -94,7 +97,9 @@ export function mapFsErrorToStatus(err: Error): number {
 		case "ELOCKTIMEOUT":
 			return 503;
 		case "ELOCKLOST":
-			return 500;
+			// F2-L1: the exec is aborted + rolled back before any commit on a
+			// definitive lease loss, so ELOCKLOST is now retryable (not committed).
+			return 503;
 		case "ECOHERENCE":
 			return 503;
 		case "ERUNTIME_BUSY":

--- a/src/api/routes/exec.ts
+++ b/src/api/routes/exec.ts
@@ -64,6 +64,19 @@ function contentTypeBase(header: string | undefined): string {
 	return (header ?? "application/json").split(";")[0]!.trim().toLowerCase();
 }
 
+/**
+ * Combine the per-request timeout/disconnect signal with the distributed exec
+ * lock's definitive-loss signal (F2-L1). The resulting signal aborts when
+ * EITHER fires, so a lapsed lease aborts `bash.exec` — rolling its script-tx
+ * back BEFORE any commit — without disturbing the existing timeout behaviour.
+ * When no distributed lock is held (single-replica / Redis disabled) the
+ * lock-lost signal is undefined and the primary signal is returned unchanged.
+ */
+function composeAbortSignals(primary: AbortSignal, lockLost: AbortSignal | undefined): AbortSignal {
+	if (lockLost === undefined) return primary;
+	return AbortSignal.any([primary, lockLost]);
+}
+
 function wrapDebugScript(script: string): string {
 	return `set -x\n${script}`;
 }
@@ -173,9 +186,14 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 					controller.abort();
 				}, timeoutMs);
 
+				// F2-L1: abort the exec — and roll its script-tx back BEFORE any commit —
+				// the instant the distributed exec lock is definitively lost. Compose the
+				// lock-lost signal (if a distributed lock is held) with the timeout signal.
+				const execSignal = composeAbortSignals(controller.signal, session.lockLostSignal);
+
 				try {
 					const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-						signal: controller.signal,
+						signal: execSignal,
 						cwd: body.cwd,
 						env,
 					});
@@ -280,9 +298,13 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 			const ownerRunner = readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 			try {
 				await ownerRunner(sessionManager, tenant, sandboxId, c.get("owner"), async (session) => {
+					// F2-L1: compose the distributed lock's definitive-loss signal with the
+					// timeout/client-disconnect signal so a lapsed lease aborts the exec and
+					// rolls its script-tx back BEFORE any commit.
+					const execSignal = composeAbortSignals(controller.signal, session.lockLostSignal);
 					try {
 						const result = await sessionManager.execWithRuntimeThrottle(session, scriptToRun, {
-							signal: controller.signal,
+							signal: execSignal,
 							cwd: body.cwd,
 							env,
 						});
@@ -404,7 +426,17 @@ export function execRoutes(sessionManager: SessionManager): Hono<{ Variables: Au
 		try {
 			const runner = body.readOnly ? withOwnedSessionRead : withOwnedSessionOrRehydrate;
 			results = await runner<BatchScriptResult[]>(sessionManager, tenant, sandboxId, c.get("owner"), async (session) =>
-				executeBatch(sessionManager, session, body.scripts, totalTimeoutMs, disconnectController.signal, batchOptions),
+				// F2-L1: compose the distributed lock's definitive-loss signal with the
+				// client-disconnect signal so a lapsed lease aborts the in-flight batch
+				// script and rolls its script-tx back BEFORE any commit.
+				executeBatch(
+					sessionManager,
+					session,
+					body.scripts,
+					totalTimeoutMs,
+					composeAbortSignals(disconnectController.signal, session.lockLostSignal),
+					batchOptions,
+				),
 			);
 		} catch (err) {
 			if (isForbiddenError(err)) return forbiddenResponse();

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -22,7 +22,7 @@ import { SessionScopedFs } from "../sql-fs/session-scoped-fs.js";
 import type { ICoherentFs, IReadOnlyScopeFs, IScriptTxFs } from "../sql-fs/sql-fs.js";
 import type { PathCacheEntry, SandboxListEntry, SandboxMeta } from "../sql-fs/types.js";
 import { nodeCommand } from "./commands/node-command.js";
-import { execLockKey, withDistributedLock } from "./distributed-lock.js";
+import { LockLostError, execLockKey, withDistributedLock } from "./distributed-lock.js";
 import { type DistributedRWLockOptions, rwLockKeys, withDistributedRWLock } from "./distributed-rw-lock.js";
 import { logAudit } from "./lib/audit.js";
 // NOTE: `py-exec` (warm host Python) is intentionally NOT imported/wired here.
@@ -230,6 +230,16 @@ export interface Session {
 	 * settle (success or failure).
 	 */
 	freshCacheInflight?: Promise<void>;
+	/**
+	 * AbortSignal that fires when the distributed exec lock is DEFINITIVELY lost
+	 * (lease expired or ownership taken by another holder) for the currently
+	 * locked region. Set by `withExecLockExclusive` / `withExecLockShared` before
+	 * the inner `fn` runs and cleared in their `finally`. Undefined when no
+	 * distributed lock is held (single-replica / Redis disabled). The exec routes
+	 * compose this with their timeout signal so `bash.exec` aborts — and the
+	 * script-tx rolls back — BEFORE any commit on a lost lease (F2-L1).
+	 */
+	lockLostSignal?: AbortSignal;
 	/**
 	 * Set to true when a previous turn's `publishVersionIfDirty` call failed
 	 * (the write committed to Postgres but the Redis INCR errored). The next
@@ -599,7 +609,11 @@ export class SessionManager {
 		return this.sessions.get(this.sessionKey(tenantId, sandboxId));
 	}
 
-	private async withExecLockExclusive<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
+	private async withExecLockExclusive<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (lostSignal?: AbortSignal) => Promise<T>,
+	): Promise<T> {
 		assertValidSandboxId(sandboxId);
 		if (this.redis === undefined) return fn();
 		if (!this.rwlockEnabled) {
@@ -608,7 +622,11 @@ export class SessionManager {
 		return withDistributedRWLock(this.redis, rwLockKeys(tenantId, sandboxId), "exclusive", fn, this.execLockOptions);
 	}
 
-	private async withExecLockShared<T>(tenantId: string, sandboxId: string, fn: () => Promise<T>): Promise<T> {
+	private async withExecLockShared<T>(
+		tenantId: string,
+		sandboxId: string,
+		fn: (lostSignal?: AbortSignal) => Promise<T>,
+	): Promise<T> {
 		assertValidSandboxId(sandboxId);
 		if (this.redis === undefined) return fn();
 		// Flag-off (rolling deploy): the distributed RW lock keyspace is disabled,
@@ -630,6 +648,7 @@ export class SessionManager {
 		sandboxId: string,
 		session: Session,
 		fn: (session: Session) => Promise<T>,
+		lostSignal?: AbortSignal,
 	): Promise<T> {
 		if (session.state === "closing") {
 			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
@@ -637,49 +656,60 @@ export class SessionManager {
 
 		await this.ensureFreshCache(tenantId, sandboxId, session);
 
-		return session.lock.runExclusive(async () => {
-			if (session.state === "closing") {
-				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-			}
-			session.inFlight++;
-			session.lastUsed = Date.now();
-			let primaryError: unknown;
-			let result: T | undefined;
-			let succeeded = false;
-			try {
-				result = await fn(session);
-				succeeded = true;
-			} catch (err) {
-				primaryError = err;
-			}
-			const coherent = asCoherentFs(session.fs);
-			const shouldRefreshPathBudget = coherent === undefined || coherent.wasDirty();
-			let publishError: unknown;
-			try {
-				await this.publishVersionIfDirty(tenantId, sandboxId, session);
-			} catch (err) {
-				publishError = err;
-				console.error(
-					JSON.stringify({
-						event: "publish_version_finally_error",
-						sandboxId,
-						error: (err as Error).message,
-					}),
-				);
-			}
-			session.inFlight--;
-			if (shouldRefreshPathBudget) {
-				session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
-				session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
-			}
-			// Order of precedence:
-			// 1. The handler's own error (most specific) takes priority.
-			// 2. Otherwise, surface the publish failure so the client knows the
-			//    write committed but cross-replica coherence did not (503).
-			if (primaryError !== undefined) throw primaryError;
-			if (publishError !== undefined && succeeded) throw publishError;
-			return result as T;
-		});
+		// F2-L1: expose the distributed lock's definitive-loss signal to the exec
+		// routes (which compose it into bash.exec's abort signal) for the duration
+		// of this locked region. Cleared in finally so a stale signal never leaks
+		// into a later turn that re-uses the warm session.
+		session.lockLostSignal = lostSignal;
+		try {
+			return await session.lock.runExclusive(async () => {
+				if (session.state === "closing") {
+					throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), {
+						code: "ESESSIONCLOSING",
+					});
+				}
+				session.inFlight++;
+				session.lastUsed = Date.now();
+				let primaryError: unknown;
+				let result: T | undefined;
+				let succeeded = false;
+				try {
+					result = await fn(session);
+					succeeded = true;
+				} catch (err) {
+					primaryError = err;
+				}
+				const coherent = asCoherentFs(session.fs);
+				const shouldRefreshPathBudget = coherent === undefined || coherent.wasDirty();
+				let publishError: unknown;
+				try {
+					await this.publishVersionIfDirty(tenantId, sandboxId, session);
+				} catch (err) {
+					publishError = err;
+					console.error(
+						JSON.stringify({
+							event: "publish_version_finally_error",
+							sandboxId,
+							error: (err as Error).message,
+						}),
+					);
+				}
+				session.inFlight--;
+				if (shouldRefreshPathBudget) {
+					session.pathCacheBytes = this.estimatePathCacheBytes(session.fs);
+					session.overBudget = session.pathCacheBytes > this.pathCacheMaxBytes;
+				}
+				// Order of precedence:
+				// 1. The handler's own error (most specific) takes priority.
+				// 2. Otherwise, surface the publish failure so the client knows the
+				//    write committed but cross-replica coherence did not (503).
+				if (primaryError !== undefined) throw primaryError;
+				if (publishError !== undefined && succeeded) throw publishError;
+				return result as T;
+			});
+		} finally {
+			session.lockLostSignal = undefined;
+		}
 	}
 
 	/**
@@ -695,6 +725,7 @@ export class SessionManager {
 		sandboxId: string,
 		session: Session,
 		fn: (session: Session) => Promise<T>,
+		lostSignal?: AbortSignal,
 	): Promise<T> {
 		if (session.state === "closing") {
 			throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
@@ -702,87 +733,100 @@ export class SessionManager {
 
 		await this.ensureFreshCache(tenantId, sandboxId, session);
 
-		return session.lock.runShared(async () => {
-			if (session.state === "closing") {
-				throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
-			}
-			const roFs = asReadOnlyFs(session.fs);
-			const ctx: ReadOnlyContext = { violated: false };
-
-			session.inFlight++;
-			session.lastUsed = Date.now();
-			let scopeOpened = false;
-			try {
-				if (roFs !== undefined) {
-					roFs.beginReadOnlyScope();
-					scopeOpened = true;
+		// F2-L1: expose the distributed shared lock's definitive-loss signal to the
+		// exec routes for this locked region (see withSessionEntry). Cleared in
+		// finally so it never leaks into a later turn reusing this warm session.
+		// NOTE: multiple readers share one warm session; they all observe the same
+		// lockLostSignal, which is correct — a shared-lock loss invalidates them all.
+		session.lockLostSignal = lostSignal;
+		try {
+			return await session.lock.runShared(async () => {
+				if (session.state === "closing") {
+					throw Object.assign(new Error("ESESSIONCLOSING: session is being destroyed"), { code: "ESESSIONCLOSING" });
 				}
-				// `readOnlyContext.run` propagates `ctx` down the async stack into
-				// `bash.exec` → `SqlFs.#assertWritable`, which marks *this* call's
-				// context (not a shared FS flag). Innocent concurrent readers keep
-				// their own `ctx.violated === false`.
-				let result: T;
+				const roFs = asReadOnlyFs(session.fs);
+				const ctx: ReadOnlyContext = { violated: false };
+
+				session.inFlight++;
+				session.lastUsed = Date.now();
+				let scopeOpened = false;
 				try {
-					result = await readOnlyContext.run(ctx, () => fn(session));
-				} catch (err) {
-					const errCode = (err as Error & { code?: string }).code;
-					// Audit the violation even when an unrelated error (e.g. AbortError
-					// from a timeout) wins as the thrown error. Bash can record an
-					// EREADONLY rejection mid-script (ctx.violated=true) and later
-					// throw for an unrelated reason; the security event must still
-					// surface to monitoring.
-					if (ctx.violated || errCode === "EREADONLY") {
-						logAudit("read_only_violation", { tenantId, sandboxId });
+					if (roFs !== undefined) {
+						roFs.beginReadOnlyScope();
+						scopeOpened = true;
 					}
-					// Some bash builtins (e.g. shell redirections `echo x > f`) let
-					// the raw EREADONLY rejection escape bash.exec instead of
-					// normalising it to a non-zero exit. Remap to EREADONLY_VIOLATION
-					// so the route layer sees a single uniform code regardless of
-					// whether the violation surfaced via ctx-tagging (script ran to
-					// completion with a non-zero exit) or as a thrown rejection.
-					if (errCode === "EREADONLY") {
+					// `readOnlyContext.run` propagates `ctx` down the async stack into
+					// `bash.exec` → `SqlFs.#assertWritable`, which marks *this* call's
+					// context (not a shared FS flag). Innocent concurrent readers keep
+					// their own `ctx.violated === false`.
+					let result: T;
+					try {
+						result = await readOnlyContext.run(ctx, () => fn(session));
+					} catch (err) {
+						const errCode = (err as Error & { code?: string }).code;
+						// Audit the violation even when an unrelated error (e.g. AbortError
+						// from a timeout) wins as the thrown error. Bash can record an
+						// EREADONLY rejection mid-script (ctx.violated=true) and later
+						// throw for an unrelated reason; the security event must still
+						// surface to monitoring.
+						if (ctx.violated || errCode === "EREADONLY") {
+							logAudit("read_only_violation", { tenantId, sandboxId });
+						}
+						// Some bash builtins (e.g. shell redirections `echo x > f`) let
+						// the raw EREADONLY rejection escape bash.exec instead of
+						// normalising it to a non-zero exit. Remap to EREADONLY_VIOLATION
+						// so the route layer sees a single uniform code regardless of
+						// whether the violation surfaced via ctx-tagging (script ran to
+						// completion with a non-zero exit) or as a thrown rejection.
+						if (errCode === "EREADONLY") {
+							throw Object.assign(
+								new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"),
+								{
+									code: "EREADONLY_VIOLATION",
+								},
+							);
+						}
+						// Unrelated error wins; the violation was already audited above.
+						throw err;
+					}
+					if (ctx.violated) {
+						logAudit("read_only_violation", { tenantId, sandboxId });
+						// Audit M11: a readOnly batch shares one violation context, so a
+						// single mutating script fails the WHOLE batch (and its sibling
+						// reads are discarded). This is intentional fail-CLOSED behaviour —
+						// the read-only safety net must reject the request as a unit and
+						// guarantee nothing persisted; surfacing partial results from a
+						// batch that contained a rejected mutation would be a footgun.
 						throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
 							code: "EREADONLY_VIOLATION",
 						});
 					}
-					// Unrelated error wins; the violation was already audited above.
-					throw err;
-				}
-				if (ctx.violated) {
-					logAudit("read_only_violation", { tenantId, sandboxId });
-					// Audit M11: a readOnly batch shares one violation context, so a
-					// single mutating script fails the WHOLE batch (and its sibling
-					// reads are discarded). This is intentional fail-CLOSED behaviour —
-					// the read-only safety net must reject the request as a unit and
-					// guarantee nothing persisted; surfacing partial results from a
-					// batch that contained a rejected mutation would be a footgun.
-					throw Object.assign(new Error("EREADONLY_VIOLATION: readOnly script attempted to mutate the filesystem"), {
-						code: "EREADONLY_VIOLATION",
-					});
-				}
-				return result;
-			} finally {
-				if (scopeOpened && roFs !== undefined) {
-					try {
-						roFs.endReadOnlyScope();
-					} catch (err) {
-						// Scope toggle must not mask the primary error; log and continue.
-						console.error(
-							JSON.stringify({
-								event: "end_read_only_scope_error",
-								tenantId,
-								sandboxId,
-								error: (err as Error).message,
-							}),
-						);
+					return result;
+				} finally {
+					if (scopeOpened && roFs !== undefined) {
+						try {
+							roFs.endReadOnlyScope();
+						} catch (err) {
+							// Scope toggle must not mask the primary error; log and continue.
+							console.error(
+								JSON.stringify({
+									event: "end_read_only_scope_error",
+									tenantId,
+									sandboxId,
+									error: (err as Error).message,
+								}),
+							);
+						}
 					}
+					session.inFlight--;
+					// readOnly path never writes — no path-budget refresh, no version
+					// publish. The dirty flag is preserved so a subsequent writer's
+					// publishVersionIfDirty still fires (defense-in-depth).
 				}
-				session.inFlight--;
-				// readOnly path never writes — no path-budget refresh, no version
-				// publish. The dirty flag is preserved so a subsequent writer's
-				// publishVersionIfDirty still fires (defense-in-depth).
-			}
-		});
+			});
+		} finally {
+			session.lockLostSignal = undefined;
+		}
 	}
 
 	private async ensureFreshCache(tenantId: string, sandboxId: string, session: Session): Promise<void> {
@@ -897,19 +941,19 @@ export class SessionManager {
 		runtimeOptions?: RuntimeOptions,
 		owner = "",
 	): Promise<T> {
-		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async (lostSignal) => {
 			const session = await this.getOrCreate(tenantId, sandboxId, runtimeOptions, owner);
-			return this.withSessionEntry(tenantId, sandboxId, session, fn);
+			return this.withSessionEntry(tenantId, sandboxId, session, fn, lostSignal);
 		});
 	}
 
 	async withExistingSession<T>(tenantId: string, sandboxId: string, fn: (session: Session) => Promise<T>): Promise<T> {
-		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async (lostSignal) => {
 			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
 			if (session === undefined) {
 				throw Object.assign(new Error(`ENOENT: sandbox ${sandboxId} not found`), { code: "ENOENT" });
 			}
-			return this.withSessionEntry(tenantId, sandboxId, session, fn);
+			return this.withSessionEntry(tenantId, sandboxId, session, fn, lostSignal);
 		});
 	}
 
@@ -929,12 +973,12 @@ export class SessionManager {
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		return this.withExecLockShared(tenantId, sandboxId, async () => {
+		return this.withExecLockShared(tenantId, sandboxId, async (lostSignal) => {
 			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
 			if (session !== undefined && session.state !== "closing") {
-				return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
+				return this.withSessionReadEntry(tenantId, sandboxId, session, fn, lostSignal);
 			}
-			return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions);
+			return this.rehydrateAndExecRead(tenantId, sandboxId, fn, runtimeOptions, lostSignal);
 		});
 	}
 
@@ -943,6 +987,7 @@ export class SessionManager {
 		sandboxId: string,
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
+		lostSignal?: AbortSignal,
 	): Promise<T> {
 		let meta: SandboxMeta | null | undefined;
 		if (this.getSandboxMetaFn !== undefined) {
@@ -960,7 +1005,7 @@ export class SessionManager {
 		if (meta?.owner) session.owner = meta.owner;
 		if (meta?.name !== undefined) session.name = meta.name;
 		if (meta?.createdAt !== undefined) session.createdAt = meta.createdAt;
-		return this.withSessionReadEntry(tenantId, sandboxId, session, fn);
+		return this.withSessionReadEntry(tenantId, sandboxId, session, fn, lostSignal);
 	}
 
 	/**
@@ -976,12 +1021,12 @@ export class SessionManager {
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
 	): Promise<T> {
-		return this.withExecLockExclusive(tenantId, sandboxId, async () => {
+		return this.withExecLockExclusive(tenantId, sandboxId, async (lostSignal) => {
 			const session = this.sessions.get(this.sessionKey(tenantId, sandboxId));
 			if (session !== undefined && session.state !== "closing") {
-				return this.withSessionEntry(tenantId, sandboxId, session, fn);
+				return this.withSessionEntry(tenantId, sandboxId, session, fn, lostSignal);
 			}
-			return this.rehydrateAndExec(tenantId, sandboxId, fn, runtimeOptions);
+			return this.rehydrateAndExec(tenantId, sandboxId, fn, runtimeOptions, lostSignal);
 		});
 	}
 
@@ -990,6 +1035,7 @@ export class SessionManager {
 		sandboxId: string,
 		fn: (session: Session) => Promise<T>,
 		runtimeOptions?: RuntimeOptions,
+		lostSignal?: AbortSignal,
 	): Promise<T> {
 		let meta: SandboxMeta | null | undefined;
 		if (this.getSandboxMetaFn !== undefined) {
@@ -1013,7 +1059,7 @@ export class SessionManager {
 		if (meta?.createdAt !== undefined) {
 			session.createdAt = meta.createdAt;
 		}
-		return this.withSessionEntry(tenantId, sandboxId, session, fn);
+		return this.withSessionEntry(tenantId, sandboxId, session, fn, lostSignal);
 	}
 
 	async persistSandboxMeta(tenantId: string, sandboxId: string, meta: SandboxMeta): Promise<void> {
@@ -1315,6 +1361,18 @@ export class SessionManager {
 				session.scriptTx.beginScope();
 				try {
 					const result = await session.bash.exec(script, resolvedOpts);
+					// F2-L1: just-bash treats an aborted run as a RESOLVED result (exit
+					// 124), not a rejection — so a definitive lock loss would otherwise
+					// fall through to endScope() and COMMIT a partially-run script under a
+					// lease we no longer hold. If the lock's lost-signal fired, ROLL BACK
+					// instead and surface ELOCKLOST so the client retries a write that
+					// never committed (rather than getting a committed-then-failed lie).
+					// NOTE: a plain timeout abort still commits (audit L7) — we key off the
+					// dedicated lockLostSignal, not the composed exec signal.
+					if (session.lockLostSignal?.aborted === true) {
+						await session.scriptTx.abortScope();
+						throw new LockLostError("exec aborted: distributed exec lock lost mid-script");
+					}
 					await session.scriptTx.endScope();
 					return result;
 				} catch (err) {

--- a/src/api/tests/unit/session-manager.f2-lease-loss-abort.test.ts
+++ b/src/api/tests/unit/session-manager.f2-lease-loss-abort.test.ts
@@ -1,0 +1,335 @@
+/**
+ * F2-L1 regression: a DEFINITIVE distributed-lock loss mid-exec must abort the
+ * exec so its script-tx ROLLS BACK BEFORE any commit, surface the retryable
+ * LockLostError, and NOT bump the version counter (no committed-then-lie).
+ * A TRANSIENT renew blip must NOT abort the exec.
+ *
+ * No real Redis — the FakeRedis mirrors the RW lock's ZSET + string-key surface
+ * (same shape as distributed-rw-lock.test.ts / session-manager.exec-lock.test.ts)
+ * with a switch to force the exclusive RENEW to report definitive loss.
+ */
+
+import type { Redis } from "ioredis";
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it } from "vitest";
+import { versionKey } from "../../../sql-fs/redis-path-snapshot.js";
+import { SessionManager } from "../../session-manager.js";
+
+// ── FakeRedis (ZSET-aware, with forced exclusive renew loss + version INCR) ─────
+
+interface StringEntry {
+	value: string;
+	expiresAt: number;
+}
+
+class FakeRedis {
+	strings = new Map<string, StringEntry>();
+	zsets = new Map<string, Map<string, number>>();
+	counters = new Map<string, number>();
+
+	/** When true, RENEW_EXCLUSIVE reports a DEFINITIVE ownership loss (returns 0). */
+	forceExclusiveRenewLost = false;
+
+	private gcStrings(): void {
+		const now = Date.now();
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
+	async set(key: string, value: string, _px: "PX", ms: number, _nx: "NX"): Promise<"OK" | null> {
+		this.gcStrings();
+		if (this.strings.has(key)) return null;
+		this.strings.set(key, { value, expiresAt: Date.now() + ms });
+		return "OK";
+	}
+
+	// Version-counter surface used by publishVersionIfDirty / ensureFreshCache.
+	async incr(key: string): Promise<number> {
+		const next = (this.counters.get(key) ?? 0) + 1;
+		this.counters.set(key, next);
+		return next;
+	}
+	async expire(_key: string, _seconds: number): Promise<number> {
+		return 1;
+	}
+	async getex(key: string, _ex: "EX", _seconds: number): Promise<string | null> {
+		const v = this.counters.get(key);
+		return v === undefined ? null : String(v);
+	}
+	async del(key: string): Promise<number> {
+		return this.counters.delete(key) ? 1 : 0;
+	}
+
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		this.gcStrings();
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		if (script.includes("PEXPIRE")) {
+			if (this.forceExclusiveRenewLost) return 0; // definitive loss
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("DEL")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
+	}
+}
+
+function asRedis(f: FakeRedis): Redis {
+	return f as unknown as Redis;
+}
+
+// ── Recording script-tx FS ──────────────────────────────────────────────────────
+//
+// A Proxy over InMemoryFs (so bash.exec has a real filesystem to run against)
+// that also satisfies IScriptTxFs + ICoherentFs and records begin/end/abort so we
+// can assert the script-tx rolled back rather than committed. `wasDirty()` returns
+// true only while a scope committed (endScope) and false after an abort — this is
+// what publishVersionIfDirty consults to decide whether to INCR the version.
+
+interface ScriptTxRecord {
+	begins: number;
+	ends: number;
+	aborts: number;
+}
+
+function makeRecordingScriptTxFs(record: ScriptTxRecord): IFileSystem {
+	const base = new InMemoryFs();
+	let scopeActive = false;
+	let committed = false; // set on endScope (commit), cleared on abortScope (rollback)
+
+	const ext: Record<string, unknown> = {
+		// ── IScriptTxFs ──
+		beginScriptScope(): void {
+			scopeActive = true;
+			committed = false;
+			record.begins++;
+		},
+		async endScriptScope(): Promise<void> {
+			scopeActive = false;
+			committed = true; // simulates COMMIT
+			record.ends++;
+		},
+		async abortScriptScope(): Promise<void> {
+			scopeActive = false;
+			committed = false; // simulates ROLLBACK — no mutation survives
+			record.aborts++;
+		},
+		get scriptScopeActive(): boolean {
+			return scopeActive;
+		},
+		get scriptTxOpen(): boolean {
+			return scopeActive;
+		},
+		// ── ICoherentFs ──
+		async reload(): Promise<void> {},
+		wasDirty(): boolean {
+			return committed;
+		},
+		clearDirty(): void {
+			committed = false;
+		},
+		poisoned(): boolean {
+			return false;
+		},
+		async bulkIngest(): Promise<void> {},
+	};
+
+	return new Proxy(base, {
+		get(target, prop, receiver) {
+			if (prop in ext) {
+				const v = ext[prop as string];
+				return typeof v === "function" ? (v as () => unknown).bind(ext) : v;
+			}
+			const value = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as unknown as IFileSystem;
+}
+
+const T = "default";
+
+// Fast lock options so the heartbeat fires inside the test window.
+const FAST_LOCK = { leaseMs: 5_000, renewMs: 60, acquireTimeoutMs: 3_000, acquireRetryMs: 10, readerLeaseMs: 5_000 };
+
+describe("F2-L1: abort exec on definitive lease loss before commit", () => {
+	it("definitive loss mid-exec → script-tx ROLLS BACK, no version INCR, retryable ELOCKLOST", async () => {
+		const redis = new FakeRedis();
+		const record: ScriptTxRecord = { begins: 0, ends: 0, aborts: 0 };
+		const sm = new SessionManager({
+			createFs: () => Promise.resolve(makeRecordingScriptTxFs(record)),
+			redis: asRedis(redis),
+			execLockOptions: FAST_LOCK,
+		});
+
+		const err = await sm
+			.withSession(T, "sbx-loss", async (session) => {
+				// The lost-signal must be exposed to the exec path for this region.
+				expect(session.lockLostSignal).toBeDefined();
+				// Force the heartbeat's next renew to report a definitive loss, then
+				// run a script slow enough that the abort interrupts it mid-flight.
+				// The route layer composes lockLostSignal into the exec signal; mimic
+				// that here so bash.exec actually observes the abort.
+				redis.forceExclusiveRenewLost = true;
+				return sm.execWithRuntimeThrottle(session, "for i in $(seq 1 50); do sleep 0.05; done; echo done", {
+					signal: session.lockLostSignal,
+				});
+			})
+			.then(
+				() => undefined,
+				(e) => e as Error,
+			);
+
+		// Surfaced error is the retryable LockLostError (NOT a committed-then-failed lie).
+		expect(err).toBeDefined();
+		expect((err as Error & { code?: string }).code).toBe("ELOCKLOST");
+
+		// Script-tx opened then ROLLED BACK — never committed.
+		expect(record.begins).toBe(1);
+		expect(record.aborts).toBe(1);
+		expect(record.ends).toBe(0);
+
+		// No version bump was published (the write did not commit).
+		expect(redis.counters.get(versionKey(T, "sbx-loss")) ?? 0).toBe(0);
+
+		await sm.shutdown();
+	});
+
+	it("the lost-signal is cleared after the locked region (no leak into the next turn)", async () => {
+		const redis = new FakeRedis();
+		const record: ScriptTxRecord = { begins: 0, ends: 0, aborts: 0 };
+		const sm = new SessionManager({
+			createFs: () => Promise.resolve(makeRecordingScriptTxFs(record)),
+			redis: asRedis(redis),
+			execLockOptions: FAST_LOCK,
+		});
+
+		let captured: AbortSignal | undefined;
+		await sm.withSession(T, "sbx-clear", async (session) => {
+			captured = session.lockLostSignal;
+			expect(captured).toBeDefined();
+			return sm.execWithRuntimeThrottle(session, "echo hi");
+		});
+
+		// After the region the field is cleared; the captured signal never aborted.
+		const after = sm.getSession(T, "sbx-clear");
+		expect(after?.lockLostSignal).toBeUndefined();
+		expect(captured?.aborted).toBe(false);
+
+		await sm.shutdown();
+	});
+
+	it("a TRANSIENT renew blip does NOT abort the exec (only definitive loss does)", async () => {
+		const redis = new FakeRedis();
+		const record: ScriptTxRecord = { begins: 0, ends: 0, aborts: 0 };
+		const sm = new SessionManager({
+			createFs: () => Promise.resolve(makeRecordingScriptTxFs(record)),
+			redis: asRedis(redis),
+			execLockOptions: FAST_LOCK,
+		});
+
+		// Make the renew EVAL transiently throw for a window, then recover. The
+		// heartbeat treats a thrown renew as "transient" (lease still valid) and
+		// must NOT abort. Recovery before the lease expires keeps ownership.
+		const origEval = redis.eval.bind(redis);
+		let blips = 0;
+		redis.eval = async (script: string, numKeys: number, ...args: string[]) => {
+			if (script.includes("PEXPIRE") && blips < 1) {
+				blips++;
+				throw new Error("transient redis blip");
+			}
+			return origEval(script, numKeys, ...args);
+		};
+
+		const result = await sm.withSession(T, "sbx-transient", async (session) => {
+			expect(session.lockLostSignal?.aborted).toBe(false);
+			const r = await sm.execWithRuntimeThrottle(session, "for i in $(seq 1 6); do sleep 0.05; done; echo ok", {
+				signal: session.lockLostSignal,
+			});
+			// Signal stayed un-aborted across the transient blip.
+			expect(session.lockLostSignal?.aborted).toBe(false);
+			return r;
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim()).toBe("ok");
+		// Committed normally — no rollback.
+		expect(record.ends).toBe(1);
+		expect(record.aborts).toBe(0);
+
+		await sm.shutdown();
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f2l1-lease-loss-abort.md
+++ b/thoughts/shared/plans/2026-06-13_f2l1-lease-loss-abort.md
@@ -1,0 +1,200 @@
+# F2-L1: Enforce lease loss — abort the exec on definitive lock loss
+
+## Overview
+
+Both distributed lock wrappers run the critical section to completion and only
+**then** check the loss flag (`distributed-rw-lock.ts:421-422`, legacy
+`distributed-lock.ts:186-187`). A writer whose lease lapsed mid-script still
+commits its script-tx, still `INCR`s the version, and only afterwards throws
+`LockLostError` (`ELOCKLOST`). The client sees an error for a write that
+**durably happened** → an agent that retries on `ELOCKLOST` double-applies.
+
+This PR ships the issue's Layer 1 "Fix to ship" — it does NOT build the epoch
+fence (that is the separate, complete fix in #131/F2-L2):
+
+- Wire the lock's `onLost` callback (DEFINITIVE loss/expiry only — NOT transient
+  renew blips; the heartbeat already distinguishes them) to an
+  `AbortController.abort()`.
+- Plumb that lost-signal into `bash.exec` (which already accepts `opts.signal`),
+  composing it with the existing timeout/disconnect signal in the exec routes.
+- On definitive loss → bash aborts → `execWithRuntimeThrottle`'s `catch` calls
+  `session.scriptTx.abortScope()` → ROLLBACK; the client gets a clean RETRYABLE
+  error BEFORE any COMMIT. No committed-then-`ELOCKLOST` lie.
+
+## Current State Analysis
+
+- `src/api/distributed-rw-lock.ts`:
+  - `runShared` (`:369`) / `runExclusive` (`:399`) start a heartbeat whose
+    `onLost` callback sets a local `lost = true` flag (`:379-381`, `:413-415`).
+  - The heartbeat (`startSharedHeartbeat` `:181`, `startExclusiveHeartbeat`
+    `:286`) already distinguishes `"ownership_lost"` (token mismatch / renew→0)
+    and lease-expiry from a transient renew blip (`:217-224`, `:321-327`); it
+    only calls `onLost()` on the former. So `onLost` IS the definitive-loss
+    signal we need.
+  - `fn` is invoked with NO argument (`:384`, `:421`); the loss flag is only
+    consulted AFTER `fn()` resolves (`:385`, `:422`) — the run-then-check bug.
+- `src/api/distributed-lock.ts` (legacy single-key path, used when
+  `rwlockEnabled=false`): same shape — `lost` flag set by the heartbeat
+  (`:170-175`), `fn()` runs to completion, `if (lost) throw` only after
+  (`:186-187`).
+- `src/api/session-manager.ts`:
+  - `withExecLockExclusive` (`:602`) / `withExecLockShared` (`:611`) wrap `fn`
+    with `withDistributedRWLock(...)` or legacy `withDistributedLock(...)`.
+    When `redis === undefined` they call `fn()` bare (single-replica — no lock,
+    no loss possible).
+  - The wrapped `fn` ultimately reaches `withSessionEntry` (`:628`) →
+    `session.lock.runExclusive` → the route's `fn(session)` →
+    `execWithRuntimeThrottle` (`:1293`) → `session.bash.exec(script, opts)`
+    (`:1317`, `:1325`). On a throw, `execWithRuntimeThrottle` calls
+    `session.scriptTx.abortScope()` (`:1321`) → ROLLBACK.
+  - `Session` (`:182`) currently has no field for a lock-lost signal.
+- `src/api/routes/exec.ts`:
+  - exec-sync (`:166-181`) and exec (SSE, `:262-274`) each build a per-call
+    `AbortController` (`controller`) for the timeout; SSE also forwards client
+    disconnect (`:267-269`). `controller.signal` is passed to
+    `execWithRuntimeThrottle` as `opts.signal` (`:178`, `:285`).
+  - The session is available inside the runner callback as `session`.
+- `src/api/tests/unit/distributed-rw-lock.test.ts` — FakeRedis mock with
+  `forceExclusiveRenewLost` / `forceSharedRenewLost` flags already exercises the
+  loss path and asserts `LockLostError`.
+
+## Key Design Decision
+
+The lock wraps the OUTER layer; the timeout `AbortController` is created in the
+INNER route handler. To bridge "lock lost" down to `bash.exec`:
+
+1. Change the lock `fn` signature from `() => Promise<T>` to
+   `(lostSignal: AbortSignal) => Promise<T>`. The wrappers create an
+   `AbortController`, wire `onLost` to `controller.abort(LockLostError)`, and
+   invoke `fn(controller.signal)`. (Adding a param is backward-compatible for
+   existing `async () => ...` callers.)
+2. `SessionManager.withExecLockExclusive/Shared` receive the `lostSignal` and
+   stash it on the `Session` (`session.lockLostSignal`) for the duration of the
+   locked region, clearing it in `finally`.
+3. The exec routes compose `session.lockLostSignal` with their timeout
+   controller via `AbortSignal.any([...])` so `bash.exec` aborts on EITHER.
+4. Keep the post-`fn` `if (lost) throw LockLostError` as-is: it still converts a
+   clean (already-rolled-back) abort into the retryable `ELOCKLOST` the client
+   sees. Because the abort fires BEFORE commit, the throw now genuinely means
+   "not committed".
+
+## Desired End State
+
+- On definitive lock loss mid-exec: `bash.exec` aborts → `abortScriptScope()`
+  ROLLBACK → no COMMIT, no version `INCR` → `withDistributedRWLock` surfaces
+  `LockLostError` (`ELOCKLOST`, retryable / 503). The client never sees a
+  committed-then-failed write.
+- A TRANSIENT renew blip does NOT abort the exec (heartbeat already gates this).
+- `pnpm typecheck && pnpm lint:fix && pnpm test:unit` green; live smoke + (best
+  effort) live lease-loss injection on real Neon+Redis documented below.
+
+## What We're NOT Doing
+
+- NOT building the epoch fence / version-fence on commit (#131/F2-L2). After L1,
+  `ELOCKLOST` means "not committed"; the committed-but-uncertain nuance stays
+  with `ECOHERENCE` until #131.
+- NOT changing the heartbeat's transient-vs-definitive logic — it is already
+  correct and is the signal we consume.
+
+## Implementation Phases
+
+### Phase 1 — Lock wrappers pass a lost-signal to `fn`
+
+**Changes:**
+- `distributed-rw-lock.ts`: `withDistributedRWLock` / `runShared` /
+  `runExclusive` create an `AbortController`, set `onLost` to `controller.abort(...)`,
+  and call `fn(controller.signal)`. Signature: `fn: (lostSignal: AbortSignal) => Promise<T>`.
+- `distributed-lock.ts`: same for `withDistributedLock`.
+
+**Automated criteria:**
+- [x] `pnpm typecheck` passes.
+- [x] Existing `distributed-rw-lock.test.ts` / `distributed-lock.test.ts` pass
+  (callers ignore the new arg).
+
+**Manual criteria:**
+- [x] `onLost` is wired ONLY to the abort; transient blips still don't call it.
+
+#### Discoveries
+- `AbortController.abort(reason)` accepts a reason; passing a `LockLostError`
+  makes `signal.reason` carry the retryable code. just-bash surfaces an
+  AbortError on abort regardless; the wrapper's post-`fn` `if (lost) throw
+  LockLostError` is what the client actually sees, so the reason is for
+  diagnostics only.
+
+### Phase 2 — Plumb the signal through SessionManager + exec routes
+
+**Changes:**
+- `session-manager.ts`: add `lockLostSignal?: AbortSignal` to `Session`.
+  `withExecLockExclusive/Shared` set it before delegating to the inner `fn` and
+  clear it in `finally`. (Bare/no-redis path leaves it undefined.)
+- `exec.ts`: in exec-sync and exec(SSE), compose `session.lockLostSignal` (if
+  present) with the timeout `controller.signal` using `AbortSignal.any` and pass
+  the composed signal to `execWithRuntimeThrottle`.
+
+**Automated criteria:**
+- [x] `pnpm typecheck` + `pnpm lint:fix` clean.
+- [x] `pnpm test:unit` green (session-manager + exec-lock suites).
+
+**Manual criteria:**
+- [x] Abort on lost-signal reaches `execWithRuntimeThrottle`'s catch →
+  `abortScope()` (verified by reading the throw path + new regression test).
+
+#### Discoveries
+- The exec-sync handler treats a resolved exec as success even if the timeout
+  timer fired (audit L7). The lost-signal abort fires BEFORE resolution, so the
+  exec REJECTS (AbortError) and the catch rethrows → the lock wrapper converts
+  it to `LockLostError`. No L7 conflict.
+- `withExecLockExclusive/withExecLockShared` are the only two places that hold
+  the distributed lock, so stashing the signal there covers every write/read
+  exec path (`withSession*`, `withExistingSession`, batch, MCP).
+
+### Phase 3 — Regression test
+
+**Changes:**
+- New `session-manager.f2-lease-loss-abort.test.ts`: drive a real
+  `SessionManager` with a FakeRedis that fires definitive loss mid-exec, assert
+  the script-tx rolled back (abortScope called, no commit, no version INCR) and
+  the surfaced error is the retryable `LockLostError`. Assert a transient blip
+  does NOT abort.
+
+**Automated criteria:**
+- [x] New test green; whole `pnpm test:unit` green.
+
+#### Discoveries
+- Re-used the FakeRedis pattern from `distributed-rw-lock.test.ts` and a
+  recording mock scriptTx to assert rollback-not-commit without a real DB.
+
+## Manual Verification (LIVE server, real Neon + local Redis :6379, PORT 8082)
+
+Server booted with `tsx --env-file .env src/api/server.ts`; `/healthz` + `/readyz`
+returned `{"status":"ok"}`. Token minted via `POST /v1/auth/bootstrap`
+(`X-Auth-Secret`). Default lock options (lease 60s, renew 20s).
+
+### A. Happy path — PASS
+- [x] Created a sandbox; `exec-sync` of `echo hello-f2l1 > /x; cat /x` returned
+  HTTP 200, `stdout="hello-f2l1\n"`, exitCode 0. The abort wiring does not break
+  normal execs.
+
+### B. Lease-loss injection — PASS (reproduced live)
+- [x] Started a ~26s `exec-sync` (`for i in $(seq 1 52); do sleep 0.5; done; echo
+  committed > /y; cat /y`) so the heartbeat's renew (at ~20s) would fire mid-exec.
+  Confirmed the writer key `vfs:default:rwlock:{<sandbox>}:writer` was present
+  (`redis-cli GET` → token), then `redis-cli DEL`'d ONLY that key at t~1s.
+- [x] At the ~20s renew, the heartbeat detected the missing key (RENEW→0 =
+  definitive loss), aborted the in-flight exec, and the script-tx ROLLED BACK.
+  The HTTP response was **503 with `code: "ELOCKLOST"`** (retryable), NOT a
+  committed-then-success lie.
+- [x] A follow-up exec confirmed `/y` does NOT exist → the write never committed
+  (clean rollback). A normal exec on the same sandbox then returned 200.
+- Reproducibility note: with the DEFAULT 20s renew interval the loss is only
+  detected at the next heartbeat, so the injection requires an exec that outlives
+  one renew cycle (used ~26s). A short (<20s) exec finishes before any renew and
+  cannot surface a live loss — the unit/integration regression test (which forces
+  the renew to report loss immediately) is the authoritative proof of the
+  fast-path behaviour; the live run confirms the end-to-end 503-ELOCKLOST +
+  rollback under real Neon + Redis.
+
+### C. Cleanup — PASS
+- [x] Server killed by PID; port 8082 free; no orphan dev server from this
+  worktree (the only remaining `tsx` processes belong to the separate `/virtualFS`
+  checkout, not `/virtualFS-f9a`).


### PR DESCRIPTION
## Summary

Closes the F2 "committed-then-lie" consequence (a) and shrinks consequence (b) to the heartbeat-detection gap. Both distributed lock wrappers (`distributed-rw-lock.ts`, legacy `distributed-lock.ts`) ran the critical section to completion and only *then* checked the loss flag — a writer whose lease lapsed mid-script still committed its script-tx, bumped the version (`INCR`), and only afterwards threw `ELOCKLOST`. The client saw an error for a write that durably happened → retrying agents double-applied.

This is **Layer 1** only. The complete epoch/version fence is the separate **#131** (F2-L2). After L1, `ELOCKLOST` genuinely means "not committed".

## Changes

- **`distributed-rw-lock.ts` / `distributed-lock.ts`**: the lock's `onLost` callback (fired on DEFINITIVE loss only — token mismatch / lease expiry, NOT transient renew blips, which the heartbeat already distinguishes) now aborts an `AbortController`. `fn` receives that `lostSignal`. If `fn` throws while `lost` is set, the canonical retryable `LockLostError` is surfaced.
- **`session-manager.ts`**: new `Session.lockLostSignal`, set by `withExecLockExclusive`/`withExecLockShared` for the locked region (cleared in `finally`). Crucially, `execWithRuntimeThrottle` now checks the lock-lost signal after `bash.exec` resolves: just-bash treats an aborted run as a **resolved** result (exit 124), not a rejection, so without this the partial script would still `endScope()` → COMMIT. On lock loss it calls `abortScope()` (ROLLBACK) and throws `LockLostError`. A plain timeout abort still commits (unchanged, audit L7) — only the dedicated lock-lost signal triggers rollback.
- **`routes/exec.ts`**: `composeAbortSignals` (`AbortSignal.any`) composes `session.lockLostSignal` with the existing timeout/disconnect signal for exec-sync, exec(SSE), and exec-sync-batch.
- **`errors.ts`**: `ELOCKLOST` now maps to **503 (retryable)** instead of 500 — after L1 it means "not committed", so the client may safely retry.

## Unit results

`pnpm typecheck && pnpm lint:fix && pnpm test:unit` all green — 953 passed / 4 skipped. New focused regression suite `session-manager.f2-lease-loss-abort.test.ts` (3 tests):
- definitive loss mid-exec → script-tx ROLLS BACK (abortScope, no endScope), no version `INCR`, surfaced error is retryable `ELOCKLOST`;
- the lost-signal is cleared after the locked region (no leak into a later turn);
- a TRANSIENT renew blip does NOT abort the exec.

## LIVE results (real Neon + local Redis, PORT 8082)

- **A. Happy path** — create sandbox + `echo … > /x; cat /x` → HTTP 200, correct stdout. Abort wiring doesn't break normal execs.
- **B. Lease-loss injection (reproduced live)** — started a ~26s exec so the 20s renew fires mid-flight; confirmed the writer key `vfs:default:rwlock:{<sandbox>}:writer` present, then `redis-cli DEL`'d ONLY that key. At the renew the heartbeat detected the loss, aborted the exec, and the response was **HTTP 503 `ELOCKLOST`** (not a committed-then-success lie). A follow-up exec confirmed `/y` does **not** exist → the write rolled back. *Note:* with the default 20s renew interval the loss is only detected at the next heartbeat, so a short (<20s) exec finishes before any renew — the unit test (which forces the renew to report loss immediately) is the authoritative proof of the fast path; the live run confirms the end-to-end 503 + rollback under real Neon + Redis.
- **C. Cleanup** — server killed by PID; port 8082 free; no orphan dev server from this worktree.

## Reviewer manual steps

1. Boot with `REDIS_URL` set. Create a sandbox, start a >20s `exec-sync`.
2. `redis-cli GET vfs:<tenant>:rwlock:{<sandbox>}:writer` to confirm the key, then `DEL` it.
3. Observe the in-flight exec return 503 `ELOCKLOST`; confirm any write it attempted did not persist. (Or set short `REDIS_EXEC_LOCK_RENEW_MS` to shorten the window.)

Note: the epoch fence is the separate **#131**.

Closes #130