### PR TITLE
perf(cache): incremental byte counter (+ children index) for O(1) dir ops (F9e)

### DIFF
--- a/.changeset/fix-f9e-dir-scan-index.md
+++ b/.changeset/fix-f9e-dir-scan-index.md
@@ -1,0 +1,16 @@
+---
+"sql-fs-api": minor
+---
+
+perf(cache): O(1) pathCache byte accounting to avoid full-map scans (F9e, #142)
+
+SqlFs now maintains an incremental `#pathCacheBytes` counter, adjusted on
+every pathCache set/delete and reset on `reload()`/`ready()`, and exposes
+`getPathCacheBytes()`. SessionManager's path-cache memory budget calls it
+instead of re-walking the entire pathCache (`Σ path.length + 100`) on every
+dirty exec. The value equals the previous full-walk exactly. Falls back to
+the full walk for backends that do not expose the counter.
+
+The `#childrenByParent` children index (part B of #142) is deferred to a
+follow-up; it is benchmark-gated and (A) delivers the higher-value, lower-risk
+win without touching readdir correctness.

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -473,6 +473,13 @@ export class SessionManager {
 	}
 
 	private estimatePathCacheBytes(fs: IFileSystem): number {
+		// F9e: prefer the O(1) incremental counter when the backend maintains one
+		// (SqlFs). Its value equals this full-walk exactly, so the budget is
+		// identical without re-scanning the whole pathCache on every dirty exec.
+		const withCounter = fs as Partial<{ getPathCacheBytes(): number }>;
+		if (typeof withCounter.getPathCacheBytes === "function") {
+			return withCounter.getPathCacheBytes();
+		}
 		const paths = fs.getAllPaths();
 		let total = 0;
 		for (const p of paths) {

--- a/src/sql-fs/sql-fs.ts
+++ b/src/sql-fs/sql-fs.ts
@@ -188,6 +188,13 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 	#scriptTxAbort: ((err: Error) => void) | undefined;
 	#scriptTxPromise: Promise<void> | undefined;
 	#readOnlyDepth = 0;
+	/**
+	 * Incremental byte estimate of `#pathCache`, maintained O(1) on every
+	 * set/delete/clear (F9e). Equals the old full-walk
+	 * `Σ (path.length + 100)` exactly, so callers can size the path-cache
+	 * memory budget without re-walking the whole Map on every dirty exec.
+	 */
+	#pathCacheBytes = 0;
 
 	constructor(opts: SqlFsOptions<Tx>) {
 		this.#dialect = opts.dialect;
@@ -360,8 +367,45 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 	 */
 	#updateCacheByInode(inodeId: bigint, patch: Partial<PathCacheEntry>): void {
 		for (const [p, e] of this.#pathCache) {
-			if (e.inodeId === inodeId) this.#pathCache.set(p, { ...e, ...patch });
+			if (e.inodeId === inodeId) this.#cacheSet(p, { ...e, ...patch });
 		}
+	}
+
+	// ── pathCache mutation helpers (F9e: O(1) byte accounting) ──────────────────
+	//
+	// Every mutation of `#pathCache` MUST go through these so `#pathCacheBytes`
+	// stays in lockstep. The byte estimate depends only on the SET of keys
+	// (`Σ key.length + 100`), so a `set` on an existing key is a no-op for the
+	// counter — matching `#updateCacheByInode`'s in-place value patches.
+
+	/** Sets a pathCache entry, adjusting the byte counter only when the key is new. */
+	#cacheSet(key: string, entry: PathCacheEntry): void {
+		if (!this.#pathCache.has(key)) {
+			this.#pathCacheBytes += key.length + 100;
+		}
+		this.#pathCache.set(key, entry);
+	}
+
+	/** Deletes a pathCache entry, subtracting its byte contribution if present. */
+	#cacheDelete(key: string): void {
+		if (this.#pathCache.delete(key)) {
+			this.#pathCacheBytes -= key.length + 100;
+		}
+	}
+
+	/** Clears the pathCache and resets the byte counter. */
+	#cacheClear(): void {
+		this.#pathCache.clear();
+		this.#pathCacheBytes = 0;
+	}
+
+	/**
+	 * O(1) byte estimate of the pathCache, equal to the old full-walk
+	 * `Σ (path.length + 100)`. Consumed by SessionManager's path-cache memory
+	 * budget so it never re-walks the whole Map on a dirty exec (F9e).
+	 */
+	getPathCacheBytes(): number {
+		return this.#pathCacheBytes;
 	}
 
 	/** Returns all pathCache paths rooted at dirPath (inclusive). */
@@ -545,8 +589,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		this.#startPrewarm();
 
 		const { entries, fromSnapshot } = await this.#loadFreshPathCache();
-		this.#pathCache.clear();
-		for (const [p, e] of entries) this.#pathCache.set(p, e);
+		this.#cacheClear();
+		for (const [p, e] of entries) this.#cacheSet(p, e);
 		// Initial load established committed state; the cache is not poisoned (F1).
 		this.#cachePoisoned = false;
 
@@ -588,8 +632,8 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		const p = (async (): Promise<void> => {
 			try {
 				const { entries } = await this.#loadFreshPathCache();
-				this.#pathCache.clear();
-				for (const [path, entry] of entries) this.#pathCache.set(path, entry);
+				this.#cacheClear();
+				for (const [path, entry] of entries) this.#cacheSet(path, entry);
 				this.#contentCache.clear();
 				this.#dirty = false;
 				// A successful reload re-established committed state in the caches,
@@ -765,7 +809,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			if (old !== undefined && old.inodeId !== entry.inodeId) {
 				this.#contentCache.delete(old.inodeId);
 			}
-			this.#pathCache.set(path, entry);
+			this.#cacheSet(path, entry);
 			const bytes = bytesByPath.get(path);
 			if (bytes !== undefined && bytes.byteLength > 0) {
 				this.#contentCache.set(entry.inodeId, bytes);
@@ -837,7 +881,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		if (displaced !== undefined && displaced.inodeId !== inodeId) {
 			this.#contentCache.delete(displaced.inodeId);
 		}
-		this.#pathCache.set(path, {
+		this.#cacheSet(path, {
 			inodeId,
 			kind: INODE_KIND.FILE,
 			mode: 0o644,
@@ -911,7 +955,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 
 		if (existing) this.#contentCache.delete(existing.inodeId);
 		if (fullBytes.byteLength > 0) this.#contentCache.set(inodeId, fullBytes);
-		this.#pathCache.set(path, {
+		this.#cacheSet(path, {
 			inodeId,
 			kind: INODE_KIND.FILE,
 			mode: 0o644,
@@ -953,7 +997,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 						await this.#dialect.insertDirent(tx, parentEntry.inodeId, seg, id);
 						return id;
 					});
-					this.#pathCache.set(next, {
+					this.#cacheSet(next, {
 						inodeId,
 						kind: INODE_KIND.DIRECTORY,
 						mode: 0o755,
@@ -989,7 +1033,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 					return id;
 				});
 
-		this.#pathCache.set(path, {
+		this.#cacheSet(path, {
 			inodeId,
 			kind: INODE_KIND.DIRECTORY,
 			mode: 0o755,
@@ -1047,7 +1091,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			for (const p of subtreePaths) {
 				const e = this.#pathCache.get(p);
 				if (e) this.#contentCache.delete(e.inodeId);
-				this.#pathCache.delete(p);
+				this.#cacheDelete(p);
 			}
 			this.#dirty = true;
 			return;
@@ -1069,7 +1113,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		}
 
 		this.#contentCache.delete(entry.inodeId);
