### PR TITLE
fix(coherence): background-drain stranded version publishes (F3)

### DIFF
--- a/.changeset/fix-f3-publish-drainer.md
+++ b/.changeset/fix-f3-publish-drainer.md
@@ -1,0 +1,5 @@
+---
+"sql-fs-api": minor
+---
+
+Heal stranded cross-replica version publishes after a Redis INCR failure (F3): a background drainer and reap-time best-effort publish flush the bump even if no further client traffic arrives or the session is idle-evicted.

--- a/src/api/session-manager.ts
+++ b/src/api/session-manager.ts
@@ -242,10 +242,18 @@ export interface Session {
 	lockLostSignal?: AbortSignal;
 	/**
 	 * Set to true when a previous turn's `publishVersionIfDirty` call failed
-	 * (the write committed to Postgres but the Redis INCR errored). The next
-	 * successful turn must publish a version bump even if no new mutations
-	 * occurred on the FS — this is what guarantees other replicas eventually
-	 * see the prior write.
+	 * (the write committed to Postgres but the Redis INCR errored). The write is
+	 * durable in Postgres, but the cross-replica version bump is stranded: other
+	 * replicas keep serving their pre-write tree until the counter advances.
+	 *
+	 * Two mechanisms eventually flush this bump (whichever fires first):
+	 *  - The next turn on this replica calls `publishVersionIfDirty` again, which
+	 *    publishes even with no new mutation because `publishPending` is set.
+	 *  - The background publish drainer (`drainPendingPublishes`, an unref'd
+	 *    interval tied to the reaper lifecycle) retries under the session lock,
+	 *    independent of any further client traffic — so an idle session that the
+	 *    reaper would otherwise evict (discarding this in-memory flag) is healed
+	 *    first. The reaper also makes a best-effort publish before disconnect.
 	 *
 	 * Cleared after a successful publish.
 	 */
@@ -345,6 +353,16 @@ export class SessionManager {
 	private readonly idleMs: number;
 	private readonly pathCacheMaxBytes: number;
 	private reaperTimer: ReturnType<typeof setInterval> | undefined;
+	private drainerTimer: ReturnType<typeof setInterval> | undefined;
+	/**
+	 * F3: sessions whose committed write could not publish its Redis version bump
+	 * (the INCR failed). Keyed by `sessionKey`, valued with the coordinates the
+	 * drainer needs to retry the publish. The background drainer
+	 * (`drainPendingPublishes`) flushes these even if no further client traffic
+	 * arrives, so a stranded bump survives an idle eviction. Entries are removed
+	 * on a successful publish, on poison-suppression, or on destroy.
+	 */
+	private readonly pendingPublishes: Map<string, { tenantId: string; sandboxId: string }> = new Map();
 	private readonly redis: Redis | undefined;
 	private readonly execLockOptions: Partial<DistributedRWLockOptions> | undefined;
 	private readonly rwlockEnabled: boolean;
@@ -925,6 +943,9 @@ export class SessionManager {
 		if (coherent.poisoned()) {
 			session.lastSeenVersion = -1;
 			session.publishPending = false;
+			// The reload that follows will fetch the truth from Postgres; there is
+			// nothing valid left to publish, so drop any pending retry for this key.
+			this.pendingPublishes.delete(this.sessionKey(tenantId, sandboxId));
 			throw Object.assign(new Error("ECOHERENCE: cache poisoned by failed reload; publish suppressed"), {
 				code: "ECOHERENCE",
 			});
@@ -946,6 +967,10 @@ export class SessionManager {
 			console.error(JSON.stringify({ event: "version_incr_error", sandboxId, error: (err as Error).message }));
 			session.lastSeenVersion = -1;
 			session.publishPending = true;
+			// F3: enqueue for the background drainer so the stranded bump is healed
+			// even if no further client traffic arrives on this replica (and before
+			// the reaper would evict the session, discarding `publishPending`).
+			this.pendingPublishes.set(this.sessionKey(tenantId, sandboxId), { tenantId, sandboxId });
 			throw Object.assign(new Error("ECOHERENCE: write committed but version publish failed; client should retry"), {
 				code: "ECOHERENCE",
 			});
@@ -971,6 +996,8 @@ export class SessionManager {
 		session.lastSeenVersion = newVersion;
 		session.publishPending = false;
 		coherent.clearDirty();
+		// F3: the bump landed — clear any pending drainer retry for this key.
+		this.pendingPublishes.delete(this.sessionKey(tenantId, sandboxId));
 	}
 
 	async withSession<T>(
@@ -1147,6 +1174,9 @@ export class SessionManager {
 
 			const p = session.lock.runExclusive(async () => {
 				this.sessions.delete(key);
+				// F3: the sandbox (and its version key) is going away — drop any
+				// stranded publish so the drainer doesn't retry against a dead key.
+				this.pendingPublishes.delete(key);
 				// Disconnect the FS unconditionally — even if destroySandboxFn,
 				// version-key deletion, or path-snapshot cleanup throws — so the
 				// per-session Postgres pool can never leak. Errors from the
@@ -1199,12 +1229,59 @@ export class SessionManager {
 		}
 	}
 
-	startReaper(intervalMs = 60_000): void {
+	startReaper(intervalMs = 60_000, drainerIntervalMs = 10_000): void {
 		if (this.reaperTimer !== undefined) return;
 		this.reaperTimer = setInterval(() => this.runReaper(), intervalMs);
 		// Reaper should never block process exit — a Node timer with `unref()`
 		// lets graceful shutdown proceed even if the reaper interval is mid-tick.
 		if (typeof this.reaperTimer.unref === "function") this.reaperTimer.unref();
+
+		// F3: background publish drainer. Heals writes whose Redis INCR failed,
+		// independent of further client traffic, so a stranded bump survives an
+		// idle eviction. No-op when Redis is disabled (nothing ever enqueues).
+		if (this.redis !== undefined && this.drainerTimer === undefined) {
+			this.drainerTimer = setInterval(() => void this.drainPendingPublishes(), drainerIntervalMs);
+			if (typeof this.drainerTimer.unref === "function") this.drainerTimer.unref();
+		}
+	}
+
+	/**
+	 * F3: retry every stranded version publish under its session lock. Re-checking
+	 * `session.publishPending` *inside* the lock is required: it serializes against
+	 * `ensureFreshCache` (which clears `#dirty` on the `-1` reload) and against a
+	 * concurrent exec turn, preventing a double INCR (V+2). A session that is
+	 * missing (evicted) or closing is dropped — the reaper already attempted a
+	 * best-effort publish before disconnecting it. A still-failing publish is left
+	 * enqueued for the next tick (fixed-interval backoff).
+	 */
+	async drainPendingPublishes(): Promise<void> {
+		if (this.redis === undefined || this.pendingPublishes.size === 0) return;
+		const snapshot = [...this.pendingPublishes.entries()];
+		for (const [key, { tenantId, sandboxId }] of snapshot) {
+			const session = this.sessions.get(key);
+			if (session === undefined || session.state === "closing") {
+				// No live session to publish from; reaper handles the in-flight case.
+				this.pendingPublishes.delete(key);
+				continue;
+			}
+			try {
+				await session.lock.runExclusive(async () => {
+					// Re-check under the lock — a racing exec or ensureFreshCache may
+					// have already flushed (or invalidated) the pending bump.
+					if (!session.publishPending) {
+						this.pendingPublishes.delete(key);
+						return;
+					}
+					await this.publishVersionIfDirty(tenantId, sandboxId, session);
+					// publishVersionIfDirty clears the map entry on success.
+				});
+			} catch (err) {
+				// Still stranded (Redis blip persists, or cache poisoned). Leave the
+				// entry for the next tick unless publishVersionIfDirty already removed
+				// it (poison-suppress path deletes the key itself).
+				console.error(JSON.stringify({ event: "publish_drain_error", sandboxId, error: (err as Error).message }));
+			}
+		}
 	}
 
 	/**
@@ -1260,6 +1337,7 @@ export class SessionManager {
 			}),
 		);
 		this.sessions.clear();
+		this.pendingPublishes.clear();
 	}
 
 	/** Alias for shutdown() — matches the plan's `closeAll()` naming. */
@@ -1271,6 +1349,10 @@ export class SessionManager {
 		if (this.reaperTimer !== undefined) {
 			clearInterval(this.reaperTimer);
 			this.reaperTimer = undefined;
+		}
+		if (this.drainerTimer !== undefined) {
+			clearInterval(this.drainerTimer);
+			this.drainerTimer = undefined;
 		}
 	}
 
@@ -1286,12 +1368,33 @@ export class SessionManager {
 				// against a disconnected filesystem.
 				session.state = "closing";
 				this.sessions.delete(key);
+				// F3: if this session has a stranded version bump, make one
+				// best-effort publish under the lock *before* disconnecting — the FS
+				// is still connected here, and once it's gone the in-memory
+				// `publishPending` flag would be lost with no way to retry.
+				const pending = this.pendingPublishes.get(key);
 				void session.lock
 					.runExclusive(async () => {
+						if (pending !== undefined && session.publishPending) {
+							try {
+								await this.publishVersionIfDirty(pending.tenantId, pending.sandboxId, session);
+							} catch (err) {
+								console.error(
+									JSON.stringify({
+										event: "publish_reap_error",
+										sandboxId: pending.sandboxId,
+										error: (err as Error).message,
+									}),
+								);
+							}
+						}
 						/* drain queued waiters; they will throw ESESSIONCLOSING */
 					})
 					.catch(() => {})
 					.finally(() => {
+						// Whether the flush succeeded or not, the session is gone — drop
+						// the drainer entry so it doesn't spin against a dead session.
+						this.pendingPublishes.delete(key);
 						void this.disconnectFs(session.fs);
 					});
 			}

--- a/src/api/tests/unit/session-manager.f3-publish-drainer.test.ts
+++ b/src/api/tests/unit/session-manager.f3-publish-drainer.test.ts
@@ -1,0 +1,335 @@
+/**
+ * F3 unit tests: durable background publish drainer.
+ *
+ * When a committed write's Redis INCR fails, the version bump is stranded and
+ * other replicas keep serving the pre-write tree. These tests cover the in-process
+ * healing path:
+ *  - INCR failure enqueues the session into the drainer's pending set.
+ *  - The background drainer republishes once Redis recovers (INCR succeeds).
+ *  - No double-INCR (V+2) when a reload races the drainer under the lock.
+ *  - A reaped publishPending session gets one best-effort publish before disconnect.
+ */
+
+import type { Redis } from "ioredis";
+import type { IFileSystem } from "just-bash";
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../session-manager.js";
+
+interface Entry {
+	value: string;
+	expiresAt: number;
+}
+
+/**
+ * Fake Redis: version-counter store + the distributed RW-lock eval scripts the
+ * exec path needs to acquire a writer lock. Mirrors the helper in
+ * session-manager.version-counter.test.ts.
+ */
+class FakeRedis {
+	store = new Map<string, Entry>(); // version keys
+	strings = new Map<string, Entry>(); // lock writer keys
+	zsets = new Map<string, Map<string, number>>();
+
+	private gc(): void {
+		const now = Date.now();
+		for (const [k, e] of this.store) if (e.expiresAt <= now) this.store.delete(k);
+		for (const [k, e] of this.strings) if (e.expiresAt <= now) this.strings.delete(k);
+	}
+
+	private reapZset(key: string, nowMs: number): void {
+		const z = this.zsets.get(key);
+		if (!z) return;
+		for (const [m, score] of z) if (score <= nowMs) z.delete(m);
+	}
+
+	private getZset(key: string): Map<string, number> {
+		let z = this.zsets.get(key);
+		if (!z) {
+			z = new Map();
+			this.zsets.set(key, z);
+		}
+		return z;
+	}
+
+	async getex(key: string, _ex: "EX", seconds: number): Promise<string | null> {
+		this.gc();
+		const e = this.store.get(key);
+		if (e === undefined) return null;
+		e.expiresAt = Date.now() + seconds * 1000;
+		return e.value;
+	}
+
+	async incr(key: string): Promise<number> {
+		this.gc();
+		const current = Number(this.store.get(key)?.value ?? "0") || 0;
+		const next = current + 1;
+		this.store.set(key, { value: String(next), expiresAt: Date.now() + 60_000 });
+		return next;
+	}
+
+	async expire(key: string, seconds: number): Promise<number> {
+		const e = this.store.get(key);
+		if (e === undefined) return 0;
+		e.expiresAt = Date.now() + seconds * 1000;
+		return 1;
+	}
+
+	async del(key: string): Promise<number> {
+		return this.store.delete(key) ? 1 : 0;
+	}
+
+	async eval(script: string, numKeys: number, ...args: string[]): Promise<unknown> {
+		this.gc();
+		const keys = args.slice(0, numKeys);
+		const argv = args.slice(numKeys);
+		if (script.includes("ZREMRANGEBYSCORE") && script.includes("EXISTS")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr, expireAtStr] = argv as [string, string, string];
+			this.reapZset(readersKey, Number(nowStr));
+			if (this.strings.has(writerKey)) return 0;
+			this.getZset(readersKey).set(token, Number(expireAtStr));
+			return 1;
+		}
+		if (script.includes("ZREM") && !script.includes("ZREMRANGEBYSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token] = argv as [string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.delete(token);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("ZSCORE")) {
+			const [readersKey] = keys as [string];
+			const [token, expireAtStr] = argv as [string, string];
+			const z = this.zsets.get(readersKey);
+			if (z?.has(token)) {
+				z.set(token, Number(expireAtStr));
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("SET") && script.includes("NX")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			if (this.strings.has(writerKey)) return null;
+			this.strings.set(writerKey, { value: token, expiresAt: Date.now() + Number(leaseMsStr) });
+			return "OK";
+		}
+		if (script.includes("ZCARD")) {
+			const [writerKey, readersKey] = keys as [string, string];
+			const [token, nowStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value !== token) return -1;
+			this.reapZset(readersKey, Number(nowStr));
+			return this.zsets.get(readersKey)?.size ?? 0;
+		}
+		if (script.includes("PEXPIRE")) {
+			const [writerKey] = keys as [string];
+			const [token, leaseMsStr] = argv as [string, string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				entry.expiresAt = Date.now() + Number(leaseMsStr);
+				return 1;
+			}
+			return 0;
+		}
+		if (script.includes("DEL")) {
+			const [writerKey] = keys as [string];
+			const [token] = argv as [string];
+			const entry = this.strings.get(writerKey);
+			if (entry?.value === token) {
+				this.strings.delete(writerKey);
+				return 1;
+			}
+			return 0;
+		}
+		throw new Error(`FakeRedis: unrecognised eval script: ${script.slice(0, 60)}`);
+	}
+}
+
+function asRedis(f: FakeRedis): Redis {
+	return f as unknown as Redis;
+}
+
+class StubCoherentFs {
+	dirty = false;
+	reloadCount = 0;
+	clearDirtyCount = 0;
+	isPoisoned = false;
+
+	getAllPaths(): string[] {
+		return [];
+	}
+	async reload(): Promise<void> {
+		this.reloadCount++;
+		this.dirty = false;
+	}
+	wasDirty(): boolean {
+		return this.dirty;
+	}
+	clearDirty(): void {
+		this.clearDirtyCount++;
+		this.dirty = false;
+	}
+	poisoned(): boolean {
+		return this.isPoisoned;
+	}
+}
+
+function makeFsFactory(instance: StubCoherentFs): (_t: string, _s: string) => Promise<IFileSystem> {
+	return vi.fn(async () => instance as unknown as IFileSystem);
+}
+
+const VKEY = "vfs:default:ver:sbx";
+
+describe("SessionManager F3 publish drainer", () => {
+	it("enqueues a stranded publish on INCR failure and drains it once Redis recovers", async () => {
+		const redis = new FakeRedis();
+		const stub = new StubCoherentFs();
+		const sm = new SessionManager({ createFs: makeFsFactory(stub), redis: asRedis(redis) });
+
+		await sm.withSession("default", "sbx", async () => {});
+
+		// Mutation turn whose INCR fails — stranded.
+		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValueOnce(new Error("ECONNRESET"));
+		await expect(
+			sm.withSession("default", "sbx", async () => {
+				stub.dirty = true;
+			}),
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
+
+		// Nothing published yet; session flagged pending.
+		expect(redis.store.has(VKEY)).toBe(false);
+		expect(sm.getSession("default", "sbx")?.publishPending).toBe(true);
+
+		// Redis recovers; the drainer flushes the stranded bump without any new exec.
+		incrSpy.mockRestore();
+		await sm.drainPendingPublishes();
+
+		expect(redis.store.get(VKEY)?.value).toBe("1");
+		expect(sm.getSession("default", "sbx")?.publishPending).toBe(false);
+		expect(sm.getSession("default", "sbx")?.lastSeenVersion).toBe(1);
+		expect(stub.dirty).toBe(false);
+
+		// Idempotent: a second drain tick is a no-op (no double INCR).
+		await sm.drainPendingPublishes();
+		expect(redis.store.get(VKEY)?.value).toBe("1");
+	});
+
+	it("does not double-INCR when a reload clears dirty before the drainer runs", async () => {
+		const redis = new FakeRedis();
+		const stub = new StubCoherentFs();
+		const sm = new SessionManager({ createFs: makeFsFactory(stub), redis: asRedis(redis) });
+
+		await sm.withSession("default", "sbx", async () => {});
+
+		// Strand a bump.
+		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValueOnce(new Error("ECONNRESET"));
+		await expect(
+			sm.withSession("default", "sbx", async () => {
+				stub.dirty = true;
+			}),
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
+		incrSpy.mockRestore();
+
+		// Another replica publishes v5; this replica's next turn reloads (ensureFreshCache),
+		// which clears dirty AND clears publishPending via a successful republish.
+		redis.store.set(VKEY, { value: "5", expiresAt: Date.now() + 60_000 });
+		await sm.withSession("default", "sbx", async () => {});
+
+		// The exec turn already healed it: counter advanced to 6 (the pending bump
+		// flushed on top of the reloaded 5), dirty/pending cleared.
+		expect(sm.getSession("default", "sbx")?.publishPending).toBe(false);
+		const afterExec = redis.store.get(VKEY)?.value;
+		expect(afterExec).toBe("6");
+
+		// Drainer runs afterward — must NOT bump again (no V+2).
+		await sm.drainPendingPublishes();
+		expect(redis.store.get(VKEY)?.value).toBe(afterExec);
+	});
+
+	it("makes a best-effort publish when a publishPending session is reaped", async () => {
+		const redis = new FakeRedis();
+		const stub = new StubCoherentFs();
+		const sm = new SessionManager({
+			createFs: makeFsFactory(stub),
+			destroySandboxFn: vi.fn().mockResolvedValue(undefined),
+			redis: asRedis(redis),
+			idleMs: 0, // every idle session is immediately reapable
+		});
+
+		await sm.withSession("default", "sbx", async () => {});
+
+		// Strand a bump.
+		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValueOnce(new Error("ECONNRESET"));
+		await expect(
+			sm.withSession("default", "sbx", async () => {
+				stub.dirty = true;
+			}),
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
+		incrSpy.mockRestore();
+		expect(redis.store.has(VKEY)).toBe(false);
+
+		// Reaper evicts the idle session — but first flushes the stranded bump while
+		// the FS is still connected. Start it on a tight interval and wait a tick.
+		sm.startReaper(5, 5);
+		await vi.waitFor(() => {
+			expect(redis.store.get(VKEY)?.value).toBe("1");
+		});
+		expect(sm.getSession("default", "sbx")).toBeUndefined();
+		sm.stopReaper();
+	});
+
+	it("drops the pending entry for a session that vanished before the drainer ran", async () => {
+		const redis = new FakeRedis();
+		const stub = new StubCoherentFs();
+		const sm = new SessionManager({
+			createFs: makeFsFactory(stub),
+			destroySandboxFn: vi.fn().mockResolvedValue(undefined),
+			redis: asRedis(redis),
+		});
+
+		await sm.withSession("default", "sbx", async () => {});
+		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValueOnce(new Error("ECONNRESET"));
+		await expect(
+			sm.withSession("default", "sbx", async () => {
+				stub.dirty = true;
+			}),
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
+		incrSpy.mockRestore();
+
+		// Destroy removes the session and its pending entry.
+		await sm.destroy("default", "sbx");
+
+		// Drainer is now a no-op — no resurrection of the destroyed sandbox's key.
+		await sm.drainPendingPublishes();
+		expect(redis.store.has(VKEY)).toBe(false);
+	});
+
+	it("leaves the entry enqueued when the retry INCR also fails", async () => {
+		const redis = new FakeRedis();
+		const stub = new StubCoherentFs();
+		const sm = new SessionManager({ createFs: makeFsFactory(stub), redis: asRedis(redis) });
+
+		await sm.withSession("default", "sbx", async () => {});
+		const incrSpy = vi.spyOn(redis, "incr").mockRejectedValue(new Error("ECONNRESET"));
+		await expect(
+			sm.withSession("default", "sbx", async () => {
+				stub.dirty = true;
+			}),
+		).rejects.toMatchObject({ code: "ECOHERENCE" });
+
+		// First drain tick: INCR still failing — entry stays for the next tick.
+		await sm.drainPendingPublishes();
+		expect(redis.store.has(VKEY)).toBe(false);
+		expect(sm.getSession("default", "sbx")?.publishPending).toBe(true);
+
+		// Redis recovers; next tick heals it.
+		incrSpy.mockRestore();
+		await sm.drainPendingPublishes();
+		expect(redis.store.get(VKEY)?.value).toBe("1");
+		expect(sm.getSession("default", "sbx")?.publishPending).toBe(false);
+	});
+});

--- a/thoughts/shared/plans/2026-06-13_f3-publish-drainer.md
+++ b/thoughts/shared/plans/2026-06-13_f3-publish-drainer.md
@@ -1,0 +1,99 @@
+# F3 — Durable background publish drainer
+
+## Overview
+
+A committed write whose Redis `INCR` fails (transient Redis blip) leaves other
+replicas serving the pre-write tree indefinitely. Data is durable in Postgres;
+only cross-replica *visibility* of the version bump is stranded. Today repair is
+hostage to a later mutating write **on the same replica** — and if the reaper
+idle-evicts the session first, the in-memory `publishPending` flag is discarded
+and the bump is permanently lost (until any unrelated write anywhere bumps the
+counter and forces laggards to reload).
+
+This adds a durable, in-process background drainer that retries stranded
+publishes, plus a best-effort publish when a `publishPending` session is reaped.
+
+## Current State
+
+- `src/api/session-manager.ts:915` `publishVersionIfDirty` — INCR-failure branch
+  (`:939-952`) sets `lastSeenVersion=-1`, `publishPending=true`, throws ECOHERENCE
+  **without** `clearDirty`. Nothing schedules a retry.
+- `src/api/session-manager.ts:252` `Session.publishPending` doc-comment claims the
+  next successful turn "guarantees other replicas eventually see the prior write"
+  — false once the session is reaped before that turn.
+- `src/api/session-manager.ts:1277` `runReaper` disconnects idle sessions with no
+  attempt to flush a pending publish first.
+- `src/api/session-manager.ts:1202` `startReaper` / `:1270` `stopReaper` /
+  `:1217` `shutdown` manage the reaper timer lifecycle.
+- `src/api/session-manager.ts:871` `ensureFreshCache` clears `#dirty` via
+  `coherent.clearDirty()` on a `-1`→current reload — the drainer must re-check
+  under the lock to avoid a double INCR (V+2) racing this.
+
+## Desired End State
+
+- A `pendingPublishes: Set<string>` (session keys) populated in the INCR-failure
+  branch.
+- An unref'd `setInterval` drainer (tied to the reaper lifecycle) that, per
+  pending key, takes `session.lock.runExclusive` and re-runs
+  `publishVersionIfDirty` keyed off `session.publishPending` (re-checked under the
+  lock). Successful publish removes the key; persistent failure keeps it for the
+  next tick (simple fixed-interval backoff).
+- `runReaper` attempts one best-effort publish (under the lock, FS still
+  connected) before disconnecting a `publishPending` session.
+- DEL-key fallback rejected (shares the INCR failure domain).
+- Interval `.unref()`-ed and cleared on `stopReaper`/`shutdown`.
+- `Session.publishPending` doc-comment corrected.
+
+## What We're NOT Doing
+
+- No durable (Redis/PG) persistence of pending publishes across replica restarts
+  — the write is already durable in PG; convergence on restart still happens via
+  the next write anywhere. This is in-process healing only.
+- No DEL-and-recreate of the version key.
+- No change to the ECOHERENCE error surfaced to the live caller.
+
+## Phase 1 — pendingPublishes Set + drainer + reap flush + doc-comment
+
+### Changes
+
+1. Add `private readonly pendingPublishes: Set<string>` and
+   `private drainerTimer` field.
+2. In the INCR-failure branch, `this.pendingPublishes.add(this.sessionKey(...))`.
+   On a successful publish and in the poisoned-suppress branch, remove the key.
+3. Add `private async drainPendingPublishes()` that iterates a snapshot of the
+   set, looks up the live session, skips closing/missing ones, and runs
+   `session.lock.runExclusive(() => this.publishVersionIfDirty(...))`. Re-check
+   `session.publishPending` under the lock; clear from set on success or when the
+   session no longer needs publishing.
+4. Start the drainer interval inside `startReaper`; `.unref()` it; clear it in
+   `stopReaper`.
+5. In `runReaper`, when evicting a `publishPending` session, run one best-effort
+   `publishVersionIfDirty` under the lock before `disconnectFs`.
+6. Fix the `Session.publishPending` doc-comment.
+
+### Success Criteria
+
+#### Automated
+- [ ] `pnpm typecheck` clean
+- [ ] `pnpm lint:fix` clean
+- [ ] New unit tests pass; existing `session-manager.version-counter.test.ts` unchanged and green
+- [ ] `pnpm test:unit` green
+
+#### Manual
+- [ ] Live server boots on :8131, read-your-writes + version counter increments
+- [ ] Server shuts down cleanly (no hang/leak) with the drainer interval present
+
+### Discoveries
+
+- `pendingPublishes` keys are `${tenantId}:${sandboxId}` (matches `sessionKey`); the
+  drainer needs to recover tenant+sandbox to call `publishVersionIfDirty`, so the
+  set stores keys and the drainer splits on the first `:` — but tenant ids may
+  contain `:`? They don't in this codebase (default tenant), and the version key
+  builder already assumes a flat tenant id. To be safe the drainer looks the
+  session up by stored key directly and reads `session.tenantId` + reconstructs
+  sandboxId from the key suffix. Simpler: store a `{tenantId, sandboxId}` tuple
+  instead of a string. Chosen: store the session key string and resolve via a
+  parallel map is overkill — instead the drainer reads the live `Session` (which
+  carries `tenantId`) and derives sandboxId by stripping the `${tenantId}:` prefix.
+- The INCR-failure → drainer recovery cannot be triggered cleanly against a live
+  Redis; covered by unit tests (Step 3) and noted in the PR.


### PR DESCRIPTION
## Summary

Fixes F3 (#132): a committed write whose Redis `INCR` fails leaves **other replicas** serving the pre-write tree indefinitely. The bump was previously hostage to a later mutating write **on the same replica** — and if the reaper idle-evicted the session first, the in-memory `publishPending` flag (and the bump) was discarded. Data stays durable in Postgres; only cross-replica *visibility* was stranded for an unbounded window.

This adds **in-process healing** that flushes the stranded bump independent of further client traffic.

## What changed (`src/api/session-manager.ts`)

- **`pendingPublishes: Map<sessionKey, {tenantId, sandboxId}>`** — populated in the `INCR`-failure branch of `publishVersionIfDirty`; removed on a successful publish, on poison-suppression, and on `destroy`.
- **`drainPendingPublishes()`** — an unref'd `setInterval` (10s, tied to the reaper lifecycle in `startReaper`, cleared in `stopReaper`/`shutdown`). Per pending key it takes `session.lock.runExclusive(() => publishVersionIfDirty(...))` and **re-checks `session.publishPending` under the lock** — this serializes against `ensureFreshCache` (which clears `#dirty` on the `-1` reload) and a concurrent exec turn, preventing a double `INCR` (V+2). A still-failing publish stays enqueued for the next tick (fixed-interval backoff). A missing/closing session is dropped (the reaper handles that case).
- **Reap-time best-effort publish** — `runReaper` makes one `publishVersionIfDirty` attempt under the lock (FS still connected) before disconnecting a `publishPending` session, then drops the entry.
- **No DEL-key fallback** (shares the `INCR` failure domain).
- Corrected the now-false `Session.publishPending` doc-comment.

Plan: `thoughts/shared/plans/2026-06-13_f3-publish-drainer.md`.

## Verification

### Unit (`src/api/tests/unit/session-manager.f3-publish-drainer.test.ts`) — 5 new tests, all green
- `enqueues a stranded publish on INCR failure and drains it once Redis recovers` (idempotent second tick)
- `does not double-INCR when a reload clears dirty before the drainer runs` (no V+2)
- `makes a best-effort publish when a publishPending session is reaped`
- `drops the pending entry for a session that vanished before the drainer ran`
- `leaves the entry enqueued when the retry INCR also fails`

Existing `session-manager.version-counter.test.ts` unchanged. Full suite: **979 passed | 4 skipped**. `pnpm typecheck && pnpm lint:fix && pnpm test:unit` all clean.

### Live (Postgres + Redis, server on :8131)
```
POST /v1/sandboxes                      -> 201 (id 333ed2ff-…)
exec "echo hi > /tmp/a"                 -> exit 0
exec "cat /tmp/a"                       -> stdout "hi\n"   (read-your-writes)
redis-cli get vfs:default:ver:<id>      -> 1               (counter incremented)
DELETE /v1/sandboxes/<id>               -> 204
redis-cli get vfs:default:ver:<id>      -> (nil)           (version key deleted)
SIGTERM                                 -> shutdown_begin → shutdown_complete, port freed in 1s (no force-exit / hang from the new interval)
```

The `INCR`-failure → drainer recovery path **cannot be triggered cleanly against a live Redis**, so it is covered by the Step-3 unit tests above and called out here.

## Reviewer manual steps
- Confirm the drainer interval is `.unref()`-ed and cleared on both `stopReaper` and `shutdown` (clean process exit verified live).
- Sanity-check that `drainPendingPublishes` re-checks `publishPending` under the lock (double-INCR guard) — covered by the V+2 regression test.

Closes #132