-		this.#pathCache.delete(path);
+		this.#cacheDelete(path);
 		this.#dirty = true;
 	}
 
@@ -1255,7 +1299,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			for (const [destPath, inodeId] of newInodeIds) {
 				const srcPath = src + destPath.slice(dest.length);
 				const srcE = this.#pathCache.get(srcPath)!;
-				this.#pathCache.set(destPath, { ...srcE, inodeId, mtime });
+				this.#cacheSet(destPath, { ...srcE, inodeId, mtime });
 			}
 			this.#dirty = true;
 			return;
@@ -1289,7 +1333,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			return id;
 		});
 
-		this.#pathCache.set(dest, {
+		this.#cacheSet(dest, {
 			inodeId: newInodeId,
 			kind: srcEntry.kind,
 			mode: srcEntry.mode,
@@ -1371,15 +1415,15 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 		}
 
 		// Remove src subtree and any existing dest subtree from cache
-		for (const p of srcPaths) this.#pathCache.delete(p);
+		for (const p of srcPaths) this.#cacheDelete(p);
 		const destPrefix = dest === "/" ? "/" : `${dest}/`;
 		for (const key of [...this.#pathCache.keys()]) {
-			if (key === dest || key.startsWith(destPrefix)) this.#pathCache.delete(key);
+			if (key === dest || key.startsWith(destPrefix)) this.#cacheDelete(key);
 		}
 
 		// Re-insert src entries under dest (remap prefix src → dest)
 		for (const [oldPath, entry] of snapshot) {
-			this.#pathCache.set(dest + oldPath.slice(src.length), entry);
+			this.#cacheSet(dest + oldPath.slice(src.length), entry);
 		}
 		this.#dirty = true;
 	}
@@ -1413,7 +1457,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			return id;
 		});
 
-		this.#pathCache.set(linkPath, {
+		this.#cacheSet(linkPath, {
 			inodeId,
 			kind: INODE_KIND.SYMLINK,
 			mode: 0o777,
@@ -1441,7 +1485,7 @@ export class SqlFs<Tx = unknown> implements ICoherentFs, IReadOnlyScopeFs {
 			await this.#dialect.incrementNlink(tx, srcEntry.inodeId);
 		});
 
-		this.#pathCache.set(newPath, { ...srcEntry });
+		this.#cacheSet(newPath, { ...srcEntry });
 		this.#dirty = true;
 	}
 

--- a/src/sql-fs/tests/unit/sql-fs.path-cache-bytes.test.ts
+++ b/src/sql-fs/tests/unit/sql-fs.path-cache-bytes.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for SqlFs.getPathCacheBytes() — incremental O(1) byte accounting (F9e).
+ *
+ * The counter MUST equal the previous full-walk `Σ (path.length + 100)` over
+ * `getAllPaths()` exactly, after every mutation (write / delete / overwrite /
+ * mkdir / cp / mv / rm -r / symlink / link) and after reload()/ready().
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SqlFs } from "../../sql-fs.js";
+import type { PathCacheEntry, SqlDialect } from "../../types.js";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+function dirEntry(path: string, inodeId: bigint): { path: string } & PathCacheEntry {
+	return { path, inodeId, kind: 2, mode: 0o755, size: 0, mtime: now, contentSha256: null, symlinkTarget: null };
+}
+
+function fileEntry(path: string, inodeId: bigint, size: number): { path: string } & PathCacheEntry {
+	return {
+		path,
+		inodeId,
+		kind: 1,
+		mode: 0o644,
+		size,
+		mtime: now,
+		contentSha256: new Uint8Array(32),
+		symlinkTarget: null,
+	};
+}
+
+/** The original full-walk formula from SessionManager.estimatePathCacheBytes. */
+function fullWalk(fs: SqlFs): number {
+	let total = 0;
+	for (const p of fs.getAllPaths()) total += p.length + 100;
+	return total;
+}
+
+/** Asserts the O(1) counter matches the full-walk reference exactly. */
+function expectInSync(fs: SqlFs): void {
+	expect(fs.getPathCacheBytes()).toBe(fullWalk(fs));
+}
+
+describe("SqlFs.getPathCacheBytes() — incremental byte accounting (F9e)", () => {
+	const sandboxId = "test-sandbox";
+	let nextInode = 100n;
+	let loadAllPathsMock: ReturnType<typeof vi.fn>;
+	let dialect: SqlDialect<unknown>;
+	let fs: SqlFs;
+
+	beforeEach(async () => {
+		nextInode = 100n;
+		loadAllPathsMock = vi.fn(async () => [
+			dirEntry("/", 1n),
+			dirEntry("/a", 2n),
+			dirEntry("/a/b", 3n),
+			fileEntry("/a/b/c.txt", 4n, 10),
+		]);
+
+		dialect = {
+			connect: vi.fn(),
+			disconnect: vi.fn(),
+			transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+			setSandboxContext: vi.fn(),
+			setSandboxContextWithLock: vi.fn(),
+			loadAllPaths: loadAllPathsMock,
+			createSandbox: vi.fn(),
+			deleteSandbox: vi.fn(),
+			createInode: vi.fn(async () => nextInode++),
+			getInode: vi.fn(),
+			updateInode: vi.fn(),
+			deleteInode: vi.fn(),
+			incrementNlink: vi.fn(),
+			decrementNlink: vi.fn(async () => 0),
+			insertDirent: vi.fn(),
+			upsertDirent: vi.fn(async () => null),
+			deleteDirent: vi.fn(async () => nextInode),
+			listDirents: vi.fn(),
+			moveDirent: vi.fn(),
+			upsertBlob: vi.fn(),
+			getBlob: vi.fn(),
+			gcOrphanBlobs: vi.fn(),
+			getBlobsForSandbox: vi.fn(async () => []),
+			loadSubtreeInodes: vi.fn(async () => []),
+			bulkIngest: vi.fn(async () => new Map<string, PathCacheEntry>()),
+			resolvePath: vi.fn(),
+		} as unknown as SqlDialect<unknown>;
+
+		fs = new SqlFs({ dialect, sandboxId, allowSymlinks: true });
+		await fs.ready();
+	});
+
+	it("starts in sync after ready()", () => {
+		// 4 entries: '/' '/a' '/a/b' '/a/b/c.txt' → (1+100)+(2+100)+(4+100)+(10+100)
+		expect(fs.getPathCacheBytes()).toBe(1 + 100 + (2 + 100) + (4 + 100) + (10 + 100));
+		expectInSync(fs);
+	});
+
+	it("is zero before ready()", () => {
+		const fresh = new SqlFs({ dialect, sandboxId });
+		expect(fresh.getPathCacheBytes()).toBe(0);
+	});
+
+	it("stays in sync across writeFile (new + overwrite)", async () => {
+		await fs.writeFile("/a/new.txt", "hello");
+		expectInSync(fs);
+		const afterNew = fs.getPathCacheBytes();
+
+		// Overwrite an existing path: key set unchanged → counter unchanged.
+		await fs.writeFile("/a/new.txt", "longer content now");
+		expect(fs.getPathCacheBytes()).toBe(afterNew);
+		expectInSync(fs);
+	});
+
+	it("stays in sync across mkdir -p (multiple new segments)", async () => {
+		await fs.mkdir("/a/x/y/z", { recursive: true });
+		expectInSync(fs);
+	});
+
+	it("stays in sync across rm of a single file", async () => {
+		await fs.writeFile("/a/tmp.txt", "x");
+		expectInSync(fs);
+		await fs.rm("/a/tmp.txt");
+		expectInSync(fs);
+		// Back to the post-ready baseline.
+		expect(fs.getPathCacheBytes()).toBe(1 + 100 + (2 + 100) + (4 + 100) + (10 + 100));
+	});
+
+	it("stays in sync across rm -r of a subtree", async () => {
+		await fs.mkdir("/a/sub", { recursive: true });
+		await fs.writeFile("/a/sub/f1.txt", "a");
+		await fs.writeFile("/a/sub/f2.txt", "bb");
+		expectInSync(fs);
+		await fs.rm("/a/sub", { recursive: true });
+		expectInSync(fs);
+	});
+
+	it("stays in sync across cp -r of a subtree", async () => {
+		await fs.mkdir("/a/sub", { recursive: true });
+		await fs.writeFile("/a/sub/f.txt", "data");
+		expectInSync(fs);
+		await fs.cp("/a/sub", "/a/copy", { recursive: true });
+		expectInSync(fs);
+	});
+
+	it("stays in sync across mv of a subtree (delete src + insert dest)", async () => {
+		await fs.mkdir("/a/sub", { recursive: true });
+		await fs.writeFile("/a/sub/f.txt", "data");
+		expectInSync(fs);
+		await fs.mv("/a/sub", "/a/moved");
+		expectInSync(fs);
+	});
+
+	it("stays in sync across symlink and hardlink", async () => {
+		await fs.symlink("/a/b/c.txt", "/a/link");
+		expectInSync(fs);
+		await fs.link("/a/b/c.txt", "/a/hard.txt");
+		expectInSync(fs);
+	});
+
+	it("resets and re-syncs after reload() with a different tree", async () => {
+		await fs.writeFile("/a/scratch.txt", "x");
+		expectInSync(fs);
+
+		// reload() pulls a smaller committed tree.
+		loadAllPathsMock.mockResolvedValueOnce([dirEntry("/", 1n), fileEntry("/only.txt", 9n, 3)]);
+		await fs.reload();
+
+		expect(fs.getPathCacheBytes()).toBe(1 + 100 + (9 + 100));
+		expectInSync(fs);
+	});
+
+	it("re-syncs after ready() is called again (clear + repopulate)", async () => {
+		await fs.writeFile("/a/scratch.txt", "x");
+		loadAllPathsMock.mockResolvedValueOnce([dirEntry("/", 1n)]);
+		await fs.ready();
+		expect(fs.getPathCacheBytes()).toBe(1 + 100);
+		expectInSync(fs);
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f9e-dir-scan-index.md
+++ b/thoughts/shared/plans/2026-06-13_f9e-dir-scan-index.md
@@ -1,0 +1,73 @@
+# F9e: O(N) directory scans — incremental byte counter (+ children map)
+
+## Problem / Goal
+
+`readdir`/subtree ops walk the entire `#pathCache` per call, and
+`SessionManager.estimatePathCacheBytes` re-walks the full path list
+(`fs.getAllPaths()` → `Σ p.length + 100`) after every dirty exec
+(`getOrCreate` and `withExecLock`'s finally). Invisible at 10³ paths,
+a repeated O(N) cost per turn at 10⁵.
+
+Issue #142 ("F9e", Real — Low). Ship in two parts:
+
+- **(A)** Incremental `#pathCacheBytes` counter inside `SqlFs`, maintained
+  O(1) at every `#pathCache` set/delete/clear, reset on `reload()`/`ready()`.
+  Expose `getPathCacheBytes()`; `SessionManager` calls it instead of the
+  full re-walk. Values MUST equal the old `estimatePathCacheBytes` exactly.
+- **(B)** `#childrenByParent: Map<string, Set<string>>` to make `readdir`
+  O(children) — ONLY if every mutation site (set/delete, cp/mv subtree,
+  reload/ready clear+repopulate) is covered + tested. Otherwise DEFER.
+
+## Discoveries
+
+- `estimatePathCacheBytes` lives in `src/api/session-manager.ts:475`, NOT
+  `sql-fs.ts` (issue line numbers predate batch-2 and refer to call-site
+  intent). Formula: `for each path: total += p.length + 100`. Depends ONLY
+  on the set of path-string keys, so the exact value is
+  `Σ key.length + 100 * pathCache.size`.
+- Call sites: `session-manager.ts:544` (getOrCreate) and `:725`
+  (withExecLock finally, guarded by `shouldRefreshPathBudget`).
+- 18 direct `#pathCache.{set,delete,clear}` sites in `sql-fs.ts`
+  (incl. `#updateCacheByInode` which only patches an EXISTING key — must
+  not change the byte count). Routing all through `#cacheSet/#cacheDelete/
+  #cacheClear` helpers keeps the counter exact and central.
+- `_getPathCache()` is exposed but used externally for READS only
+  (snapshot writer + tests). No external mutation path to miss.
+- `reload()`/`ready()` both `clear()` then repopulate via `set` — both
+  already routed through the helpers, so the counter resets correctly.
+
+## Decision on (B)
+
+DEFER (B). `readdir`/`#childPaths` correctness is silently broken if any
+mutation site desyncs the children map; (A) delivers the higher-value,
+lower-risk win the issue calls for ("ship (A) first"). (B) is
+benchmark-gated in the issue and not required for the acceptance criteria
+of this PR. Noted in the PR body as a follow-up.
+
+## Phase 1 — (A) incremental byte counter
+
+### Changes
+- `sql-fs.ts`: add `#pathCacheBytes = 0`; add private `#cacheSet`,
+  `#cacheDelete`, `#cacheClear` helpers maintaining it O(1); route all 18
+  mutation sites through them. Add public `getPathCacheBytes(): number`.
+- `session-manager.ts`: `estimatePathCacheBytes` prefers
+  `fs.getPathCacheBytes()` when present, else falls back to the full walk
+  (memory backend / other IFileSystem impls have no counter).
+
+### Automated criteria
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint:fix` clean
+- [x] New unit test: counter equals old full-walk across write/delete/
+      overwrite/mkdir/cp/mv/rm -r and after `reload()`/`ready()`
+      (`sql-fs.path-cache-bytes.test.ts`, 11 tests)
+- [x] `pnpm test:unit` green (985 passed) — no weakened tests
+
+### Manual criteria
+- [x] LIVE (Neon + Redis, port 8134): built a 35-file/10-dir tree, then
+      cp -r / mv / rm -r; `ls`, `ls -R`, and `GET /tree` all returned
+      complete, correct, consistent listings (`find` 46 vs tree-API 45,
+      i.e. minus the root prefix). No server errors; no crash.
+
+## Phase 2 — (B) children index
+
+DEFERRED to a follow-up PR (see Decision above).


### PR DESCRIPTION
## Summary

Fixes the repeated O(N) pathCache full-walk that ran on every dirty exec (F9e, #142).

`SessionManager.estimatePathCacheBytes` re-walked the entire pathCache
(`Σ path.length + 100`) after each dirty exec (`getOrCreate` + the `withExecLock`
finally). Invisible at 10³ paths, a repeated per-turn cost at 10⁵.

### What changed (Part A — shipped)
- `SqlFs` maintains an incremental `#pathCacheBytes` counter via three private
  helpers — `#cacheSet` / `#cacheDelete` / `#cacheClear` — that ALL 18 pathCache
  mutation sites now route through (write/mkdir/rm/rm -r/cp/cp -r/mv/symlink/link,
  `#updateCacheByInode`, bulkIngest, and the `ready()`/`reload()` clear+repopulate).
  The counter is O(1) per mutation and depends only on the key set, so an in-place
  value patch (e.g. chmod via `#updateCacheByInode`) is a no-op for the counter.
- New public `getPathCacheBytes(): number`. `SessionManager.estimatePathCacheBytes`
  prefers it when present and equals the old full-walk **exactly**; falls back to
  the full walk for backends (memory / other `IFileSystem`) that don't expose it.

### Part B (children index) — DEFERRED
`#childrenByParent: Map<string, Set<string>>` is **not** in this PR. It is
benchmark-gated in the issue, and its hardest invariant (every mutation site +
cp/mv subtree + the `reload()`/`ready()` clear+repopulate) silently desyncs
`readdir` if any site is missed. Per the "keep it small" guidance, (A) delivers
the higher-value, lower-risk win alone. Tracked as a follow-up.

## Tests

### Unit (new) — `src/sql-fs/tests/unit/sql-fs.path-cache-bytes.test.ts` (11 tests, all green)
Asserts the counter equals the old full-walk over `getAllPaths()` after every
mutation: ready baseline, zero before ready, writeFile new+overwrite, mkdir -p,
rm of a file, rm -r of a subtree, cp -r of a subtree, mv of a subtree,
symlink+hardlink, reload() with a different tree, and a second ready() (clear+repopulate).

Full gate: `pnpm typecheck && pnpm lint:fix && pnpm test:unit` → **985 passed, 4 skipped**. No tests weakened.

### Live (Neon + Redis, real API server on :8134)
- Bootstrapped a JWT, created a sandbox, built a 35-file / 10-dir tree.
- `ls`, `ls /demo/dir3`, and `ls -R /demo` → complete, correct listings.
- `cp -r /demo/dir1 /demo/copy1` + `mv /demo/dir2 /demo/moved2` + `rm -r /demo/dir5`
  → post-op `ls /demo` = `copy1 dir1 dir3 dir4 moved2` (dir2/dir5 gone, copy/move intact).
- `GET /tree?prefix=/demo` returned 45 entries vs `find /demo | wc -l` = 46
  (the one diff is the root prefix dir, as expected) — index-served listings stay consistent.
- Session served many dirty execs (each hits `getPathCacheBytes()` in the exec-lock finally);
  no server errors, no crash. Sandbox torn down, server stopped.

## Reviewer manual steps
1. `pnpm test:unit -- src/sql-fs/tests/unit/sql-fs.path-cache-bytes.test.ts`
2. Optional live: start `PORT=8134 tsx --env-file .env src/api/server.ts`, build a tree,
   compare `find <dir> | wc -l` to `GET /tree?prefix=<dir>` length (off by exactly 1 = root prefix).

Closes #142